### PR TITLE
Add branch naming convention to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,9 @@ Django web application for managing cycling events, deployed to Heroku.
 - Keep code self-documenting through clear naming
 - No badges in UI templates
 
+## Git
+- Branch names: `<YYYYMMDD>-<description>`, e.g. `20260317-branch-naming-skill`
+
 ## Development Environment
 - Development is on Windows; production is Linux on Heroku
 - Always use `uv` to run commands


### PR DESCRIPTION
## Summary
- Adds a Git section to CLAUDE.md documenting the branch naming convention: `<YYYYMMDD>-<description>`

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)