### PR TITLE
Darken default event card border for better visibility

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -258,7 +258,7 @@ body {
 .event-card {
   transition: background-color 0.2s ease, border-color 0.2s ease;
   background-color: #ffffff;
-  border-color: #dee2e6;
+  border-color: #adb5bd;
   position: relative;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- Change event card default border color from `#dee2e6` to `#adb5bd` (Bootstrap gray-500)
- Makes borders (especially dashed borders on announced events) easier to see
- Hover border (`#6c757d`) remains darker, preserving the hover distinction

## Test plan
- [ ] Visually verify event cards on `/upcoming` and `/calendar` have a more visible border
- [ ] Verify hover still provides a noticeable darkening effect
- [ ] Verify announced events' dashed borders are clearly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)