### PR TITLE
Fix Sentry issue OBC-RIDEHUB-29

### DIFF
--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -185,7 +185,8 @@ class Event(models.Model):
         if self.archived:
             return False
 
-        return timezone.now() < self.registration_closes_at
+        closes_at = self.registration_closes_at or self.starts_at
+        return timezone.now() < closes_at
 
     def __str__(self):
         return self.name

--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -45,7 +45,9 @@ class EventService:
         if source_event.ends_at:
             ends_at_delta = source_event.ends_at - source_event.starts_at
 
-        registration_closes_delta = source_event.registration_closes_at - source_event.starts_at
+        registration_closes_delta = None
+        if source_event.registration_closes_at:
+            registration_closes_delta = source_event.registration_closes_at - source_event.starts_at
 
         new_event = Event.objects.create(
             program=source_event.program,
@@ -55,7 +57,7 @@ class EventService:
             location_url=source_event.location_url,
             starts_at=new_starts_at,
             ends_at=new_starts_at + ends_at_delta if ends_at_delta else None,
-            registration_closes_at=new_starts_at + registration_closes_delta,
+            registration_closes_at=new_starts_at + registration_closes_delta if registration_closes_delta else None,
             external_registration_url=source_event.external_registration_url,
             registration_limit=source_event.registration_limit,
             description=source_event.description,

--- a/backoffice/tests/models/test_event.py
+++ b/backoffice/tests/models/test_event.py
@@ -248,3 +248,32 @@ class EventTimeValidationTestCase(TestCase):
         )
         event.full_clean()
 
+
+class EventRegistrationOpenTestCase(TestCase):
+    def setUp(self):
+        self.program = Program.objects.create(name="Test Program")
+        self.now = timezone.now()
+        self.one_hour_later = self.now + timedelta(hours=1)
+
+    def test_registration_open_with_null_registration_closes_at_before_start(self):
+        event = Event(
+            program=self.program,
+            name="Test Event",
+            starts_at=self.one_hour_later,
+            registration_closes_at=None,
+            external_registration_url='https://example.com/register'
+        )
+
+        self.assertTrue(event.registration_open)
+
+    def test_registration_open_with_null_registration_closes_at_after_start(self):
+        event = Event(
+            program=self.program,
+            name="Test Event",
+            starts_at=self.now - timedelta(hours=1),
+            registration_closes_at=None,
+            external_registration_url='https://example.com/register'
+        )
+
+        self.assertFalse(event.registration_open)
+

--- a/docs/specifications/events-times.md
+++ b/docs/specifications/events-times.md
@@ -23,6 +23,7 @@
  - Always less than or equal to start time
  - May be blank if there exists an external registration URL
  - Must be set if no external registration URL
+ - If blank, assume it is equivalent to the start time
  - Offers quick set options:
    - At start
    - 1 hour before start

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -336,6 +336,22 @@ class EventDetailViewTests(BaseEventViewTestCase):
         self.assertFalse(response.context['user_is_registered'])
         self.assertNotContains(response, 'You are registered for this event')
 
+    def test_event_detail_with_external_registration_url_and_no_registration_closes_at(self):
+        now = timezone.now()
+        event = Event.objects.create(
+            program=self.program,
+            name='External Registration Event',
+            starts_at=now + timedelta(days=7),
+            registration_closes_at=None,
+            external_registration_url='https://example.com/register'
+        )
+        url = reverse('event_detail', kwargs={'event_id': event.id})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'web/events/detail.html')
+
 
 class EventViewTimezoneTests(TestCase):
     """Tests for timezone handling in event views."""


### PR DESCRIPTION
This Pull Request introduces enhancements and bug fixes related to event registration handling in the application. It refines logic for determining registration close time, updates documentation, and adds new test cases for edge cases.

Logic Updates:
 - Modified registration_open property to default the close time to the start time if undefined.
 - Adjusted event duplication logic to prevent errors when registration_closes_at is None.

Test Enhancements:

 - Added unit tests for registration_open behavior when registration_closes_at is None.
 - Created a view test for event details when external registration URL is provided without a close time.

Documentation Updates:

  - Updated events-times.md specification to specify the behavior when registration_closes_at is empty.