### PR TITLE
Add matching border color to calendar event cards

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -346,6 +346,7 @@ body {
 
 .calendar-event {
   transition: background-color 0.2s ease, border-color 0.2s ease;
+  border-color: #adb5bd;
 }
 
 .calendar-event-announced {


### PR DESCRIPTION
## Summary
- Add `border-color: #adb5bd` to `.calendar-event` to match `.event-card`
- PR #232 only updated the list/upcoming view cards but missed the calendar view cards, which still used Bootstrap's lighter default (`#dee2e6`)

## Test plan
- [ ] Visually verify calendar event cards at `/calendar` now have the same darker border as `/upcoming` cards
- [ ] Verify dashed borders on announced events are clearly visible in the calendar view

🤖 Generated with [Claude Code](https://claude.com/claude-code)