### PR TITLE
Fix inverted filter logic for official email removal

### DIFF
--- a/web/views/helpers.py
+++ b/web/views/helpers.py
@@ -28,7 +28,7 @@ def changes_email_addresses(request: HttpRequest) -> HttpResponse:
     all_emails = set(staff_users) | set(ride_leader_users)
 
     # Remove officials
-    all_emails_except_officials = filter(lambda e: e.endswith('@ottawabicycleclub.ca'), all_emails)
+    all_emails_except_officials = filter(lambda e: not e.endswith('@ottawabicycleclub.ca'), all_emails)
 
     # Return comma-separated email addresses
     email_list = ','.join(sorted(all_emails_except_officials))


### PR DESCRIPTION
## Summary
- Fixed bug in `changes_email_addresses` where the filter was keeping official emails (`@ottawabicycleclub.ca`) instead of removing them
- Added `not` to properly exclude official email addresses from the list

## Test plan
- [ ] Verify that official emails are now correctly excluded from the changes email list

🤖 Generated with [Claude Code](https://claude.com/claude-code)