### PR TITLE
Fix card border color: add !important and darken

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -258,7 +258,7 @@ body {
 .event-card {
   transition: background-color 0.2s ease, border-color 0.2s ease;
   background-color: #ffffff;
-  border-color: #adb5bd;
+  border-color: #8e959c !important;
   position: relative;
   overflow: hidden;
 }
@@ -346,6 +346,7 @@ body {
 
 .calendar-event {
   transition: background-color 0.2s ease, border-color 0.2s ease;
+  border-color: #8e959c !important;
 }
 
 .calendar-event-announced {

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -258,7 +258,7 @@ body {
 .event-card {
   transition: background-color 0.2s ease, border-color 0.2s ease;
   background-color: #ffffff;
-  border-color: #8e959c !important;
+  border-color: #adb5bd !important;
   position: relative;
   overflow: hidden;
 }
@@ -346,7 +346,7 @@ body {
 
 .calendar-event {
   transition: background-color 0.2s ease, border-color 0.2s ease;
-  border-color: #8e959c !important;
+  border-color: #adb5bd !important;
 }
 
 .calendar-event-announced {


### PR DESCRIPTION
## Summary
- Previous `border-color: #adb5bd` on `.event-card` was being overridden by Bootstrap's `.border` utility class (which uses `!important`), so the change had no visible effect
- Add `!important` to both `.event-card` and `.calendar-event` border-color rules
- Darken from `#adb5bd` to `#8e959c` for better visibility (closer to the `#6c757d` hover color while still distinct)

## Test plan
- [ ] Verify event cards on `/upcoming` now have a noticeably darker border
- [ ] Verify calendar event cards at `/calendar` also have the darker border
- [ ] Verify hover still darkens the border slightly further
- [ ] Verify dashed borders on announced events are clearly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)