### PR TITLE
Don't reset password for existing users

### DIFF
--- a/backoffice/services/user_service.py
+++ b/backoffice/services/user_service.py
@@ -27,7 +27,6 @@ class UserService(object):
             case Some(user):
                 user.first_name = user_detail.first_name
                 user.last_name = user_detail.last_name
-                user.set_unusable_password()
                 user.save()
                 return user
             case _:


### PR DESCRIPTION
A bug was discovered where if a staff member signed up using their account, their password for the admin would be set to be unusable.