### PR TITLE
Changed timezone to Toronto

### DIFF
--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -122,7 +122,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'EST'
+TIME_ZONE = 'America/Toronto'
 
 USE_I18N = True
 


### PR DESCRIPTION
Using `America/Toronto` will avoid EST/EDT confusion.