### PR TITLE
Make ride description safe to render

### DIFF
--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -107,7 +107,7 @@
                     <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">{{ ride.name }}</h3>
                     
                     <div class="prose prose-gray dark:prose-invert max-w-none mb-4">
-                        <p>{{ ride.description }}</p>
+                        <p>{{ ride.description|safe }}</p>
                     </div>
                     
                     <div class="flex items-center mb-4">


### PR DESCRIPTION
Forgot to mark as safe, so HTML tags were shown.