### PR TITLE
Fixed styling for headers

### DIFF
--- a/web/static/web/prose-styling.css
+++ b/web/static/web/prose-styling.css
@@ -27,6 +27,7 @@
     font-size: 12pt;
     font-weight: bold;
 }
+
 .prose a {
     color: #4A6DA7;
     text-decoration: underline;


### PR DESCRIPTION
Corrections for issues in https://github.com/davidpettersson/ridehub/issues/124

Because of switch from Tailwind to Bootstrap, certain font sizes did no longer align. Also added missing T4.