### PR TITLE
Merge duplicate Route URLs in 0073 migration

### DIFF
--- a/backoffice/migrations/0073_unique_route_url.py
+++ b/backoffice/migrations/0073_unique_route_url.py
@@ -4,30 +4,49 @@ from django.db.models import Count
 
 def empty_url_to_null(apps, schema_editor):
     Route = apps.get_model('backoffice', 'Route')
-    Route.objects.filter(url='').update(url=None)
+    affected = Route.objects.filter(url='').update(url=None)
+    print(f'[0073] empty_url_to_null: normalized {affected} blank URL(s) to NULL')
 
 
 def null_url_to_empty(apps, schema_editor):
     Route = apps.get_model('backoffice', 'Route')
-    Route.objects.filter(url__isnull=True).update(url='')
+    affected = Route.objects.filter(url__isnull=True).update(url='')
+    print(f'[0073] null_url_to_empty: restored {affected} NULL URL(s) to blank')
 
 
-def check_duplicate_urls(apps, schema_editor):
+def merge_duplicate_urls(apps, schema_editor):
     Route = apps.get_model('backoffice', 'Route')
-    duplicates = (
+    Ride = apps.get_model('backoffice', 'Ride')
+    dupe_urls = list(
         Route.objects.exclude(url__isnull=True)
         .values('url')
         .annotate(c=Count('id'))
         .filter(c__gt=1)
+        .values_list('url', flat=True)
     )
-    duplicates = list(duplicates)
-    if duplicates:
-        details = ', '.join(f"{d['url']} ({d['c']})" for d in duplicates)
-        raise RuntimeError(
-            f"Cannot apply unique constraint on Route.url; duplicates found: {details}. "
-            "Merge or remove duplicates in the admin (or via a one-off SQL UPDATE) "
-            "before re-running migrate."
+    if not dupe_urls:
+        print('[0073] merge_duplicate_urls: no duplicates found')
+        return
+    print(f'[0073] merge_duplicate_urls: {len(dupe_urls)} duplicate URL group(s) to merge')
+    total_repointed = 0
+    total_deleted = 0
+    for url in dupe_urls:
+        routes = list(Route.objects.filter(url=url).order_by('id'))
+        canonical = routes[0]
+        dupe_ids = [r.id for r in routes[1:]]
+        repointed = Ride.objects.filter(route_id__in=dupe_ids).update(route_id=canonical.id)
+        deleted, _ = Route.objects.filter(id__in=dupe_ids).delete()
+        total_repointed += repointed
+        total_deleted += deleted
+        print(
+            f'[0073]   {url}: keeping Route id={canonical.id}, '
+            f'merging {len(dupe_ids)} dupe(s) {dupe_ids}, '
+            f'repointed {repointed} Ride(s), deleted {deleted} Route row(s)'
         )
+    print(
+        f'[0073] merge_duplicate_urls: total {total_repointed} Ride(s) repointed, '
+        f'{total_deleted} Route row(s) deleted'
+    )
 
 
 class Migration(migrations.Migration):
@@ -48,7 +67,7 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.RunPython(empty_url_to_null, null_url_to_empty),
-        migrations.RunPython(check_duplicate_urls, migrations.RunPython.noop),
+        migrations.RunPython(merge_duplicate_urls, migrations.RunPython.noop),
         migrations.AlterField(
             model_name='route',
             name='url',


### PR DESCRIPTION
## Summary
Production has 10 duplicate \`Route.url\` groups predating the unique constraint:

\`\`\`
RuntimeError: Cannot apply unique constraint on Route.url; duplicates found:
  https://ridewithgps.com/routes/47409619 (2),
  https://ridewithgps.com/routes/37244814 (2),
  https://ridewithgps.com/routes/47635489 (2),
  https://ridewithgps.com/routes/47291852 (3),
  https://ridewithgps.com/routes/51469973 (2),
  https://ridewithgps.com/routes/34836477 (2),
  https://ridewithgps.com/trips/173670824 (3),
  https://ridewithgps.com/routes/51437651 (2),
  https://ridewithgps.com/routes/38927297 (2),
  https://ridewithgps.com/routes/46706731 (2).
\`\`\`

The previous data migration aborted with \`RuntimeError\`, leaving the release stuck.

## Strategy
Replace \`check_duplicate_urls\` with \`merge_duplicate_urls\`:

- Group \`Route\` rows by \`url\`.
- Pick the **lowest \`id\`** as canonical (oldest, stable across reruns).
- Repoint every \`Ride.route_id\` from the dupes to the canonical row.
- Delete the now-unreferenced duplicate \`Route\` rows.

\`Ride.route\` is the only FK pointing at \`Route\` (\`on_delete=PROTECT\`, see \`backoffice/models.py:405\`), and there are no M2M relations, so repointing every \`Ride\` reference before deletion preserves all ride relations end-to-end.

## Debug output
Every RunPython step now prints to stdout so the Heroku release log shows exactly what changed:

\`\`\`
[0073] empty_url_to_null: normalized N blank URL(s) to NULL
[0073] merge_duplicate_urls: 10 duplicate URL group(s) to merge
[0073]   https://ridewithgps.com/...: keeping Route id=X, merging 1 dupe(s) [Y], repointed K Ride(s), deleted 1 Route row(s)
...
[0073] merge_duplicate_urls: total K Ride(s) repointed, M Route row(s) deleted
\`\`\`

## Why amend 0073 again instead of writing 0074
- 0073 still has not applied successfully on production (the dupe check raised), so there is no \`django_migrations\` row to invalidate. Retrying the amended version is the natural path forward.
- Local SQLite DBs have no duplicates, so the new merge function is a no-op for them — there is no schema or data divergence between environments.
- A 0074 cannot run until 0073 finishes, so it would not unblock production.

## Test plan
- [x] \`uv run python manage.py test\` — 496 tests pass
- [x] Confirmed \`Ride.route\` is the only FK to \`Route\` (no other relations to repoint)
- [ ] Re-run the Heroku release and inspect the \`[0073]\` debug lines
- [ ] On staging, verify dupe URLs collapsed to a single canonical row each and all referencing Rides still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)