### PR TITLE
Fix Route.url migration order for Postgres NOT NULL

### DIFF
--- a/backoffice/migrations/0073_unique_route_url.py
+++ b/backoffice/migrations/0073_unique_route_url.py
@@ -37,6 +37,16 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterField(
+            model_name='route',
+            name='url',
+            field=models.URLField(
+                blank=True,
+                null=True,
+                help_text='Ride with GPS URL. If this is set, then whenever an import from Ride with GPS happens other fields will be overwritten for this route.',
+                verbose_name='Ride With GPS URL',
+            ),
+        ),
         migrations.RunPython(empty_url_to_null, null_url_to_empty),
         migrations.RunPython(check_duplicate_urls, migrations.RunPython.noop),
         migrations.AlterField(


### PR DESCRIPTION
## Summary
- Migration `0073_unique_route_url` (merged via #241) ran the `''` → `NULL` data migration **before** the `AlterField` that dropped the `NOT NULL` constraint on `Route.url`. Postgres correctly rejected the `UPDATE` with `NotNullViolation` for any pre-existing `Route` row whose `url=''`.
- SQLite test databases passed only because they had no pre-existing rows for the data migration to touch.
- Heroku release failure:

  ```
  psycopg.errors.NotNullViolation: null value in column "url" of relation "backoffice_route" violates not-null constraint
  DETAIL:  Failing row contains (600, David's testing route, null, ...).
  ```

- Fix: split the AlterField into two steps — first drop `NOT NULL`, then run the data conversion and duplicate check, then add `unique=True`.

## Why amend `0073` instead of writing `0074`?
- Production never successfully applied the old `0073` (the release failed), so there's no row in `django_migrations` to invalidate. Retrying the amended `0073` on the next deploy succeeds.
- Local SQLite DBs that applied the old `0073` end up with the exact same final schema as the amended version; Django will not re-run a migration that's already marked applied, so there is no divergence.
- A `0074` would not unblock production: it can only run *after* `0073` runs, and `0073` can't run until it's fixed.

## Test plan
- [x] `uv run python manage.py test` — all 496 tests pass
- [x] `uv run python manage.py migrate` against a fresh local SQLite DB
- [ ] Re-run the Heroku release and confirm `0073` applies cleanly
- [ ] Verify on staging that any `Route` rows with `url=''` are now stored as `NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)