### PR TITLE
Flush deferred FK triggers before adding unique constraint

### DIFF
--- a/backoffice/migrations/0073_unique_route_url.py
+++ b/backoffice/migrations/0073_unique_route_url.py
@@ -49,6 +49,12 @@ def merge_duplicate_urls(apps, schema_editor):
     )
 
 
+def flush_deferred_constraints(apps, schema_editor):
+    if schema_editor.connection.vendor == 'postgresql':
+        schema_editor.execute('SET CONSTRAINTS ALL IMMEDIATE')
+        print('[0073] flush_deferred_constraints: fired pending FK triggers')
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -68,6 +74,7 @@ class Migration(migrations.Migration):
         ),
         migrations.RunPython(empty_url_to_null, null_url_to_empty),
         migrations.RunPython(merge_duplicate_urls, migrations.RunPython.noop),
+        migrations.RunPython(flush_deferred_constraints, migrations.RunPython.noop),
         migrations.AlterField(
             model_name='route',
             name='url',


### PR DESCRIPTION
## Summary
The Heroku release ran the data merge in \`0073\` successfully but failed on the final \`AlterField\`:

\`\`\`
psycopg.errors.ObjectInUse: cannot ALTER TABLE "backoffice_route" because it has pending trigger events
\`\`\`

## Cause
\`merge_duplicate_urls\` issues \`UPDATE\` on \`Ride\` (repoint FKs) and \`DELETE\` on \`Route\` (drop dupes). Both queue deferred foreign-key trigger events inside the migration's transaction. Postgres refuses any \`ALTER TABLE\` on a table while it still has pending trigger events.

## Fix
Insert a Postgres-only \`RunPython\` step between the data merge and the final \`AlterField\` that runs:

\`\`\`sql
SET CONSTRAINTS ALL IMMEDIATE;
\`\`\`

This fires the queued triggers right then, so by the time \`AlterField\` adds the \`UNIQUE\` constraint there are no pending events. SQLite skips the SET CONSTRAINTS call (it does not support deferrable constraints), so local DBs are unaffected.

## Why amend 0073 again
- Production rolled back when the final \`AlterField\` failed, so 0073 still has not been recorded as applied. Retrying the amended version is the natural path forward.
- Local SQLite DBs that have already applied 0073 won't re-run it; the new \`flush_deferred_constraints\` step is a no-op there anyway.

## Test plan
- [x] \`uv run python manage.py test\` — 496 tests pass
- [ ] Re-run Heroku release; expect the same merge debug log followed by clean \`AlterField\` and the new \`flush_deferred_constraints\` log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)