### PR TITLE
Use fast password hasher during tests

### DIFF
--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 
 import dj_database_url
@@ -208,3 +209,6 @@ SOCIALACCOUNT_PROVIDERS = {
 
 AZURE_AD_STAFF_DOMAIN = '@ottawabicycleclub.ca'
 AZURE_AD_STAFF_GROUP = 'Ride Administrators'
+
+if 'test' in sys.argv:
+    PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']


### PR DESCRIPTION
## Summary
- Switch from PBKDF2 (~844ms/hash) to MD5 (~0.03ms/hash) when `test` is in `sys.argv`
- Reduces full test suite runtime from **~257s to ~8s** (31x speedup)
- All 447 tests continue to pass

## Test plan
- [x] Verified all 447 tests pass with the new hasher
- [x] Confirmed timing improvement (257s → 8s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)