### PR TITLE
Add manage registrations button to registrations list page

### DIFF
--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -151,6 +151,11 @@
         <a href="{% url 'event_detail' event.id %}" class="btn btn-outline-secondary btn-sm rounded-pill d-inline-flex align-items-center">
             <i class="bi bi-arrow-left me-2"></i> Back to event details
         </a>
+        {% if user.is_staff %}
+        <a href="{% url 'event_registrations_manage' event.id %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
+            <i class="bi bi-people me-2"></i> Manage registrations
+        </a>
+        {% endif %}
         {% if can_access_rider_contacts %}
         <button class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center copy-emails-btn" data-emails="{{ all_emails }}" data-type="all">
             <i class="bi bi-clipboard me-2"></i>


### PR DESCRIPTION
## Summary
- Adds a staff-only "Manage registrations" button to the `/event/<id>/registrations` page, matching the existing button on the event detail page

Closes #223

## Test plan
- [ ] As a staff user, visit `/events/<id>/registrations` and confirm the "Manage registrations" button appears
- [ ] Confirm the button links to `/events/<id>/registrations/manage`
- [ ] As a non-staff user, confirm the button does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)