### PR TITLE
Allow for runtime configuration of one-time tokens

### DIFF
--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -57,7 +57,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 SESAME_MAX_AGE = 60 * 5
-SESAME_ONE_TIME = not os.environ.get('SESAME_ONE_TIME', None) is None
+SESAME_ONE_TIME = os.environ.get('SESAME_ONE_TIME') is not None
 
 LOGIN_REDIRECT_URL = "/profile"
 LOGIN_URL = "/login/"


### PR DESCRIPTION
User reported that the login link was always expired. Email providers impacted both Microsoft. Suspect that they probe/preflight the URL and expire the token before the user can access it.