### PR TITLE
Allow staff users to see past event registrations

### DIFF
--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -186,6 +186,134 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
 
 
 
+class PastEventRegistrationsVisibilityTests(BaseEventViewTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('riders_list', kwargs={'event_id': self.event.id})
+
+    def _make_event_old(self):
+        self.event.starts_at = timezone.now() - timedelta(hours=80)
+        self.event.ends_at = timezone.now() - timedelta(hours=78)
+        self.event.registration_closes_at = timezone.now() - timedelta(hours=81)
+        self.event.save()
+
+    def test_staff_can_see_registrations_for_old_event(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['registrations_available'])
+        self.assertContains(response, 'Regular')
+        self.assertContains(response, 'Leader')
+
+    def test_regular_user_cannot_see_registrations_for_old_event(self):
+        # Arrange
+        self.client.login(username='regular_user', password='password123')
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['registrations_available'])
+        self.assertNotContains(response, 'Leader User')
+
+    def test_anonymous_user_cannot_see_registrations_for_old_event(self):
+        # Arrange
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['registrations_available'])
+        self.assertNotContains(response, 'Leader User')
+
+
+class PastEventDetailVisibilityTests(BaseEventViewTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('event_detail', kwargs={'event_id': self.event.id})
+        self.ride.speed_ranges.add(self.speed_range)
+
+    def _make_event_old(self):
+        self.event.starts_at = timezone.now() - timedelta(hours=80)
+        self.event.ends_at = timezone.now() - timedelta(hours=78)
+        self.event.registration_closes_at = timezone.now() - timedelta(hours=81)
+        self.event.save()
+
+    def test_staff_sees_rides_for_old_event(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['registrations_available'])
+        self.assertTrue(len(response.context['rides']) > 0)
+
+    def test_regular_user_does_not_see_rides_for_old_event(self):
+        # Arrange
+        self.client.login(username='regular_user', password='password123')
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['registrations_available'])
+        self.assertEqual(response.context['rides'], {})
+
+
+class PastEventEmergencyContactsVisibilityTests(BaseEventViewTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('event_emergency_contacts', kwargs={'event_id': self.event.id})
+
+    def _make_event_old(self):
+        self.event.starts_at = timezone.now() - timedelta(hours=80)
+        self.event.ends_at = timezone.now() - timedelta(hours=78)
+        self.event.registration_closes_at = timezone.now() - timedelta(hours=81)
+        self.event.save()
+
+    def test_staff_can_access_emergency_contacts_for_old_event(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url, HTTP_HX_REQUEST='true')
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['contacts_revealed'])
+
+    def test_ride_leader_cannot_access_emergency_contacts_for_old_event(self):
+        # Arrange
+        self.client.login(username='leader_user', password='password123')
+        self._make_event_old()
+
+        # Act
+        response = self.client.get(self.url, HTTP_HX_REQUEST='true')
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+
+
 class EventEmergencyContactsViewTests(BaseEventViewTestCase):
 
     def setUp(self):

--- a/web/tests/views/test_registration_manage_views.py
+++ b/web/tests/views/test_registration_manage_views.py
@@ -70,9 +70,10 @@ class ManagePageAvailabilityTests(BaseManageTestCase):
         self.event.registration_closes_at = timezone.now() - timezone.timedelta(hours=81)
         self.event.save()
 
-    def test_manage_page_shows_unavailable_for_old_event(self):
+    def test_staff_can_view_manage_page_for_old_event(self):
         # Arrange
         self.client.login(username='staff@example.com', password='password123')
+        self._create_confirmed_registration(self.regular_user, self.ride, self.speed_range)
         self._make_event_old()
 
         # Act
@@ -80,10 +81,10 @@ class ManagePageAvailabilityTests(BaseManageTestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.context['registrations_available'])
-        self.assertContains(response, 'Registration details are no longer available')
+        self.assertTrue(response.context['registrations_available'])
+        self.assertContains(response, 'Regular')
 
-    def test_staff_add_redirects_for_old_event(self):
+    def test_staff_can_access_add_form_for_old_event(self):
         # Arrange
         self.client.login(username='staff@example.com', password='password123')
         self._make_event_old()
@@ -92,9 +93,9 @@ class ManagePageAvailabilityTests(BaseManageTestCase):
         response = self.client.get(reverse('staff_registration_add', args=[self.event.id]))
 
         # Assert
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
 
-    def test_staff_edit_redirects_for_old_event(self):
+    def test_staff_can_access_edit_form_for_old_event(self):
         # Arrange
         self.client.login(username='staff@example.com', password='password123')
         reg = self._create_confirmed_registration(self.regular_user, self.ride, self.speed_range)
@@ -106,9 +107,9 @@ class ManagePageAvailabilityTests(BaseManageTestCase):
         )
 
         # Assert
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
 
-    def test_staff_withdraw_redirects_for_old_event(self):
+    def test_staff_can_withdraw_registration_for_old_event(self):
         # Arrange
         self.client.login(username='staff@example.com', password='password123')
         reg = self._create_confirmed_registration(self.regular_user, self.ride, self.speed_range)
@@ -122,7 +123,7 @@ class ManagePageAvailabilityTests(BaseManageTestCase):
         # Assert
         self.assertEqual(response.status_code, 302)
         updated_reg = Registration.objects.get(id=reg.id)
-        self.assertEqual(updated_reg.state, Registration.STATE_CONFIRMED)
+        self.assertEqual(updated_reg.state, Registration.STATE_WITHDRAWN)
 
 
 class ManagePageAccessTests(BaseManageTestCase):

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -20,6 +20,12 @@ from web.filters import PublicRegistrationFilter
 from web.tables import PublicRegistrationTable
 
 
+def _registrations_visible(event, user):
+    if event.registrations_available:
+        return True
+    return user.is_authenticated and user.is_staff
+
+
 def _create_ride_structure(ride):
     return {
         'ride': ride,
@@ -137,7 +143,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
         Event,
         id=event_id)
 
-    if event.registrations_available:
+    if _registrations_visible(event, request.user):
         rides = _get_rides_with_riders_for_event(event_id)
     else:
         rides = {}
@@ -154,7 +160,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
         'event': event,
         'rides': rides,
         'user_is_registered': user_is_registered,
-        'registrations_available': event.registrations_available,
+        'registrations_available': _registrations_visible(event, request.user),
     }
 
     return render(request, 'web/events/detail.html', context)
@@ -278,7 +284,7 @@ def _build_registrations_context(request, event, contacts_revealed):
 def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
-    if not event.registrations_available:
+    if not _registrations_visible(event, request.user):
         context = {
             'event': event,
             'all_riders': Registration.objects.none(),
@@ -301,7 +307,7 @@ def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
 def event_emergency_contacts(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
-    if not event.registrations_available:
+    if not _registrations_visible(event, request.user):
         return redirect('riders_list', event_id=event_id)
 
     is_ride_leader = Registration.objects.filter(

--- a/web/views/registration_manage.py
+++ b/web/views/registration_manage.py
@@ -27,18 +27,6 @@ def event_registrations_manage(request: HttpRequest, event_id: int) -> HttpRespo
     if event.external_registration_url:
         return redirect('event_detail', event_id=event.id)
 
-    if not event.registrations_available:
-        registration_count = Registration.objects.filter(
-            event_id=event_id,
-            state__in=[Registration.STATE_CONFIRMED, Registration.STATE_UNVERIFIED],
-        ).count()
-        context = {
-            'event': event,
-            'registrations_available': False,
-            'registration_count': registration_count,
-        }
-        return render(request, 'web/events/registrations_manage.html', context)
-
     registrations = Registration.objects.filter(
         event_id=event_id,
         state__in=[Registration.STATE_CONFIRMED, Registration.STATE_UNVERIFIED],
@@ -75,9 +63,6 @@ def staff_registration_add(request: HttpRequest, event_id: int) -> HttpResponse:
 
     if event.external_registration_url:
         return redirect('event_detail', event_id=event.id)
-
-    if not event.registrations_available:
-        return redirect('event_registrations_manage', event_id=event.id)
 
     if request.method == 'POST':
         form = StaffRegistrationForm(request.POST, event=event)
@@ -127,9 +112,6 @@ def staff_registration_edit(request: HttpRequest, event_id: int, registration_id
 
     if event.external_registration_url:
         return redirect('event_detail', event_id=event.id)
-
-    if not event.registrations_available:
-        return redirect('event_registrations_manage', event_id=event.id)
 
     registration = get_object_or_404(Registration, id=registration_id, event=event)
 
@@ -195,8 +177,6 @@ def staff_registration_withdraw(request: HttpRequest, event_id: int, registratio
     if request.method != 'POST':
         return redirect('event_registrations_manage', event_id=event_id)
 
-    if not event.registrations_available:
-        return redirect('event_registrations_manage', event_id=event.id)
     registration = get_object_or_404(Registration, id=registration_id, event=event)
 
     service = RegistrationService()


### PR DESCRIPTION
## Summary
- Staff users can now view, add, edit, and withdraw registrations for past events (after the 72-hour visibility window)
- Regular and anonymous users still see registrations hidden as before
- Closes #239

## Test plan
- [ ] As a staff user, view a past event's registration list — registrations should be visible
- [ ] As a staff user, view a past event's detail page — rides and rider counts should be visible
- [ ] As a staff user, access emergency contacts for a past event — should work
- [ ] As a staff user, add/edit/withdraw registrations on a past event's manage page — should work
- [ ] As a regular user, view a past event's registration list — registrations should still be hidden
- [ ] As an anonymous user, view a past event's registration list — registrations should still be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)