### PR TITLE
Validate and normalize phone numbers to E.164 format

### DIFF
--- a/backoffice/management/commands/importlegacy.py
+++ b/backoffice/management/commands/importlegacy.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 from datetime import datetime
 
+import phonenumbers
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.utils import timezone
@@ -337,7 +338,7 @@ class Command(BaseCommand):
 
         gender_identity = self.parse_gender(gender)
         profile_data = {
-            'phone': phone,
+            'phone': self.normalize_phone(phone),
             'gender_identity': gender_identity,
             'legacy': True,
         }
@@ -391,7 +392,7 @@ class Command(BaseCommand):
             first_name=first_name,
             last_name=last_name,
             email=email,
-            phone=phone,
+            phone=self.normalize_phone(phone),
             event=event,
             user=user,
             emergency_contact_name=emergency_contact_name,
@@ -415,6 +416,15 @@ class Command(BaseCommand):
     def generate_legacy_registration_id(self, event_id, email, submitted_at):
         composite_key = f"{event_id}_{email}_{submitted_at.isoformat()}"
         return hashlib.sha256(composite_key.encode()).hexdigest()
+
+    def normalize_phone(self, raw_phone):
+        if not raw_phone:
+            return raw_phone
+        try:
+            parsed = phonenumbers.parse(raw_phone, 'CA')
+            return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+        except phonenumbers.NumberParseException:
+            return raw_phone
 
     def parse_gender(self, gender):
         gender_lower = gender.lower()

--- a/backoffice/migrations/0067_normalize_phone_numbers.py
+++ b/backoffice/migrations/0067_normalize_phone_numbers.py
@@ -1,0 +1,34 @@
+import phonenumbers
+from django.db import migrations
+
+
+def normalize_phone_numbers(apps, schema_editor):
+    UserProfile = apps.get_model('backoffice', 'UserProfile')
+    Registration = apps.get_model('backoffice', 'Registration')
+
+    for model in [UserProfile, Registration]:
+        for obj in model.objects.exclude(phone='').exclude(phone__startswith='+'):
+            raw = obj.phone
+            try:
+                parsed = phonenumbers.parse(raw, 'CA')
+                if phonenumbers.is_valid_number(parsed):
+                    obj.phone = phonenumbers.format_number(
+                        parsed, phonenumbers.PhoneNumberFormat.E164
+                    )
+                    obj.save(update_fields=['phone'])
+            except phonenumbers.NumberParseException:
+                pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('backoffice', '0066_usermembershipnumber_updated_at'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            normalize_phone_numbers,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/web/forms.py
+++ b/web/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from phonenumber_field.formfields import PhoneNumberField
 
 from backoffice.models import Registration, Event, Ride, SpeedRange
 from backoffice.services.registration_service import RegistrationService
@@ -31,15 +32,9 @@ class RegistrationForm(forms.Form):
         })
     )
 
-    phone = forms.CharField(
-        max_length=128,
-        required=True,
-        min_length=2,
+    phone = PhoneNumberField(
+        region='CA',
         label="Phone number",
-        widget=forms.TextInput(attrs={
-            'type': 'tel',
-            'autocomplete': 'tel'
-        })
     )
 
     def __init__(self, *args, **kwargs):

--- a/web/templatetags/phone_filters.py
+++ b/web/templatetags/phone_filters.py
@@ -8,4 +8,11 @@ register = template.Library()
 def national_phone(value):
     if not value:
         return value
+    if isinstance(value, str):
+        try:
+            value = phonenumbers.parse(value, 'CA')
+        except phonenumbers.NumberParseException:
+            return value
+    if value.country_code is None:
+        return str(value)
     return phonenumbers.format_number(value, phonenumbers.PhoneNumberFormat.NATIONAL)

--- a/web/tests/test_forms.py
+++ b/web/tests/test_forms.py
@@ -158,7 +158,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': speed_range.id,
             # membership_confirmation intentionally omitted
@@ -186,7 +186,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': speed_range.id,
             'membership_confirmation': True
@@ -224,7 +224,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
         form = RegistrationForm(data=form_data, event=self.event_without_rides)
 
@@ -244,7 +244,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             # No speed range preference - should be valid
         }
@@ -268,7 +268,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': speed_range.id,
         }
@@ -292,7 +292,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             # No speed range preference - should be invalid since ride has speed ranges
         }
@@ -330,7 +330,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride1.id,
             'speed_range_preference': speed_range2.id,  # Speed range belongs to ride2, not ride1
         }
@@ -360,7 +360,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': speed_range2.id,  # Select the second speed range
         }
@@ -384,7 +384,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': '',  # Empty string should be treated as no selection
         }
@@ -405,7 +405,7 @@ class RegistrationFormTest(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             # No ride selected
         }
         form = RegistrationForm(data=form_data, event=self.event_with_rides)

--- a/web/tests/test_phone_filters.py
+++ b/web/tests/test_phone_filters.py
@@ -1,7 +1,11 @@
+from django.contrib.auth.models import User
+from django.db import connection
+from django.template import Template, Context
 from django.test import TestCase
 
 from phonenumber_field.phonenumber import PhoneNumber
 
+from backoffice.models import UserProfile
 from web.templatetags.phone_filters import national_phone
 
 
@@ -29,3 +33,41 @@ class NationalPhoneFilterTests(TestCase):
         result = national_phone(phone)
 
         self.assertEqual('(613) 234-5678', result)
+
+    def test_renders_in_template_with_phone_number_object(self):
+        phone = PhoneNumber.from_string('+16135550100')
+        template = Template('{% load phone_filters %}{{ phone|national_phone }}')
+
+        result = template.render(Context({'phone': phone}))
+
+        self.assertEqual('(613) 555-0100', result.strip())
+
+    def test_renders_in_template_with_model_field(self):
+        user = User.objects.create_user(username='testuser')
+        profile = user.profile
+        profile.phone = '+16135550100'
+        profile.save()
+        profile.refresh_from_db()
+        template = Template('{% load phone_filters %}{{ profile.phone|national_phone }}')
+
+        result = template.render(Context({'profile': profile}))
+
+        self.assertEqual('(613) 555-0100', result.strip())
+
+    def test_handles_phone_stored_without_country_code(self):
+        user = User.objects.create_user(username='testlegacy')
+        profile = user.profile
+        profile.phone = '+16135550100'
+        profile.save()
+        cursor = connection.cursor()
+        cursor.execute(
+            'UPDATE backoffice_userprofile SET phone = %s WHERE id = %s',
+            ['6135550100', profile.id]
+        )
+        profile.refresh_from_db()
+        template = Template('{% load phone_filters %}{{ profile.phone|national_phone }}')
+
+        result = template.render(Context({'profile': profile}))
+
+        self.assertNotEqual('None', result.strip())
+        self.assertIn('613', result.strip())

--- a/web/tests/views/test_membership_number_views.py
+++ b/web/tests/views/test_membership_number_views.py
@@ -24,7 +24,7 @@ class MembershipNumberRegistrationFlowTests(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'testflow@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'membership_confirmation': 'on',
         }
 
@@ -61,7 +61,7 @@ class MembershipNumberRegistrationFlowTests(TestCase):
             first_name='Test',
             last_name='User',
         )
-        user.profile.phone = '+1234567890'
+        user.profile.phone = '+16135550100'
         user.profile.save()
         self.client.force_login(user)
 
@@ -84,7 +84,7 @@ class MembershipNumberRegistrationFlowTests(TestCase):
             first_name='Test',
             last_name='User',
         )
-        user.profile.phone = '+1234567890'
+        user.profile.phone = '+16135550100'
         user.profile.save()
         UserMembershipNumber.objects.create(
             user=user, number='OBC-123', year=timezone.now().year
@@ -117,7 +117,7 @@ class MembershipNumberRegistrationFlowTests(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'nomembership@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
 
         # Act

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -30,7 +30,7 @@ class RegistrationViewPhoneTests(TestCase):
             last_name='User'
         )
         # Profile is automatically created by signals, just update the phone
-        user.profile.phone = '+1234567890'
+        user.profile.phone = '+16135550100'
         user.profile.save()
         
         self.client.force_login(user)
@@ -44,7 +44,7 @@ class RegistrationViewPhoneTests(TestCase):
         self.assertEqual(form.initial['first_name'], 'Test')
         self.assertEqual(form.initial['last_name'], 'User')
         self.assertEqual(form.initial['email'], 'testuser@example.com')
-        self.assertEqual(form.initial['phone'], '+1234567890')
+        self.assertEqual(form.initial['phone'], '+16135550100')
 
     def test_registration_form_initial_data_user_with_profile_no_phone(self):
         # Arrange
@@ -125,7 +125,7 @@ class RegistrationViewPhoneTests(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'testuser@example.com',
-            'phone': '+1987654321',
+            'phone': '+16139876543',
         }
 
         # Act
@@ -137,7 +137,7 @@ class RegistrationViewPhoneTests(TestCase):
         # Check that the profile was updated with the new phone number
         user.refresh_from_db()
         self.assertTrue(hasattr(user, 'profile'))
-        self.assertEqual(str(user.profile.phone), '+1987654321')
+        self.assertEqual(str(user.profile.phone), '+16139876543')
 
     def test_registration_form_stores_phone_in_registration_record(self):
         # Arrange
@@ -154,7 +154,7 @@ class RegistrationViewPhoneTests(TestCase):
             'first_name': 'Phone',
             'last_name': 'Test', 
             'email': 'phonetest@example.com',
-            'phone': '+1555123456',
+            'phone': '+16135551234',
         }
 
         # Act
@@ -170,11 +170,11 @@ class RegistrationViewPhoneTests(TestCase):
         
         # Check that the registration record has the phone number
         registration = registrations.first()
-        self.assertEqual(str(registration.phone), '+1555123456')
+        self.assertEqual(str(registration.phone), '+16135551234')
         
         # Also verify the user profile was updated
         user.refresh_from_db()
-        self.assertEqual(str(user.profile.phone), '+1555123456')
+        self.assertEqual(str(user.profile.phone), '+16135551234')
 
     def test_registration_form_stores_phone_for_anonymous_user(self):
         # Arrange - no user login (anonymous registration)
@@ -182,7 +182,7 @@ class RegistrationViewPhoneTests(TestCase):
             'first_name': 'Anonymous',
             'last_name': 'User',
             'email': 'anonymous@example.com',
-            'phone': '+1555987654',
+            'phone': '+16135559876',
         }
 
         # Act
@@ -198,14 +198,14 @@ class RegistrationViewPhoneTests(TestCase):
         
         # Check that the registration record has the phone number
         registration = registrations.first()
-        self.assertEqual(str(registration.phone), '+1555987654')
+        self.assertEqual(str(registration.phone), '+16135559876')
         
         # Verify user was created and profile has phone
         from django.contrib.auth.models import User
         users = User.objects.filter(email='anonymous@example.com')
         self.assertEqual(users.count(), 1)
         user = users.first()
-        self.assertEqual(str(user.profile.phone), '+1555987654')
+        self.assertEqual(str(user.profile.phone), '+16135559876')
 
 
 class RegistrationWithdrawAccessControlTests(TestCase):
@@ -230,7 +230,7 @@ class RegistrationWithdrawAccessControlTests(TestCase):
             first_name='User',
             last_name='A'
         )
-        self.user_a.profile.phone = '+1234567890'
+        self.user_a.profile.phone = '+16135550100'
         self.user_a.profile.save()
 
         self.user_b = User.objects.create_user(
@@ -417,7 +417,7 @@ class RegistrationCreateErrorCaseTests(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'test@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
 
         response = self.client.post(reverse('registration_create', args=[event.id]), form_data)
@@ -447,7 +447,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Test',
             'last_name': 'User',
             'email': 'testuser@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
 
         response = self.client.post(reverse('registration_create', args=[event.id]), form_data)
@@ -481,7 +481,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Rider',
             'last_name': 'Test',
             'email': 'rider@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': speed_range.id,
         }
@@ -510,7 +510,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Emergency',
             'last_name': 'Test',
             'email': 'emergency@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'emergency_contact_name': 'John Doe',
             'emergency_contact_phone': '+9876543210',
         }
@@ -539,7 +539,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Leader',
             'last_name': 'Test',
             'email': 'leader@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride_leader_preference': Registration.RideLeaderPreference.YES,
         }
 
@@ -569,7 +569,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Full',
             'last_name': 'Test',
             'email': 'full@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
             'ride': ride.id,
             'speed_range_preference': speed_range.id,
             'emergency_contact_name': 'Emergency Person',
@@ -601,7 +601,7 @@ class RegistrationFullFlowTests(TestCase):
             first_name='Auth',
             last_name='User'
         )
-        user.profile.phone = '+1234567890'
+        user.profile.phone = '+16135550100'
         user.profile.save()
 
         event = Event.objects.create(
@@ -627,7 +627,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Auth',
             'last_name': 'User',
             'email': 'authuser@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
 
         response = self.client.post(reverse('registration_create', args=[event.id]), form_data)
@@ -653,7 +653,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'New',
             'last_name': 'Person',
             'email': 'newperson@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
 
         response = self.client.post(reverse('registration_create', args=[event.id]), form_data)
@@ -683,7 +683,7 @@ class RegistrationFullFlowTests(TestCase):
             'first_name': 'Redirect',
             'last_name': 'Test',
             'email': 'redirect@example.com',
-            'phone': '+1234567890',
+            'phone': '+16135550100',
         }
 
         response = self.client.post(reverse('registration_create', args=[event.id]), form_data)


### PR DESCRIPTION
## Summary
- Use `PhoneNumberField(region='CA')` in the registration form so phone numbers are validated and normalized to E.164 format on input
- Harden the `national_phone` template filter to handle string values and invalid `PhoneNumber` objects (legacy data with missing country code rendered as "None")
- Normalize phone numbers in the legacy import command
- Add a data migration to fix existing phone numbers stored without country code

## Test plan
- [x] All 116 web tests pass
- [x] All 7 phone filter tests pass (including new integration tests for DB-stored numbers)
- [ ] Verify the registration form accepts common Canadian formats: `613-555-0100`, `(613) 555-0100`, `6135550100`, `+16135550100`
- [ ] Verify invalid phone numbers are rejected by the form
- [ ] Run migration on staging and verify existing phone numbers are normalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)