### PR TITLE
Require explicit reveal of contact details on registrations page

### DIFF
--- a/web/tables.py
+++ b/web/tables.py
@@ -91,6 +91,16 @@ class PublicRegistrationTable(tables.Table):
             'class': 'table',
             'th': {'class': 'small fw-medium'},
         }
+        row_attrs = {
+            'data-registration-id': lambda record: record.id,
+        }
+
+    def __init__(self, *args, contacts_hidden=False, **kwargs):
+        self.contacts_hidden = contacts_hidden
+        super().__init__(*args, **kwargs)
+
+    def _hidden_placeholder(self):
+        return format_html('<span class="small text-muted fst-italic">(hidden)</span>')
 
     def render_name(self, value):
         return format_html('<span class="small fw-medium">{}</span>', value)
@@ -108,20 +118,28 @@ class PublicRegistrationTable(tables.Table):
         return format_html('<span class="small text-muted">{}</span>', display)
 
     def render_email(self, value):
+        if self.contacts_hidden:
+            return self._hidden_placeholder()
         return format_html(
             '<a href="mailto:{}" class="small text-primary">{}</a>', value, value
         )
 
     def render_phone(self, value):
+        if self.contacts_hidden:
+            return self._hidden_placeholder()
         formatted = national_phone(value)
         return format_html(
             '<a href="tel:{}" class="small text-primary">{}</a>', value, formatted
         )
 
     def render_emergency_contact_name(self, value):
+        if self.contacts_hidden:
+            return self._hidden_placeholder()
         return format_html('<span class="small text-muted">{}</span>', value)
 
     def render_emergency_contact_phone(self, value):
+        if self.contacts_hidden:
+            return self._hidden_placeholder()
         formatted = national_phone(value)
         return format_html(
             '<a href="tel:{}" class="small text-primary">{}</a>', value, formatted

--- a/web/templates/web/events/_registrations_list.html
+++ b/web/templates/web/events/_registrations_list.html
@@ -1,0 +1,102 @@
+{% load phone_filters %}
+{% load django_tables2 %}
+
+{% if all_riders %}
+<h2 class="fs-5 fw-medium mb-3">Registered riders ({{ filtered_riders|length }})</h2>
+
+{% include 'web/events/_registration_filter.html' %}
+
+    <!-- Mobile view (card-based layout) -->
+    <div class="d-md-none">
+        {% for rider_reg in filtered_riders %}
+            <div class="card mb-3 p-4" data-registration-id="{{ rider_reg.id }}">
+                <div class="d-flex flex-column align-items-start mb-2">
+                    <div class="d-flex align-items-center">
+                        <h4 class="fw-medium fs-5 mb-0">{{ rider_reg.first_name }} {{ rider_reg.last_name }}</h4>
+                    </div>
+                </div>
+                <div class="small">
+                    <div class="row mb-1">
+                        <div class="col-5 fw-medium">Ride:</div>
+                        <div class="col-7 text-muted">{{ rider_reg.ride.name|default:"N/A" }}</div>
+                    </div>
+                    <div class="row mb-1">
+                        <div class="col-5 fw-medium">Speed group:</div>
+                        <div class="col-7 text-muted">{{ rider_reg.speed_range_preference.range|default:"N/A" }}</div>
+                    </div>
+                    <div class="row mb-1">
+                        <div class="col-5 fw-medium">Ride leader:</div>
+                        <div class="col-7 text-muted">{{ rider_reg.get_ride_leader_preference_display }}</div>
+                    </div>
+
+                    {% if can_access_rider_contacts %}
+                    <div class="mt-3 border-top border-danger-subtle pt-2 w-100">
+                        {% if contacts_revealed %}
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Email:</div>
+                            <div class="col-7 text-muted">
+                                <a href="mailto:{{ rider_reg.email }}" class="text-primary">
+                                    {{ rider_reg.email }}
+                                </a>
+                            </div>
+                        </div>
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Phone:</div>
+                            <div class="col-7 text-muted">
+                                <a href="tel:{{ rider_reg.phone }}" class="text-primary">
+                                    {{ rider_reg.phone|national_phone }}
+                                </a>
+                            </div>
+                        </div>
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Emergency:</div>
+                            <div class="col-7 text-muted">{{ rider_reg.emergency_contact_name }}</div>
+                        </div>
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Emergency phone:</div>
+                            <div class="col-7 text-muted">
+                                <a href="tel:{{ rider_reg.emergency_contact_phone }}" class="text-primary">
+                                    {{ rider_reg.emergency_contact_phone }}
+                                </a>
+                            </div>
+                        </div>
+                        {% else %}
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Email:</div>
+                            <div class="col-7 text-muted fst-italic">(hidden)</div>
+                        </div>
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Phone:</div>
+                            <div class="col-7 text-muted fst-italic">(hidden)</div>
+                        </div>
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Emergency:</div>
+                            <div class="col-7 text-muted fst-italic">(hidden)</div>
+                        </div>
+                        <div class="row mb-1">
+                            <div class="col-5 fw-medium">Emergency phone:</div>
+                            <div class="col-7 text-muted fst-italic">(hidden)</div>
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+
+    <!-- Desktop view (table-based layout) -->
+    <div class="d-none d-md-block card shadow-sm">
+        <div class="p-4">
+            <div class="overflow-auto">
+                {% render_table table %}
+            </div>
+        </div>
+    </div>
+{% else %}
+<h2 class="fs-5 fw-medium mb-3">Registered riders (0)</h2>
+<div class="py-5 text-center card">
+    <p class="text-muted">No riders found for this event.</p>
+</div>
+{% endif %}
+

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -169,7 +169,7 @@
         {% endif %}
         {% if can_reveal_contacts and not contacts_revealed %}
         <button class="btn btn-danger btn-sm rounded-pill d-inline-flex align-items-center"
-                hx-get="{% url 'event_emergency_contacts' event.id %}"
+                hx-get="{% url 'event_emergency_contacts' event.id %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}"
                 hx-target="#registrations-content"
                 hx-swap="innerHTML"
                 hx-on::after-request="this.disabled=true; this.classList.remove('btn-danger'); this.classList.add('btn-outline-secondary')">

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -1,6 +1,4 @@
 {% extends 'web/_base_bootstrap.html' %}
-{% load phone_filters %}
-{% load django_tables2 %}
 {% block title %}Riders for {{ event.name }}{% endblock %}
 {% block content %}
 <style media="print">
@@ -169,6 +167,15 @@
         </button>
         {% endif %}
         {% endif %}
+        {% if can_reveal_contacts and not contacts_revealed %}
+        <button class="btn btn-danger btn-sm rounded-pill d-inline-flex align-items-center"
+                hx-get="{% url 'event_emergency_contacts' event.id %}"
+                hx-target="#registrations-content"
+                hx-swap="innerHTML"
+                hx-on::after-request="this.disabled=true; this.classList.remove('btn-danger'); this.classList.add('btn-outline-secondary')">
+            <i class="bi bi-shield-exclamation me-2"></i> Reveal contact details
+        </button>
+        {% endif %}
     </div>
     {% if can_access_rider_contacts %}
     <div id="copy-success-message" class="alert alert-success mb-3 small d-none d-print-none" role="alert">
@@ -212,108 +219,34 @@
     <div class="py-5 text-center card">
         <p class="text-muted">Registration details are no longer available for this event.</p>
     </div>
-    {% elif all_riders %}
-    <h2 class="fs-5 fw-medium mb-3">Registered riders ({{ filtered_riders|length }})</h2>
-
-    {% include 'web/events/_registration_filter.html' %}
-
-        <!-- Mobile view (card-based layout) -->
-        <div class="d-md-none">
-            {% for rider_reg in filtered_riders %}
-                <div class="card mb-3 p-4">
-                    <div class="d-flex flex-column align-items-start mb-2">
-                        <div class="d-flex align-items-center">
-                            <h4 class="fw-medium fs-5 mb-0">{{ rider_reg.first_name }} {{ rider_reg.last_name }}</h4>
-                        </div>
-                    </div>
-                    <div class="small">
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Ride:</div>
-                            <div class="col-7 text-muted">{{ rider_reg.ride.name|default:"N/A" }}</div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Speed group:</div>
-                            <div class="col-7 text-muted">{{ rider_reg.speed_range_preference.range|default:"N/A" }}</div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Ride leader:</div>
-                            <div class="col-7 text-muted">{{ rider_reg.get_ride_leader_preference_display }}</div>
-                        </div>
-
-                        {% if can_access_rider_contacts %}
-                        <div class="mt-3 border-top border-danger-subtle pt-2 w-100">
-                            <div class="row mb-1">
-                                <div class="col-5 fw-medium">Email:</div>
-                                <div class="col-7 text-muted">
-                                    <a href="mailto:{{ rider_reg.email }}" class="text-primary">
-                                        {{ rider_reg.email }}
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="row mb-1">
-                                <div class="col-5 fw-medium">Phone:</div>
-                                <div class="col-7 text-muted">
-                                    <a href="tel:{{ rider_reg.phone }}" class="text-primary">
-                                        {{ rider_reg.phone|national_phone }}
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="row mb-1">
-                                <div class="col-5 fw-medium">Emergency:</div>
-                                <div class="col-7 text-muted">{{ rider_reg.emergency_contact_name }}</div>
-                            </div>
-                            <div class="row mb-1">
-                                <div class="col-5 fw-medium">Emergency phone:</div>
-                                <div class="col-7 text-muted">
-                                    <a href="tel:{{ rider_reg.emergency_contact_phone }}" class="text-primary">
-                                        {{ rider_reg.emergency_contact_phone }}
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        {% endif %}
-                    </div>
-                </div>
-            {% endfor %}
-        </div>
-
-        <!-- Desktop view (table-based layout) -->
-        <div class="d-none d-md-block card shadow-sm">
-            <div class="p-4">
-                <div class="overflow-auto">
-                    {% render_table table %}
-                </div>
-            </div>
-        </div>
     {% else %}
-    <h2 class="fs-5 fw-medium mb-3">Registered riders (0)</h2>
-    <div class="py-5 text-center card">
-        <p class="text-muted">No riders found for this event.</p>
+    <div id="registrations-content">
+        {% include 'web/events/_registrations_list.html' %}
     </div>
     {% endif %}
 </div>
 
 {% if can_access_rider_contacts %}
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    const copyButtons = document.querySelectorAll('.copy-emails-btn');
-    const successMessage = document.getElementById('copy-success-message');
-    const successText = document.getElementById('copy-success-text');
+(function() {
+    var copyButtons = document.querySelectorAll('.copy-emails-btn');
+    var successMessage = document.getElementById('copy-success-message');
+    var successText = document.getElementById('copy-success-text');
 
-    copyButtons.forEach(button => {
+    copyButtons.forEach(function(button) {
         button.addEventListener('click', async function() {
-            const emails = this.getAttribute('data-emails');
-            const type = this.getAttribute('data-type');
+            var emails = this.getAttribute('data-emails');
+            var type = this.getAttribute('data-type');
 
             try {
                 await navigator.clipboard.writeText(emails);
 
-                const count = emails ? emails.split(',').length : 0;
-                const label = type === 'all' ? 'rider' : 'ride leader';
-                successText.textContent = `Copied ${count} ${label} email${count !== 1 ? 's' : ''} to clipboard!`;
+                var count = emails ? emails.split(',').length : 0;
+                var label = type === 'all' ? 'rider' : 'ride leader';
+                successText.textContent = 'Copied ' + count + ' ' + label + ' email' + (count !== 1 ? 's' : '') + ' to clipboard!';
                 successMessage.classList.remove('d-none');
 
-                setTimeout(() => {
+                setTimeout(function() {
                     successMessage.classList.add('d-none');
                 }, 3000);
             } catch (err) {
@@ -321,7 +254,7 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
-});
+})();
 </script>
 {% endif %}
 

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -122,10 +122,13 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
         self.assertTemplateUsed(response, 'web/events/registrations.html')
         self.assertTrue(response.context['is_ride_leader'])
         self.assertTrue(response.context['can_access_rider_contacts'])
-        # Check that private data is visible to ride leaders
-        self.assertContains(response, 'Emergency Contact')  # The actual emergency contact name
-        self.assertContains(response, '123-456-7890')  # The actual emergency contact phone
-        self.assertContains(response, 'mailto:regular@example.com')  # Email links
+        self.assertTrue(response.context['can_reveal_contacts'])
+        self.assertFalse(response.context['contacts_revealed'])
+        self.assertNotContains(response, 'Emergency Contact')
+        self.assertNotContains(response, '123-456-7890')
+        self.assertNotContains(response, 'mailto:regular@example.com')
+        self.assertContains(response, '(hidden)')
+        self.assertContains(response, 'Reveal contact details')
 
     def test_staff_user_access(self):
         # Arrange
@@ -139,10 +142,13 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
         self.assertTemplateUsed(response, 'web/events/registrations.html')
         self.assertFalse(response.context['is_ride_leader'])
         self.assertTrue(response.context['can_access_rider_contacts'])
-        # Check that private data is visible to staff users
-        self.assertContains(response, 'Emergency Contact')  # The actual emergency contact name
-        self.assertContains(response, '123-456-7890')  # The actual emergency contact phone
-        self.assertContains(response, 'mailto:regular@example.com')  # Email links
+        self.assertTrue(response.context['can_reveal_contacts'])
+        self.assertFalse(response.context['contacts_revealed'])
+        self.assertNotContains(response, 'Emergency Contact')
+        self.assertNotContains(response, '123-456-7890')
+        self.assertNotContains(response, 'mailto:regular@example.com')
+        self.assertContains(response, '(hidden)')
+        self.assertContains(response, 'Reveal contact details')
 
     def test_regular_user_access(self):
         # Arrange
@@ -178,6 +184,72 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
         self.assertNotContains(response, '123-456-7890')  # The actual emergency contact phone
         self.assertNotContains(response, 'mailto:regular@example.com')  # Email links
 
+
+
+class EventEmergencyContactsViewTests(BaseEventViewTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('event_emergency_contacts', kwargs={'event_id': self.event.id})
+
+    def test_ride_leader_htmx_reveals_contacts(self):
+        # Arrange
+        self.client.login(username='leader_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url, HTTP_HX_REQUEST='true')
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'web/events/_registrations_list.html')
+        self.assertTrue(response.context['contacts_revealed'])
+        self.assertContains(response, 'Emergency Contact')
+        self.assertContains(response, '123-456-7890')
+        self.assertContains(response, 'mailto:regular@example.com')
+        self.assertNotContains(response, 'Reveal contact details')
+
+    def test_staff_htmx_reveals_contacts(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url, HTTP_HX_REQUEST='true')
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Emergency Contact')
+
+    def test_regular_user_denied(self):
+        # Arrange
+        self.client.login(username='regular_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url, HTTP_HX_REQUEST='true')
+
+        # Assert
+        self.assertEqual(response.status_code, 403)
+
+    def test_anonymous_user_redirected_to_login(self):
+        # Arrange
+        client = Client()
+
+        # Act
+        response = client.get(self.url, HTTP_HX_REQUEST='true')
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login', response.url)
+
+    def test_non_htmx_request_redirects(self):
+        # Arrange
+        self.client.login(username='leader_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('riders_list', kwargs={'event_id': self.event.id}))
 
 
 class EventRegistrationsFilterTests(BaseEventViewTestCase):
@@ -262,7 +334,7 @@ class EventRegistrationsFilterTests(BaseEventViewTestCase):
         filtered = list(response.context['filtered_riders'])
         self.assertEqual(len(filtered), 3)
 
-    def test_filter_preserves_contact_visibility_for_staff(self):
+    def test_filter_preserves_contact_hidden_for_staff(self):
         # Arrange
         self.client.login(username='staff_user', password='password123')
 
@@ -271,7 +343,9 @@ class EventRegistrationsFilterTests(BaseEventViewTestCase):
 
         # Assert
         self.assertTrue(response.context['can_access_rider_contacts'])
-        self.assertContains(response, 'mailto:leader@example.com')
+        self.assertFalse(response.context['contacts_revealed'])
+        self.assertNotContains(response, 'mailto:leader@example.com')
+        self.assertContains(response, '(hidden)')
 
     def test_filter_preserves_contact_hidden_for_anonymous(self):
         # Act
@@ -336,7 +410,7 @@ class EventRegistrationsColumnTests(BaseEventViewTestCase):
         # Assert
         self.assertNotContains(response, 'mailto:regular@example.com')
 
-    def test_staff_user_sees_email_column(self):
+    def test_staff_user_sees_hidden_email_column(self):
         # Arrange
         self.client.login(username='staff_user', password='password123')
 
@@ -344,7 +418,8 @@ class EventRegistrationsColumnTests(BaseEventViewTestCase):
         response = self.client.get(self.url)
 
         # Assert
-        self.assertContains(response, 'mailto:regular@example.com')
+        self.assertNotContains(response, 'mailto:regular@example.com')
+        self.assertContains(response, '(hidden)')
 
     def test_ride_leader_column_present_for_all_users(self):
         # Act

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from web.views.events import event_detail, event_list, event_registrations, \
-    calendar_view, events_redirect
+    event_emergency_contacts, calendar_view, events_redirect
 from web.views.events_ical import EventFeed
 from web.views.helpers import changes_email_addresses
 from web.views.login import LoginFormView, logout_view, CustomLoginView
@@ -32,6 +32,7 @@ urlpatterns = [
     path('events/<int:event_id>/registrations/add', staff_registration_add, name='staff_registration_add'),
     path('events/<int:event_id>/registrations/<int:registration_id>/edit', staff_registration_edit, name='staff_registration_edit'),
     path('events/<int:event_id>/registrations/<int:registration_id>/withdraw', staff_registration_withdraw, name='staff_registration_withdraw'),
+    path('events/<int:event_id>/registrations/emergency-contacts', event_emergency_contacts, name='event_emergency_contacts'),
     path('events/<int:event_id>/registrations', event_registrations, name='riders_list'),
     path('events/<int:event_id>/registration', registration_create, name='registration_create'),
     path('events/<int:event_id>', event_detail, name='event_detail'),

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -3,6 +3,8 @@ from datetime import datetime, date, timedelta
 from itertools import groupby
 from urllib.parse import urlencode
 
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse
@@ -202,36 +204,23 @@ def event_list(request: HttpRequest) -> HttpResponse:
     return render(request, 'web/events/list.html', context)
 
 
-def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
-    event = get_object_or_404(Event, id=event_id)
-
-    if not event.registrations_available:
-        context = {
-            'event': event,
-            'all_riders': Registration.objects.none(),
-            'is_ride_leader': False,
-            'can_access_rider_contacts': False,
-            'all_emails': '',
-            'ride_leader_emails': '',
-            'registrations_available': False,
-            'registration_count': event.registration_count,
-        }
-        return render(request, 'web/events/registrations.html', context=context)
-
+def _build_registrations_context(request, event, contacts_revealed):
     is_ride_leader = False
 
     if request.user.is_authenticated:
         is_ride_leader = Registration.objects.filter(
-            event_id=event_id,
+            event_id=event.id,
             user=request.user,
             state=Registration.STATE_CONFIRMED,
             ride_leader_preference=Registration.RideLeaderPreference.YES
         ).exists()
 
-    can_access_rider_contacts = is_ride_leader or (request.user.is_authenticated and request.user.is_staff)
+    is_staff = request.user.is_authenticated and request.user.is_staff
+    can_access_rider_contacts = is_ride_leader or is_staff
+    can_reveal_contacts = can_access_rider_contacts
 
     all_riders = Registration.objects.filter(
-        event_id=event_id,
+        event_id=event.id,
         state=Registration.STATE_CONFIRMED
     ).select_related(
         'ride',
@@ -244,41 +233,92 @@ def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
         'user__last_name'
     )
 
-    all_emails = ', '.join(sorted(set(
-        rider.email for rider in all_riders if rider.email
-    )))
-
-    ride_leader_emails = ', '.join(sorted(set(
-        rider.email for rider in all_riders
-        if rider.email and rider.ride_leader_preference == Registration.RideLeaderPreference.YES
-    )))
+    all_emails = ''
+    ride_leader_emails = ''
+    if can_access_rider_contacts:
+        all_emails = ', '.join(sorted(set(
+            rider.email for rider in all_riders if rider.email
+        )))
+        ride_leader_emails = ', '.join(sorted(set(
+            rider.email for rider in all_riders
+            if rider.email and rider.ride_leader_preference == Registration.RideLeaderPreference.YES
+        )))
 
     registration_filter = PublicRegistrationFilter(
         request.GET, queryset=all_riders, event=event
     )
 
+    contacts_hidden = can_reveal_contacts and not contacts_revealed
     exclude_columns = ()
     if not can_access_rider_contacts:
         exclude_columns = ('email', 'phone', 'emergency_contact_name', 'emergency_contact_phone')
 
-    table = PublicRegistrationTable(registration_filter.qs, exclude=exclude_columns)
+    table = PublicRegistrationTable(
+        registration_filter.qs, exclude=exclude_columns, contacts_hidden=contacts_hidden
+    )
     RequestConfig(request, paginate=False).configure(table)
 
-    context = {
+    return {
         'event': event,
         'all_riders': all_riders,
         'filtered_riders': registration_filter.qs,
         'table': table,
         'filter': registration_filter,
-        'filter_clear_url': reverse('riders_list', args=[event_id]),
+        'filter_clear_url': reverse('riders_list', args=[event.id]),
         'is_ride_leader': is_ride_leader,
         'can_access_rider_contacts': can_access_rider_contacts,
+        'can_reveal_contacts': can_reveal_contacts,
+        'contacts_revealed': contacts_revealed,
         'all_emails': all_emails,
         'ride_leader_emails': ride_leader_emails,
         'registrations_available': True,
     }
 
+
+def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
+    event = get_object_or_404(Event, id=event_id)
+
+    if not event.registrations_available:
+        context = {
+            'event': event,
+            'all_riders': Registration.objects.none(),
+            'is_ride_leader': False,
+            'can_access_rider_contacts': False,
+            'can_reveal_contacts': False,
+            'contacts_revealed': False,
+            'all_emails': '',
+            'ride_leader_emails': '',
+            'registrations_available': False,
+            'registration_count': event.registration_count,
+        }
+        return render(request, 'web/events/registrations.html', context=context)
+
+    context = _build_registrations_context(request, event, contacts_revealed=False)
     return render(request, 'web/events/registrations.html', context=context)
+
+
+@login_required
+def event_emergency_contacts(request: HttpRequest, event_id: int) -> HttpResponse:
+    event = get_object_or_404(Event, id=event_id)
+
+    if not event.registrations_available:
+        return redirect('riders_list', event_id=event_id)
+
+    is_ride_leader = Registration.objects.filter(
+        event_id=event_id,
+        user=request.user,
+        state=Registration.STATE_CONFIRMED,
+        ride_leader_preference=Registration.RideLeaderPreference.YES
+    ).exists()
+
+    if not is_ride_leader and not request.user.is_staff:
+        raise PermissionDenied
+
+    if not request.headers.get('HX-Request'):
+        return redirect('riders_list', event_id=event_id)
+
+    context = _build_registrations_context(request, event, contacts_revealed=True)
+    return render(request, 'web/events/_registrations_list.html', context=context)
 
 
 


### PR DESCRIPTION
## Summary
- Ride leaders and staff must now click a red "Reveal contact details" button to view emergency contacts, email, and phone on the registrations page
- Contact columns show italic "(hidden)" placeholder text before reveal
- Data is fetched from the server via HTMX (not pre-loaded in HTML), supporting a future audit trail
- Email copy buttons are always available for authorized users; only sensitive contact details require the explicit reveal
- Created follow-up issue #237 for related cleanup work

## Test plan
- [ ] As anonymous user: no contact columns, no reveal button
- [ ] As regular rider: no contact columns, no reveal button
- [ ] As ride leader: contact columns show "(hidden)", reveal button visible. Click reveal → contacts appear, button disables
- [ ] As staff: same behavior as ride leader (reveal required)
- [ ] Direct URL `/events/<id>/registrations/emergency-contacts` in browser → redirects to registrations page
- [ ] Unauthorized access to endpoint → 403
- [ ] Email copy buttons work before and after reveal
- [ ] Mobile card layout shows "(hidden)" and reveals correctly

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)