### PR TITLE
Refactoring and simplification of membership models

### DIFF
--- a/membership/admin.py
+++ b/membership/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from membership.models import Member, Registration, Match
+from membership.models import Member, Registration
 
 
 class MemberAdmin(admin.ModelAdmin):
@@ -10,17 +10,12 @@ class MemberAdmin(admin.ModelAdmin):
 
 
 class RegistrationAdmin(admin.ModelAdmin):
-    list_display = ('identity', 'first_name', 'last_name', 'registered_at',)
+    list_display = ('identity', 'first_name', 'last_name', 'registered_at', 'matched_member',)
     list_display_links = ('identity',)
     date_hierarchy = 'registered_at'
     ordering = ('-registered_at',)
     search_fields = ('first_name', 'last_name',)
 
 
-class MatchAdmin(admin.ModelAdmin):
-    list_display = ('registration', 'member', 'method', 'confidence',)
-
-
 admin.site.register(Member, MemberAdmin)
 admin.site.register(Registration, RegistrationAdmin)
-admin.site.register(Match, MatchAdmin)

--- a/membership/management/commands/matchmembers.py
+++ b/membership/management/commands/matchmembers.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         self.stdout.write(f'Minimum confidence threshold: {self.min_confidence}')
         self.stdout.write('')
 
-        members = list(Member.objects.filter(user__isnull=True))
+        members = list(Member.objects.filter(matched_user__isnull=True))
         self.stdout.write(f'Found {len(members)} unlinked members')
 
         users = list(User.objects.select_related('profile').all())
@@ -184,8 +184,8 @@ class Command(BaseCommand):
             )
 
             if not self.dry_run:
-                member.user = user
-                member.save(update_fields=['user'])
+                member.matched_user = user
+                member.save(update_fields=['matched_user'])
 
             stats['linked'] += 1
 

--- a/membership/migrations/0014_registration_member_remove_match.py
+++ b/membership/migrations/0014_registration_member_remove_match.py
@@ -1,0 +1,40 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def migrate_match_to_registration(apps, schema_editor):
+    Match = apps.get_model('membership', 'Match')
+    Registration = apps.get_model('membership', 'Registration')
+
+    for match in Match.objects.all():
+        Registration.objects.filter(id=match.registration_id).update(
+            member_id=match.member_id
+        )
+
+
+def reverse_migration(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('membership', '0013_add_member_user'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='registration',
+            name='member',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to='membership.member',
+            ),
+        ),
+        migrations.RunPython(migrate_match_to_registration, reverse_migration),
+        migrations.DeleteModel(
+            name='Match',
+        ),
+    ]

--- a/membership/migrations/0015_rename_member_to_matched_member.py
+++ b/membership/migrations/0015_rename_member_to_matched_member.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('membership', '0014_registration_member_remove_match'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='registration',
+            old_name='member',
+            new_name='matched_member',
+        ),
+    ]

--- a/membership/migrations/0016_rename_user_to_matched_user.py
+++ b/membership/migrations/0016_rename_user_to_matched_user.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('membership', '0015_rename_member_to_matched_member'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='member',
+            old_name='user',
+            new_name='matched_user',
+        ),
+    ]

--- a/membership/models.py
+++ b/membership/models.py
@@ -51,7 +51,7 @@ class Member(models.Model):
         help_text='Identifies which year the member was last registered. Month and day always 1.',
     )
 
-    user = models.ForeignKey(
+    matched_user = models.ForeignKey(
         to=User,
         on_delete=models.SET_NULL,
         null=True,
@@ -128,37 +128,12 @@ class Registration(models.Model):
         null=True,
     )
 
+    matched_member = models.ForeignKey(
+        to=Member,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+
     def __str__(self):
         return f"{self.first_name} {self.last_name} in {self.registered_at.year}"
-
-
-class Match(models.Model):
-    registration = models.OneToOneField(
-        to=Registration,
-        on_delete=models.CASCADE,
-    )
-
-    member = models.ForeignKey(
-        to=Member,
-        on_delete=models.CASCADE,
-    )
-
-    method = models.CharField(
-        max_length=128,
-    )
-
-    confidence = models.FloatField(
-        help_text='Confidence score between 0..1'
-    )
-
-    matched_at = models.DateTimeField(
-        auto_now_add=True,
-        null=True,
-    )
-
-    def __str__(self):
-        return f"{self.registration} -> {self.member}"
-
-    class Meta:
-        verbose_name = 'match'
-        verbose_name_plural = 'matches'


### PR DESCRIPTION
## Summary

Simplifies the membership data model by removing the intermediate `Match` model and linking registrations directly to members.

### Changes

**Model Changes:**
- Removed `Match` model entirely (was storing registration-to-member links with method/confidence metadata)
- Added `Registration.matched_member` ForeignKey directly linking registrations to members
- Renamed `Member.user` to `Member.matched_user` for consistency

**Updated Commands:**
- `matchregistrations` - Now sets `Registration.matched_member` directly instead of creating Match records
- `mergemembers` - Updated to query/update `Registration.matched_member` instead of Match records
- `matchmembers` - Updated to use `Member.matched_user` field name

**Migrations:**
- `0014_registration_member_remove_match` - Adds member FK to Registration, migrates data from Match table, then drops Match table
- `0015_rename_member_to_matched_member` - Renames the field to `matched_member`
- `0016_rename_user_to_matched_user` - Renames `Member.user` to `matched_user`

### Benefits
- Simpler data model with one less table
- Direct relationship between Registration and Member
- Clearer field names indicating the matching relationship

🤖 Generated with [Claude Code](https://claude.com/claude-code)