### PR TITLE
Remove archived state from event lifecycle

### DIFF
--- a/backoffice/actions.py
+++ b/backoffice/actions.py
@@ -129,35 +129,3 @@ def duplicate_event(admin: ModelAdmin, request: HttpRequest, query_set: QuerySet
 
 
 duplicate_event.short_description = "Duplicate selected events"
-
-def archive_event(admin: ModelAdmin, request: HttpRequest, query_set: QuerySet):
-    archive_count = 0
-    skipped = []
-
-    for event in query_set:
-        try:
-            event.archive()
-            event.save()
-        except TransitionNotAllowed:
-            skipped.append(event.name)
-            continue
-
-        archive_count += 1
-
-    if skipped:
-        admin.message_user(
-            request,
-            f"Could not archive: {', '.join(skipped)}. Only live or cancelled events can be archived.",
-            messages.ERROR,
-        )
-
-    if archive_count == 1:
-        message = "1 event was successfully archived."
-    elif archive_count > 1:
-        message = f"{archive_count} events were successfully archived."
-    else:
-        return
-
-    admin.message_user(request, message, messages.SUCCESS)
-
-archive_event.short_description = "Archive selected events"

--- a/backoffice/admin.py
+++ b/backoffice/admin.py
@@ -33,7 +33,7 @@ class EventAdmin(SortableAdminBase, admin.ModelAdmin):
     list_filter = ('starts_at', 'program', 'state',)
     search_fields = ('name',)
     actions = [cancel_event, duplicate_event]
-    readonly_fields = ('cancelled_at', 'cancellation_reason', 'archived_at')
+    readonly_fields = ('cancelled_at', 'cancellation_reason')
     form = EventAdminForm
 
     def get_queryset(self, request):

--- a/backoffice/forms.py
+++ b/backoffice/forms.py
@@ -43,7 +43,7 @@ class EventAdminForm(forms.ModelForm):
             self.fields['state'].choices = [
                 (value, label)
                 for value, label in self.fields['state'].choices
-                if value not in (Event.STATE_CANCELLED, Event.STATE_ARCHIVED)
+                if value != Event.STATE_CANCELLED
             ]
 
     def _find_transition_method(self, old_state, new_state):

--- a/backoffice/management/commands/importlegacy.py
+++ b/backoffice/management/commands/importlegacy.py
@@ -283,9 +283,7 @@ class Command(BaseCommand):
             description='Legacy event imported from WebScorer',
             legacy=True,
             legacy_event_id=event_id,
-            visible=False,
-            archived=True,
-            archived_at=timezone.now(),
+            state=Event.STATE_DRAFT,
         )
         self.operations.add_event(event, existing=False)
         events_cache[cache_key] = event

--- a/backoffice/migrations/0069_remove_event_archive_state.py
+++ b/backoffice/migrations/0069_remove_event_archive_state.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+
+
+def convert_archived_to_cancelled(apps, schema_editor):
+    Event = apps.get_model('backoffice', 'Event')
+    Event.objects.filter(state='archived').update(state='cancelled')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('backoffice', '0068_normalize_phone_numbers_v2'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            convert_archived_to_cancelled,
+            migrations.RunPython.noop,
+        ),
+        migrations.RemoveField(
+            model_name='event',
+            name='archived_at',
+        ),
+        migrations.AlterField(
+            model_name='event',
+            name='state',
+            field=models.CharField(
+                choices=[
+                    ('draft', 'Draft'),
+                    ('announced', 'Announced'),
+                    ('live', 'Live'),
+                    ('cancelled', 'Cancelled'),
+                ],
+                default='live',
+                help_text='Draft: not visible to public. Announced: visible but registration closed. Live: visible with registration open.',
+                max_length=50,
+            ),
+        ),
+    ]

--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -73,14 +73,12 @@ class Event(models.Model):
     STATE_ANNOUNCED = 'announced'
     STATE_LIVE = 'live'
     STATE_CANCELLED = 'cancelled'
-    STATE_ARCHIVED = 'archived'
 
     STATE_CHOICES = [
         (STATE_DRAFT, 'Draft'),
         (STATE_ANNOUNCED, 'Announced'),
         (STATE_LIVE, 'Live'),
         (STATE_CANCELLED, 'Cancelled'),
-        (STATE_ARCHIVED, 'Archived'),
     ]
 
     state = FSMField(
@@ -166,12 +164,6 @@ class Event(models.Model):
         help_text='Reason for cancellation.'
     )
 
-    archived_at = models.DateTimeField(
-        null=True,
-        blank=True,
-        help_text='When the event was archived.'
-    )
-
     organizer_email = models.EmailField(
         blank=True,
         help_text='When set, members will be able to reach out to the organizer at this email.'
@@ -195,10 +187,6 @@ class Event(models.Model):
     @property
     def cancelled(self) -> bool:
         return self.state == self.STATE_CANCELLED
-
-    @property
-    def archived(self) -> bool:
-        return self.state == self.STATE_ARCHIVED
 
     @property
     def duration(self) -> timedelta:
@@ -291,9 +279,6 @@ class Event(models.Model):
     def cancel(self):
         self.cancelled_at = timezone.now()
 
-    @transition(field=state, source=[STATE_LIVE, STATE_CANCELLED], target=STATE_ARCHIVED)
-    def archive(self):
-        self.archived_at = timezone.now()
 
 
 class Route(models.Model):

--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -7,11 +7,8 @@ from backoffice.models import Event, Ride
 
 
 class EventService:
-    def fetch_events(self, include_archived: bool = False, only_visible: bool = True) -> QuerySet[Event]:
+    def fetch_events(self, only_visible: bool = True) -> QuerySet[Event]:
         queryset = Event.objects.all()
-
-        if not include_archived:
-            queryset = queryset.exclude(state=Event.STATE_ARCHIVED)
 
         if only_visible:
             queryset = queryset.filter(
@@ -20,18 +17,18 @@ class EventService:
 
         return queryset.order_by('starts_at')
 
-    def fetch_upcoming_events(self, include_archived: bool = False, only_visible: bool = True,
+    def fetch_upcoming_events(self, only_visible: bool = True,
                               current_date: date | None = None, program_id: int | None = None,
                               query: str | None = None) -> QuerySet[Event]:
         current_date = current_date or timezone.now().date()
-        qs = self.fetch_events(include_archived, only_visible).filter(starts_at__date__gte=current_date)
+        qs = self.fetch_events(only_visible).filter(starts_at__date__gte=current_date)
         if program_id is not None:
             qs = qs.filter(program_id=program_id)
         if query:
             qs = qs.filter(Q(name__icontains=query) | Q(program__name__icontains=query)).distinct()
         return qs
 
-    def fetch_events_for_month(self, year: int, month: int, include_archived: bool = False,
+    def fetch_events_for_month(self, year: int, month: int,
                                only_visible: bool = True, program_id: int | None = None,
                                query: str | None = None) -> QuerySet[Event]:
         from datetime import date
@@ -41,7 +38,7 @@ class EventService:
         _, last_day_of_month = calendar.monthrange(year, month)
         last_day = date(year, month, last_day_of_month)
 
-        qs = self.fetch_events(include_archived, only_visible).filter(
+        qs = self.fetch_events(only_visible).filter(
             starts_at__date__gte=first_day,
             starts_at__date__lte=last_day
         )

--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -273,9 +273,6 @@ class RegistrationService:
         if event.cancelled:
             return False, 'Event is cancelled.'
 
-        if event.archived:
-            return False, 'Event is archived.'
-
         if not event.registration_open:
             return False, 'Registration is closed.'
 

--- a/backoffice/services/reviews_service.py
+++ b/backoffice/services/reviews_service.py
@@ -14,8 +14,6 @@ class ReviewsService:
         events = Event.objects.filter(
             starts_at__date__gte=start_date,
             starts_at__date__lte=end_date,
-        ).exclude(
-            state=Event.STATE_ARCHIVED
         )
 
         confirmed_registrations = Registration.objects.filter(

--- a/backoffice/tests/services/test_event_service.py
+++ b/backoffice/tests/services/test_event_service.py
@@ -184,16 +184,6 @@ class FetchEventsForMonthTests(BaseEventServiceTest):
             state=Event.STATE_DRAFT,
         )
 
-        # Archived event in January
-        Event.objects.create(
-            program=self.program,
-            name="January Archived",
-            starts_at=timezone.make_aware(datetime.datetime.combine(jan_middle, datetime.datetime.min.time())),
-            registration_closes_at=timezone.make_aware(
-                datetime.datetime.combine(jan_middle, datetime.datetime.min.time())),
-            state=Event.STATE_ARCHIVED,
-        )
-
     def test_fetch_events_for_month_with_only_visible(self):
         # Arrange
         # (Setup is done in setUp method)
@@ -209,7 +199,6 @@ class FetchEventsForMonthTests(BaseEventServiceTest):
         self.assertIn("January Middle", event_names)
         self.assertNotIn("February First", event_names)
         self.assertNotIn("January Hidden", event_names)
-        self.assertNotIn("January Archived", event_names)
 
     def test_fetch_events_for_month_with_all_visibility(self):
         # Arrange
@@ -220,30 +209,12 @@ class FetchEventsForMonthTests(BaseEventServiceTest):
 
         # Assert
         self.assertEqual(4, result.count(),
-                         "Should return all non-archived events for January 2024 regardless of visibility")
+                         "Should return all events for January 2024 regardless of visibility")
         event_names = [event.name for event in result]
         self.assertIn("January First", event_names)
         self.assertIn("January Last", event_names)
         self.assertIn("January Middle", event_names)
         self.assertIn("January Hidden", event_names)
-        self.assertNotIn("February First", event_names)
-        self.assertNotIn("January Archived", event_names)
-
-    def test_fetch_events_for_month_with_archived(self):
-        # Arrange
-        # (Setup is done in setUp method)
-
-        # Act
-        result = self.service.fetch_events_for_month(2024, 1, include_archived=True, only_visible=False)
-
-        # Assert
-        self.assertEqual(5, result.count(), "Should return all events for January 2024 including archived")
-        event_names = [event.name for event in result]
-        self.assertIn("January First", event_names)
-        self.assertIn("January Last", event_names)
-        self.assertIn("January Middle", event_names)
-        self.assertIn("January Hidden", event_names)
-        self.assertIn("January Archived", event_names)
         self.assertNotIn("February First", event_names)
 
     def test_fetch_events_for_month_leap_year_february(self):
@@ -384,20 +355,6 @@ class DuplicateEventTestCase(TestCase):
 
     def test_duplicate_event_defaults_cancelled_to_draft(self):
         self.source_event.cancel()
-        self.source_event.save()
-
-        new_date = self.base_start_time.date() + datetime.timedelta(days=7)
-
-        new_event = self.service.duplicate_event(
-            self.source_event, "New Event", new_date
-        )
-
-        self.assertEqual(new_event.state, Event.STATE_DRAFT)
-
-    def test_duplicate_event_defaults_archived_to_draft(self):
-        self.source_event.cancel()
-        self.source_event.save()
-        self.source_event.archive()
         self.source_event.save()
 
         new_date = self.base_start_time.date() + datetime.timedelta(days=7)

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -290,46 +290,6 @@ class FetchCurrentRegistrationsTestCase(TestCase):
         for reg in current_registrations_for_self_user:
             self.assertEqual(reg.user, self.user)
 
-    def test_fetch_current_registrations_excludes_archived_events(self):
-        # Arrange
-        # Non-archived event and registration (should be included)
-        event_not_archived = Event.objects.create(
-            name="Current Event Not Archived",
-            program=self.program,
-            starts_at=self.test_today_datetime_noon + datetime.timedelta(days=1),
-            registration_closes_at=self.test_today_datetime_noon,
-            state=Event.STATE_LIVE
-        )
-        reg_not_archived = Registration.objects.create(
-            user=self.user,
-            event=event_not_archived,
-            name=self.user.username,
-            email=self.user.email
-        )
-
-        # Archived event and registration (should be excluded)
-        event_archived = Event.objects.create(
-            name="Current Event Archived",
-            program=self.program,
-            starts_at=self.test_today_datetime_noon + datetime.timedelta(days=2),
-            registration_closes_at=self.test_today_datetime_noon + datetime.timedelta(days=1),
-            state=Event.STATE_ARCHIVED
-        )
-        Registration.objects.create(
-            user=self.user,
-            event=event_archived,
-            name=self.user.username,
-            email=self.user.email
-        )
-
-        # Act
-        current_registrations = self.service.fetch_current_registrations(self.user)
-
-        # Assert
-        self.assertEqual(len(current_registrations), 1)
-        self.assertIn(reg_not_archived, current_registrations)
-        self.assertEqual(current_registrations[0], reg_not_archived)
-
     def test_fetch_current_registrations_gets_latest_for_multiple_on_same_event(self):
         # Arrange
         # Event for which user will have multiple registrations
@@ -1539,20 +1499,6 @@ class IsRegistrationAllowedTestCase(TestCase):
 
         self.assertFalse(allowed)
         self.assertEqual(reason, 'Event is cancelled.')
-
-    def test_registration_not_allowed_for_archived_event(self):
-        event = Event.objects.create(
-            program=self.program,
-            name="Archived Event",
-            starts_at=timezone.now() + timezone.timedelta(days=7),
-            registration_closes_at=timezone.now() + timezone.timedelta(days=6),
-            state=Event.STATE_ARCHIVED,
-        )
-
-        allowed, reason = self.service.is_registration_allowed(event)
-
-        self.assertFalse(allowed)
-        self.assertEqual(reason, 'Event is archived.')
 
     def test_registration_not_allowed_when_closed(self):
         event = Event.objects.create(

--- a/backoffice/tests/test_event_admin_form.py
+++ b/backoffice/tests/test_event_admin_form.py
@@ -38,9 +38,6 @@ class EventAdminFormTestCase(TestCase):
         elif state == Event.STATE_CANCELLED:
             event.cancel()
             event.save()
-        elif state == Event.STATE_ARCHIVED:
-            event.archive()
-            event.save()
         return event
 
     def _get_form_data(self, event, **overrides):
@@ -118,12 +115,6 @@ class EventAdminFormTestCase(TestCase):
         form = TestEventAdminForm(instance=event)
         state_values = [value for value, _ in form.fields['state'].choices]
         self.assertNotIn(Event.STATE_CANCELLED, state_values)
-
-    def test_archived_not_in_state_choices(self):
-        event = self.create_event(state=Event.STATE_LIVE)
-        form = TestEventAdminForm(instance=event)
-        state_values = [value for value, _ in form.fields['state'].choices]
-        self.assertNotIn(Event.STATE_ARCHIVED, state_values)
 
     def test_no_state_change_saves_normally(self):
         event = self.create_event(state=Event.STATE_LIVE)

--- a/backoffice/tests/test_event_states.py
+++ b/backoffice/tests/test_event_states.py
@@ -34,9 +34,6 @@ class EventStatesTestCase(TestCase):
         elif state == Event.STATE_CANCELLED:
             event.cancel()
             event.save()
-        elif state == Event.STATE_ARCHIVED:
-            event.archive()
-            event.save()
 
         return event
 
@@ -124,30 +121,6 @@ class EventStatesTestCase(TestCase):
         self.assertTrue(event.cancelled)
         self.assertIsNotNone(event.cancelled_at)
 
-    def test_archive_from_live(self):
-        event = self.create_event(state=Event.STATE_LIVE)
-        self.assertEqual(event.state, Event.STATE_LIVE)
-        self.assertFalse(event.archived)
-        self.assertIsNone(event.archived_at)
-
-        event.archive()
-        event.save()
-
-        self.assertEqual(event.state, Event.STATE_ARCHIVED)
-        self.assertTrue(event.archived)
-        self.assertIsNotNone(event.archived_at)
-
-    def test_archive_from_cancelled(self):
-        event = self.create_event(state=Event.STATE_CANCELLED)
-        self.assertEqual(event.state, Event.STATE_CANCELLED)
-
-        event.archive()
-        event.save()
-
-        self.assertEqual(event.state, Event.STATE_ARCHIVED)
-        self.assertTrue(event.archived)
-        self.assertIsNotNone(event.archived_at)
-
     def test_cannot_live_from_cancelled(self):
         event = self.create_event(state=Event.STATE_CANCELLED)
         self.assertEqual(event.state, Event.STATE_CANCELLED)
@@ -161,34 +134,6 @@ class EventStatesTestCase(TestCase):
 
         with self.assertRaises(TransitionNotAllowed):
             event.cancel()
-
-    def test_cannot_cancel_from_archived(self):
-        event = self.create_event(state=Event.STATE_ARCHIVED)
-        self.assertEqual(event.state, Event.STATE_ARCHIVED)
-
-        with self.assertRaises(TransitionNotAllowed):
-            event.cancel()
-
-    def test_cannot_archive_from_draft(self):
-        event = self.create_event(state=Event.STATE_DRAFT)
-        self.assertEqual(event.state, Event.STATE_DRAFT)
-
-        with self.assertRaises(TransitionNotAllowed):
-            event.archive()
-
-    def test_cannot_archive_from_announced(self):
-        event = self.create_event(state=Event.STATE_ANNOUNCED)
-        self.assertEqual(event.state, Event.STATE_ANNOUNCED)
-
-        with self.assertRaises(TransitionNotAllowed):
-            event.archive()
-
-    def test_cannot_live_from_archived(self):
-        event = self.create_event(state=Event.STATE_ARCHIVED)
-        self.assertEqual(event.state, Event.STATE_ARCHIVED)
-
-        with self.assertRaises(TransitionNotAllowed):
-            event.live()
 
     def test_cannot_cancel_from_announced(self):
         event = self.create_event(state=Event.STATE_ANNOUNCED)
@@ -251,7 +196,6 @@ class EventStatesTestCase(TestCase):
             (Event.STATE_ANNOUNCED, True),
             (Event.STATE_LIVE, True),
             (Event.STATE_CANCELLED, True),
-            (Event.STATE_ARCHIVED, False),
         ]:
             event = self.create_event(state=state)
             self.assertEqual(event.visible, expected, f"visible should be {expected} for state {state}")
@@ -262,25 +206,13 @@ class EventStatesTestCase(TestCase):
             (Event.STATE_ANNOUNCED, False),
             (Event.STATE_LIVE, False),
             (Event.STATE_CANCELLED, True),
-            (Event.STATE_ARCHIVED, False),
         ]:
             event = self.create_event(state=state)
             self.assertEqual(event.cancelled, expected, f"cancelled should be {expected} for state {state}")
 
-    def test_archived_property_by_state(self):
-        for state, expected in [
-            (Event.STATE_DRAFT, False),
-            (Event.STATE_ANNOUNCED, False),
-            (Event.STATE_LIVE, False),
-            (Event.STATE_CANCELLED, False),
-            (Event.STATE_ARCHIVED, True),
-        ]:
-            event = self.create_event(state=state)
-            self.assertEqual(event.archived, expected, f"archived should be {expected} for state {state}")
-
     def test_registration_open_only_in_live_state(self):
         future_close = self.now + timedelta(hours=12)
-        for state in [Event.STATE_DRAFT, Event.STATE_ANNOUNCED, Event.STATE_CANCELLED, Event.STATE_ARCHIVED]:
+        for state in [Event.STATE_DRAFT, Event.STATE_ANNOUNCED, Event.STATE_CANCELLED]:
             event = self.create_event(state=state, registration_closes_at=future_close)
             self.assertFalse(event.registration_open, f"registration_open should be False for state {state}")
 

--- a/docs/specifications/events-duplication.md
+++ b/docs/specifications/events-duplication.md
@@ -16,7 +16,6 @@ Rules:
  - All fields from the existing event are copied over to the new event, with exceptions:
    - A new event must never carry over any cancellation status.
    - A new event starts as visible by default.
-   - A new event must never carry over archived status.
    - A new event must never carry over legacy import fields.
  - Linked records may sometimes be deep copied, sometimes not.
    - Ride records must be duplicated.
@@ -56,7 +55,6 @@ Flow:
 | registration_closes_at | Inherit time from source, shift date by same offset as starts_at |
 | visible | Set to `True` |
 | cancelled, cancelled_at, cancellation_reason | Reset to defaults |
-| archived, archived_at | Do not copy (use defaults) |
 | legacy, legacy_event_id | Do not copy (use defaults) |
 
 ## Ride copying

--- a/docs/specifications/events-states.md
+++ b/docs/specifications/events-states.md
@@ -1,10 +1,10 @@
 # Event State Machine
 
-This document describes the event lifecycle state machine. The `state` field is the single source of truth for event visibility, cancellation, and archival status.
+This document describes the event lifecycle state machine. The `state` field is the single source of truth for event visibility and cancellation status.
 
 ## States
 
-The Event model has five possible states, defined as class constants (e.g., `Event.STATE_LIVE`):
+The Event model has four possible states, defined as class constants (e.g., `Event.STATE_LIVE`):
 
 | State       | Description                                    | Visibility | Registration |
 |-------------|------------------------------------------------|------------|--------------|
@@ -12,7 +12,6 @@ The Event model has five possible states, defined as class constants (e.g., `Eve
 | `announced` | Event is visible but not open for registration | Public     | Closed       |
 | `live`      | Event is live and accepting registrations      | Public     | Open         |
 | `cancelled` | Event has been cancelled                       | Public     | Closed       |
-| `archived`  | Event has been removed/deleted                 | Admin-only | Closed       |
 
 ## Computed Properties
 
@@ -22,7 +21,6 @@ The model provides computed properties derived from `state`:
 |-------------|---------------------------------------------|
 | `visible`   | `announced`, `live`, `cancelled`            |
 | `cancelled` | `cancelled`                                 |
-| `archived`  | `archived`                                  |
 
 ## State Transitions
 
@@ -38,12 +36,10 @@ The model provides computed properties derived from `state`:
       | announced |<------------->|   live    |
       +-----------+               +-----+-----+
                                         |
-                          +-------------+-------------+
-                          |                           |
-                          v                           v
-                    +-----------+               +-----------+
-                    | cancelled |-------------->|  archived |
-                    +-----------+               +-----------+
+                                        v
+                                  +-----------+
+                                  | cancelled |
+                                  +-----------+
 ```
 
 ### Available Transitions
@@ -54,9 +50,8 @@ The model provides computed properties derived from `state`:
 | `announce()` | draft, live      | announced    | None                  | No confirmed registrations*     |
 | `draft()`    | announced, live  | draft        | None                  | No confirmed registrations*     |
 | `cancel()`   | live             | cancelled    | Sets `cancelled_at`   | None                            |
-| `archive()`  | live, cancelled  | archived     | Sets `archived_at`    | No confirmed registrations*     |
 
-*Guard only applies when transitioning from `live` state. Transitioning from other source states (e.g., `cancelled` to `archived`) is always allowed.
+*Guard only applies when transitioning from `live` state.
 
 ## Admin Interface
 

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -331,21 +331,6 @@ class RegistrationCreateErrorCaseTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn(b'Event is cancelled', response.content)
 
-    def test_registration_returns_400_for_archived_event(self):
-        event = Event.objects.create(
-            name="Archived Event",
-            program=self.program,
-            starts_at=timezone.now() + timezone.timedelta(days=7),
-            registration_closes_at=timezone.now() + timezone.timedelta(days=6),
-        )
-        event.archive()
-        event.save()
-
-        response = self.client.get(reverse('registration_create', args=[event.id]))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(b'Event is archived', response.content)
-
     def test_registration_returns_400_when_registration_closed(self):
         event = Event.objects.create(
             name="Closed Event",


### PR DESCRIPTION
## Summary
- Removes the `archived` state entirely from the Event model FSM, including the `STATE_ARCHIVED` constant, `archived_at` field, `archived` property, and `archive()` transition
- Removes the `archive_event` admin action and all archive-related filtering (`include_archived` params) from event services
- Adds a data migration converting any existing archived events to cancelled state
- Updates tests, documentation, and the legacy import command accordingly

## Test plan
- [x] All 356 tests pass
- [ ] Verify no events are in archived state in production before deploying
- [ ] Confirm admin interface no longer shows archive-related options

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)