### PR TITLE
Add Plausible custom property for signed-in visitors

### DIFF
--- a/web/templates/web/_base.html
+++ b/web/templates/web/_base.html
@@ -9,6 +9,14 @@
     <!-- Early scripts -->
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script defer data-domain="obcrides.ca" src="https://plausible.io/js/script.js"></script>
+    <script>
+      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
+      plausible.init({
+        customProperties: {
+          logged_in: "{% if user.is_authenticated %}true{% else %}false{% endif %}"
+        }
+      });
+    </script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
     <!-- Include Tailwind CSS directly -->

--- a/web/templates/web/_base_bootstrap.html
+++ b/web/templates/web/_base_bootstrap.html
@@ -11,6 +11,14 @@
 
     <!-- Early scripts -->
     <script defer data-domain="obcrides.ca" src="https://plausible.io/js/script.js"></script>
+    <script>
+      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
+      plausible.init({
+        customProperties: {
+          logged_in: "{% if user.is_authenticated %}true{% else %}false{% endif %}"
+        }
+      });
+    </script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script>
 


### PR DESCRIPTION
## Summary
- Adds a `logged_in` custom property to Plausible pageview tracking via `plausible.init()` with `customProperties`
- Sends `"true"` or `"false"` based on Django's `user.is_authenticated`
- Applied to both `_base_bootstrap.html` and `_base.html` base templates
- Note: You'll need to register the `logged_in` custom property in the Plausible dashboard under Custom Properties settings

## Test plan
- [ ] Verify Plausible continues to track pageviews after the snippet change
- [ ] Register `logged_in` as a custom property in Plausible dashboard
- [ ] Confirm `logged_in=true` appears for authenticated users
- [ ] Confirm `logged_in=false` appears for anonymous visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)