### PR TITLE
Upgrade Plausible snippet with logged_in custom property

### DIFF
--- a/web/templates/web/_base.html
+++ b/web/templates/web/_base.html
@@ -8,14 +8,14 @@
 
     <!-- Early scripts -->
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-    <script defer data-domain="obcrides.ca" src="https://plausible.io/js/script.js"></script>
+    <script async src="https://plausible.io/js/pa-XujvMCTT79u83iuv0Levp.js"></script>
     <script>
-      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
       plausible.init({
         customProperties: {
           logged_in: "{% if user.is_authenticated %}true{% else %}false{% endif %}"
         }
-      });
+      })
     </script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 

--- a/web/templates/web/_base_bootstrap.html
+++ b/web/templates/web/_base_bootstrap.html
@@ -10,14 +10,14 @@
     <title>{% block title %}RideHub{% endblock %}</title>
 
     <!-- Early scripts -->
-    <script defer data-domain="obcrides.ca" src="https://plausible.io/js/script.js"></script>
+    <script async src="https://plausible.io/js/pa-XujvMCTT79u83iuv0Levp.js"></script>
     <script>
-      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
       plausible.init({
         customProperties: {
           logged_in: "{% if user.is_authenticated %}true{% else %}false{% endif %}"
         }
-      });
+      })
     </script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- Replaces old Plausible `script.js` with new snippet format (`pa-XujvMCTT79u83iuv0Levp.js`)
- Adds `logged_in` custom property to track signed-in vs anonymous visitors
- Updated in both `_base_bootstrap.html` and `_base.html`

## Test plan
- [ ] Verify Plausible continues to track pageviews
- [ ] Register `logged_in` as a custom property in Plausible dashboard
- [ ] Confirm `logged_in=true` for authenticated users, `false` for anonymous

🤖 Generated with [Claude Code](https://claude.com/claude-code)