### PR TITLE
Calendar/upcoming events routing

### DIFF
--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -8,7 +8,10 @@ from backoffice.models import Event
 
 class EventService:
     def fetch_events(self, include_archived: bool = False, only_visible: bool = True) -> QuerySet[Event]:
-        filters = {'archived': include_archived}
+        filters = {}
+        
+        if not include_archived:
+            filters['archived'] = False
 
         if only_visible:
             filters['visible'] = True
@@ -25,7 +28,6 @@ class EventService:
         from datetime import date
         import calendar
         
-        # Get the first and last day of the month using calendar.monthrange
         first_day = date(year, month, 1)
         _, last_day_of_month = calendar.monthrange(year, month)
         last_day = date(year, month, last_day_of_month)

--- a/web/templates/email/event_cancelled.html
+++ b/web/templates/email/event_cancelled.html
@@ -23,6 +23,6 @@
     <p>{{ cancellation_reason }}</p>
     
     <p>
-        <a href="{{ base_url }}{% url 'event_list' %}" class="button">View other events</a>
+        <a href="{{ base_url }}{% url 'events' %}" class="button">View other events</a>
     </p>
 {% endblock %}

--- a/web/templates/email/event_cancelled.txt
+++ b/web/templates/email/event_cancelled.txt
@@ -12,6 +12,6 @@ REASON FOR CANCELLATION:
 
 We apologize for any inconvenience this may cause.
 
-You can view other upcoming events at: {{ base_url }}{% url 'event_list' %}
+You can view other upcoming events at: {{ base_url }}{% url 'events' %}
 
 Ottawa Bicycle Club

--- a/web/templates/web/_base.html
+++ b/web/templates/web/_base.html
@@ -78,11 +78,11 @@
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <div class="flex items-center space-x-4">
-            <a href="{% url 'event_list' %}" class="flex-shrink-0">
+            <a href="{% url 'events' %}" class="flex-shrink-0">
               {% load static %}
               <img src="{% static 'web/obc-logo.png' %}" alt="Ottawa Bicycle Club" class="h-10">
             </a>
-            <a href="{% url 'event_list' %}" class="text-white hover:text-gray-200 transition-colors duration-200">
+            <a href="{% url 'events' %}" class="text-white hover:text-gray-200 transition-colors duration-200">
               Events
             </a>
           </div>

--- a/web/templates/web/_base_bootstrap.html
+++ b/web/templates/web/_base_bootstrap.html
@@ -32,24 +32,12 @@
       <div class="container">
         <div class="d-flex justify-content-between w-100" style="height: 64px;">
           <div class="d-flex align-items-center">
-            <a href="{% url 'event_list' %}" class="me-3">
+            <a href="{% url 'events' %}" class="me-3">
               <img src="{% static 'web/obc-logo.png' %}" alt="Ottawa Bicycle Club" height="40">
             </a>
-            {% flag "calendar_view" %}
-            {% if request.session.preferred_events_view == 'calendar' %}
-            <a href="{% url 'calendar' %}" class="text-white{% if request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">
+            <a href="{% url 'events' %}" class="text-white{% if request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' or request.resolver_match.url_name == 'upcoming' %} active{% endif %}">
               Events
             </a>
-            {% else %}
-            <a href="{% url 'event_list' %}" class="text-white{% if request.resolver_match.url_name == 'event_list' %} active{% endif %}">
-              Events
-            </a>
-            {% endif %}
-            {% else %}
-            <a href="{% url 'event_list' %}" class="text-white{% if request.resolver_match.url_name == 'event_list' %} active{% endif %}">
-              Upcoming events
-            </a>
-            {% endflag %}
           </div>
           <div class="d-flex align-items-center">
             {% if user.is_authenticated %}

--- a/web/templates/web/events/calendar.html
+++ b/web/templates/web/events/calendar.html
@@ -21,7 +21,7 @@
                         <i class="bi bi-calendar3 me-2"></i>Calendar
                     </button>
                     <ul class="dropdown-menu" aria-labelledby="viewDropdown">
-                        <li><a class="dropdown-item" href="{% url 'event_list' %}">
+                        <li><a class="dropdown-item" href="{% url 'upcoming' %}">
                             <i class="bi bi-list-ul me-2"></i>List
                         </a></li>
                         <li><a class="dropdown-item active" href="{% url 'calendar' %}">

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="mb-4">
         <div class="d-flex align-items-center mb-4">
-            <a href="{% url 'event_list' %}" class="btn btn-outline-secondary btn-sm rounded-pill d-inline-flex align-items-center">
+            <a href="{% url 'events' %}" class="btn btn-outline-secondary btn-sm rounded-pill d-inline-flex align-items-center">
                 <i class="bi bi-arrow-left me-2"></i> Back to events
             </a>
         </div>

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -11,7 +11,7 @@
                     <i class="bi bi-list-ul me-2"></i>List
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="viewDropdown">
-                    <li><a class="dropdown-item active" href="{% url 'event_list' %}">
+                    <li><a class="dropdown-item active" href="{% url 'upcoming' %}">
                         <i class="bi bi-list-ul me-2"></i>List
                     </a></li>
                     <li><a class="dropdown-item" href="{% url 'calendar' %}">

--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -181,7 +181,7 @@
             {% else %}
                 <div class="text-center py-5">
                     <p class="text-muted">You haven't registered for any events yet.</p>
-                    <a href="{% url 'event_list' %}" class="btn btn-primary mt-3 d-inline-flex align-items-center">
+                    <a href="{% url 'events' %}" class="btn btn-primary mt-3 d-inline-flex align-items-center">
                         <i class="bi bi-calendar-event me-2"></i>
                         Browse Events
                     </a>

--- a/web/templates/web/registrations/submitted.html
+++ b/web/templates/web/registrations/submitted.html
@@ -17,11 +17,11 @@
                 <div class="mt-8 flex flex-col space-y-3 sm:flex-row sm:space-y-0 sm:space-x-3 justify-center">
                     {% if user.is_authenticated %}
                     <a href="{% url 'profile' %}" class="btn-primary">
-                        View Your Profile
+                        View profile
                     </a>
                     {% endif %}
-                    <a href="{% url 'event_list' %}" class="btn-primary">
-                        Return to Event List
+                    <a href="{% url 'events' %}" class="btn-primary">
+                        View event list
                     </a>
                 </div>
             </div>

--- a/web/tests/templates/test_email_templates.py
+++ b/web/tests/templates/test_email_templates.py
@@ -205,12 +205,12 @@ class TestEventCancelledEmail(BaseEmailTestCase):
         self.assert_all_links_absolute(html_content)
 
         # Verify events link exists and is absolute
-        events_url = f"{self.base_url}{reverse('event_list')}"
+        events_url = f"{self.base_url}{reverse('events')}"
         self.assertRegex(html_content, rf'href="{re.escape(events_url)}"')
 
     def test_text_version_has_absolute_urls(self):
         text_content = render_to_string('email/event_cancelled.txt', self.context)
 
         # Verify events URL is present
-        events_url = f"{self.base_url}{reverse('event_list')}"
+        events_url = f"{self.base_url}{reverse('events')}"
         self.assertIn(events_url, text_content)

--- a/web/tests/views/test_auth_views.py
+++ b/web/tests/views/test_auth_views.py
@@ -38,7 +38,7 @@ class LogoutViewTests(TestCase):
 
         response = self.client.get(self.logout_url)
 
-        self.assertRedirects(response, reverse('event_list'), fetch_redirect_response=False)
+        self.assertRedirects(response, reverse('events'), fetch_redirect_response=False)
 
     def test_logout_clears_authentication(self):
         self.client.login(username='testuser', password='password123')

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 
 from web.views.debug import trigger_task, trigger_error
-from web.views.events import redirect_to_event_list, event_detail, event_list, event_registrations, \
-    event_registrations_full, calendar_view
+from web.views.events import event_detail, event_list, event_registrations, \
+    event_registrations_full, calendar_view, events_redirect
 from web.views.events_ical import EventFeed
 from web.views.helpers import changes_email_addresses
 from web.views.login import LoginFormView, logout_view, CustomLoginView
@@ -19,17 +19,18 @@ urlpatterns = [
     path('helpers/changes_email_addresses', changes_email_addresses),
     path('calendar', calendar_view, name='calendar'),
     path('calendar/<int:year>/<int:month>', calendar_view, name='calendar_month'),
+    path('upcoming', event_list, name='upcoming'),
+    path('events', events_redirect, name='events'),
     path('events/<int:event_id>/registrations/full', event_registrations_full, name='event_registrations_full'),
     path('events/<int:event_id>/registrations', event_registrations, name='riders_list'),
     path('events/<int:event_id>/registration', registration_create, name='registration_create'),
     path('events/<int:event_id>', event_detail, name='event_detail'),
     path('events.ics', EventFeed(), name='event_feed'),
-    path('events', event_list, name='event_list'),
     path('registrations/<int:registration_id>/withdraw', registration_withdraw, name='registration_withdraw'),
     path('registrations/<int:registration_id>', registration_detail, name='registration_detail'),
     path('registrations/submitted', registration_submitted, name='registration_submitted'),
     path('registrations', registration_list, name='registration_list'),
     path('rides/<int:ride_id>/speed-ranges', ride_speed_ranges, name='get_speed_ranges'),
     path('profile', profile, name='profile'),
-    path('', redirect_to_event_list, name='index'),
+    path('', events_redirect, name='index'),
 ]

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -108,8 +108,14 @@ def _get_rides_with_riders_for_event(event_id: int) -> dict:
     return _finalize_rides_data(rides_data)
 
 
-def redirect_to_event_list(request: HttpRequest) -> HttpResponseRedirect:
-    return redirect('event_list')
+def events_redirect(request: HttpRequest) -> HttpResponseRedirect:
+    """Redirect to user's preferred events view or default to upcoming"""
+    preferred_view = request.session.get('preferred_events_view', 'upcoming')
+    
+    if preferred_view == 'calendar':
+        return redirect('calendar')
+    else:
+        return redirect('upcoming')
 
 
 def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
@@ -138,7 +144,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
 
 def event_list(request: HttpRequest) -> HttpResponse:
     # Set preferred view in session
-    request.session['preferred_events_view'] = 'list'
+    request.session['preferred_events_view'] = 'upcoming'
     
     events = EventService().fetch_upcoming_events()
     starts_at_date = lambda event: event.starts_at.date()

--- a/web/views/login.py
+++ b/web/views/login.py
@@ -81,4 +81,4 @@ class CustomLoginView(SesameLoginView):
 
 def logout_view(request):
     logout(request)
-    return redirect('event_list')
+    return redirect('events')


### PR DESCRIPTION
With calendar, we will need to make some changes to what /events leads to. Based on user preference, it will now route to the appropriate page, and default to the upcoming list.