### PR TITLE
Replace registration indicator with triangle corner cutout

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -247,6 +247,36 @@ body {
   z-index: 1;
 }
 
+.registered-indicator {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  background-color: #198754;
+  clip-path: polygon(0 0, 100% 0, 100% 100%);
+  z-index: 2;
+}
+
+.registered-indicator i {
+  position: absolute;
+  top: 5px;
+  right: 4px;
+  color: white;
+  font-size: 0.7rem;
+}
+
+.registered-indicator.registered-indicator-sm {
+  width: 20px;
+  height: 20px;
+}
+
+.registered-indicator-sm i {
+  top: 2px;
+  right: 2px;
+  font-size: 0.45rem;
+}
+
 .event-card:hover {
   background-color: #f8f9fa !important;
   border-color: #6c757d !important;
@@ -271,7 +301,7 @@ body {
   z-index: 0;
 }
 
-.calendar-event > div {
+.calendar-event > div:not(.registered-indicator) {
   position: relative;
   z-index: 1;
 }

--- a/web/templates/web/events/calendar.html
+++ b/web/templates/web/events/calendar.html
@@ -73,14 +73,20 @@
                                                         <a href="{% url 'event_detail' event.id %}" class="text-decoration-none">
                                                             {% if event.starts_at.date < today %}
                                                             <div class="p-1 bg-white border rounded text-muted calendar-event"{% if event.program.color %} style="--program-color: {{ event.program.color }};"{% endif %} title="{{ event.name }} - {{ event.starts_at|date:'g:i A'|lower|cut:'.m.' }}{% if event.ends_at %} - {{ event.ends_at|date:'g:i A'|lower|cut:'.m.' }}{% endif %}">
+                                                                {% if user.is_authenticated and event.id in registered_event_ids %}
+                                                                <div class="registered-indicator registered-indicator-sm"><i class="bi bi-check-lg" aria-hidden="true"></i><span class="visually-hidden">Registered</span></div>
+                                                                {% endif %}
                                                                 <div class="fw-medium text-truncate" style="font-size: 0.65rem;">{{ event.starts_at|date:"g:i A"|lower|cut:".m." }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A"|lower|cut:".m." }}{% endif %}</div>
-                                                                <div class="text-truncate" style="font-size: 0.75rem;">{{ event.name }}{% if user.is_authenticated and event.id in registered_event_ids %}<span class="text-success" style="font-size: 0.65rem;" aria-hidden="true">✓</span><span class="visually-hidden">Registered</span>{% endif %}</div>
+                                                                <div class="text-truncate" style="font-size: 0.75rem;">{{ event.name }}</div>
                                                                 <div class="text-truncate"><span class="badge fw-normal text-muted" style="font-size: 0.6rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span></div>
                                                             </div>
                                                             {% else %}
                                                             <div class="p-1 bg-white border rounded text-dark calendar-event"{% if event.program.color %} style="--program-color: {{ event.program.color }};"{% endif %} title="{{ event.name }} - {{ event.starts_at|date:'g:i A'|lower|cut:'.m.' }}{% if event.ends_at %} - {{ event.ends_at|date:'g:i A'|lower|cut:'.m.' }}{% endif %}">
+                                                                {% if user.is_authenticated and event.id in registered_event_ids %}
+                                                                <div class="registered-indicator registered-indicator-sm"><i class="bi bi-check-lg" aria-hidden="true"></i><span class="visually-hidden">Registered</span></div>
+                                                                {% endif %}
                                                                 <div class="fw-medium text-truncate" style="font-size: 0.65rem;">{{ event.starts_at|date:"g:i A"|lower|cut:".m." }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A"|lower|cut:".m." }}{% endif %}</div>
-                                                                <div class="text-truncate" style="font-size: 0.75rem;">{{ event.name }}{% if user.is_authenticated and event.id in registered_event_ids %}<span class="text-success" style="font-size: 0.65rem;" aria-hidden="true">✓</span><span class="visually-hidden">Registered</span>{% endif %}</div>
+                                                                <div class="text-truncate" style="font-size: 0.75rem;">{{ event.name }}</div>
                                                                 <div class="text-truncate"><span class="badge fw-normal text-muted" style="font-size: 0.6rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span></div>
                                                             </div>
                                                             {% endif %}
@@ -122,16 +128,19 @@
             {% for event_date, events in events_by_date.items %}
             <div class="d-md-none" x-cloak x-show="selectedDay === {{ event_date.day }}">
                 {% for event in events %}
-                <a href="{% url 'event_detail' event.id %}" class="calendar-day-detail text-decoration-none d-flex align-items-center gap-2">
+                <a href="{% url 'event_detail' event.id %}" class="calendar-day-detail text-decoration-none d-flex align-items-center gap-2 position-relative overflow-hidden">
+                    {% if user.is_authenticated and event.id in registered_event_ids %}
+                    <div class="registered-indicator">
+                        <i class="bi bi-check-lg" aria-hidden="true"></i>
+                        <span class="visually-hidden">Registered</span>
+                    </div>
+                    {% endif %}
                     <span class="calendar-dot-detail" style="background-color: {{ event.program.color|default:'#6c757d' }};"></span>
                     <div class="flex-grow-1" style="min-width: 0;">
                         <div class="fw-medium{% if event_date < today %} text-muted{% else %} text-dark{% endif %}" style="font-size: 0.875rem;">{{ event.name }}</div>
                         <div class="text-muted" style="font-size: 0.75rem;">{{ event.starts_at|date:"g:i A"|lower|cut:".m." }}{% if event.ends_at %} – {{ event.ends_at|date:"g:i A"|lower|cut:".m." }}{% endif %} · {{ event.program.name }}</div>
                     </div>
-                    {% if user.is_authenticated and event.id in registered_event_ids %}
-                    <i class="bi bi-check-circle-fill text-success" aria-hidden="true"></i>
-                    <span class="visually-hidden">Registered</span>
-                    {% else %}
+                    {% if not user.is_authenticated or event.id not in registered_event_ids %}
                     <i class="bi bi-chevron-right text-muted" aria-hidden="true"></i>
                     {% endif %}
                 </a>

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -23,37 +23,35 @@
                 {% for event in events %}
                 <a href="{% url 'event_detail' event.id %}" class="text-decoration-none">
                     <div class="card shadow-sm border h-100 event-card"{% if event.program.color %} style="--program-color: {{ event.program.color }};"{% endif %}>
+                        {% if user.is_authenticated and event.id in registered_event_ids %}
+                        <div class="registered-indicator">
+                            <i class="bi bi-check-lg" aria-hidden="true"></i>
+                            <span class="visually-hidden">You are registered</span>
+                        </div>
+                        {% endif %}
                         <div class="card-body p-3">
-                            <div class="d-flex justify-content-between align-items-start">
-                                <div class="flex-grow-1">
-                                    <div class="small text-muted mb-1">
-                                        {{ event.starts_at|date:"g:i A" }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A" }}{% endif %}
-                                    </div>
-                                    <h3 class="fs-5 fw-medium mb-1 text-dark">
-                                        {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
-                                    </h3>
-                                    <div class="mb-2">
-                                        <span class="badge fw-normal text-muted small" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
-                                    </div>
-                                    <div class="d-flex flex-wrap gap-3 small text-muted">
-                                        {% if event.location %}
-                                        <div class="d-inline-flex align-items-center">
-                                            <i class="bi bi-geo-alt me-2"></i>
-                                            <span>{{ event.location }}</span>
-                                        </div>
-                                        {% endif %}
-
-                                        {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                        <div class="d-inline-flex align-items-center">
-                                            <i class="bi bi-people me-2"></i>
-                                            <span>{{ event.registration_count }} registered{% if not event.has_capacity_available %} (full){% endif %}</span>
-                                        </div>
-                                        {% endif %}
-                                    </div>
+                            <div class="small text-muted mb-1">
+                                {{ event.starts_at|date:"g:i A" }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A" }}{% endif %}
+                            </div>
+                            <h3 class="fs-5 fw-medium mb-1 text-dark">
+                                {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
+                            </h3>
+                            <div class="mb-2">
+                                <span class="badge fw-normal text-muted small" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
+                            </div>
+                            <div class="d-flex flex-wrap gap-3 small text-muted">
+                                {% if event.location %}
+                                <div class="d-inline-flex align-items-center">
+                                    <i class="bi bi-geo-alt me-2"></i>
+                                    <span>{{ event.location }}</span>
                                 </div>
-                                {% if user.is_authenticated and event.id in registered_event_ids %}
-                                <i class="bi bi-check-circle-fill text-success" style="font-size: 1.1rem; flex-shrink: 0;" aria-hidden="true"></i>
-                                <span class="visually-hidden">You are registered</span>
+                                {% endif %}
+
+                                {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
+                                <div class="d-inline-flex align-items-center">
+                                    <i class="bi bi-people me-2"></i>
+                                    <span>{{ event.registration_count }} registered{% if not event.has_capacity_available %} (full){% endif %}</span>
+                                </div>
                                 {% endif %}
                             </div>
                         </div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -23,23 +23,21 @@
                 {% for event in events %}
                 <a href="{% url 'event_detail' event.id %}" class="text-decoration-none">
                     <div class="card shadow-sm border h-100 event-card"{% if event.program.color %} style="--program-color: {{ event.program.color }};"{% endif %}>
+                        {% if user.is_authenticated and event.id in registered_event_ids %}
+                        <div class="registered-indicator">
+                            <i class="bi bi-check-lg" aria-hidden="true"></i>
+                            <span class="visually-hidden">You are registered</span>
+                        </div>
+                        {% endif %}
                         <div class="card-body py-2 px-3">
-                            <div class="d-flex justify-content-between align-items-start">
-                                <div class="flex-grow-1">
-                                    <div class="small text-muted" style="font-size: 0.8rem;">
-                                        {{ event.starts_at|date:"g:i A" }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A" }}{% endif %}
-                                    </div>
-                                    <div class="fs-6 fw-medium text-dark">
-                                        {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
-                                    </div>
-                                    <div>
-                                        <span class="badge fw-normal text-muted" style="font-size: 0.75rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
-                                    </div>
-                                </div>
-                                {% if user.is_authenticated and event.id in registered_event_ids %}
-                                <i class="bi bi-check-circle-fill text-success" style="font-size: 1.1rem; flex-shrink: 0;" aria-hidden="true"></i>
-                                <span class="visually-hidden">You are registered</span>
-                                {% endif %}
+                            <div class="small text-muted" style="font-size: 0.8rem;">
+                                {{ event.starts_at|date:"g:i A" }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A" }}{% endif %}
+                            </div>
+                            <div class="fs-6 fw-medium text-dark">
+                                {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
+                            </div>
+                            <div>
+                                <span class="badge fw-normal text-muted" style="font-size: 0.75rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
                             </div>
                         </div>
                         {% if event.location or event.has_rides or event.distance_range or not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}


### PR DESCRIPTION
## Summary
- Replaces the green circle checkmark registration indicator with a diagonal triangle cutout in the top-right corner of event cards
- Green background with white check icon, positioned above card content
- Applied consistently across list view, dense list view, calendar desktop cells (small variant), and calendar mobile detail panel

## Test plan
- [ ] Verify triangle indicator renders correctly on list view cards
- [ ] Verify triangle indicator renders correctly on dense list view cards
- [ ] Verify small triangle indicator renders correctly on calendar desktop event cells
- [ ] Verify triangle indicator renders correctly on calendar mobile detail rows
- [ ] Verify cards without registration show no indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)