### PR TITLE
Registration bugfix to be more lenient with types

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class RegistrationDetail:
     ride: Ride|None
-    ride_leader_preference: str
+    ride_leader_preference: str|None
     speed_range_preference: SpeedRange|None
     emergency_contact_name: str|None
     emergency_contact_phone: str|None

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -25,12 +25,13 @@ def registration_submitted(request: HttpRequest) -> HttpResponse:
 
 
 def _get_registration_detail(form: RegistrationForm) -> RegistrationDetail:
+
     return RegistrationDetail(
-        ride=form.cleaned_data['ride'],
-        speed_range_preference=form.cleaned_data['speed_range_preference'],
-        emergency_contact_name=form.cleaned_data['emergency_contact_name'],
-        emergency_contact_phone=form.cleaned_data['emergency_contact_phone'],
-        ride_leader_preference=form.cleaned_data['ride_leader_preference'],
+        ride=form.cleaned_data.get('ride'),
+        speed_range_preference=form.cleaned_data.get('speed_range_preference'),
+        emergency_contact_name=form.cleaned_data.get('emergency_contact_name'),
+        emergency_contact_phone=form.cleaned_data.get('emergency_contact_phone'),
+        ride_leader_preference=form.cleaned_data.get('ride_leader_preference'),
     )
 
 


### PR DESCRIPTION
If the event has no ride or preferences, the registration would fail. Now won't fail due to missing keys in form.