### PR TITLE
Use single table layout on mobile and desktop registrations list

### DIFF
--- a/web/templates/web/events/_registrations_list.html
+++ b/web/templates/web/events/_registrations_list.html
@@ -1,4 +1,3 @@
-{% load phone_filters %}
 {% load django_tables2 %}
 
 {% if all_riders %}
@@ -6,87 +5,7 @@
 
 {% include 'web/events/_registration_filter.html' %}
 
-    <!-- Mobile view (card-based layout) -->
-    <div class="d-md-none">
-        {% for rider_reg in filtered_riders %}
-            <div class="card mb-3 p-4" data-registration-id="{{ rider_reg.id }}">
-                <div class="d-flex flex-column align-items-start mb-2">
-                    <div class="d-flex align-items-center">
-                        <h4 class="fw-medium fs-5 mb-0">{{ rider_reg.first_name }} {{ rider_reg.last_name }}</h4>
-                    </div>
-                </div>
-                <div class="small">
-                    <div class="row mb-1">
-                        <div class="col-5 fw-medium">Ride:</div>
-                        <div class="col-7 text-muted">{{ rider_reg.ride.name|default:"N/A" }}</div>
-                    </div>
-                    <div class="row mb-1">
-                        <div class="col-5 fw-medium">Speed group:</div>
-                        <div class="col-7 text-muted">{{ rider_reg.speed_range_preference.range|default:"N/A" }}</div>
-                    </div>
-                    <div class="row mb-1">
-                        <div class="col-5 fw-medium">Ride leader:</div>
-                        <div class="col-7 text-muted">{{ rider_reg.get_ride_leader_preference_display }}</div>
-                    </div>
-
-                    {% if can_access_rider_contacts %}
-                    <div class="mt-3 border-top border-danger-subtle pt-2 w-100">
-                        {% if contacts_revealed %}
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Email:</div>
-                            <div class="col-7 text-muted">
-                                <a href="mailto:{{ rider_reg.email }}" class="text-primary">
-                                    {{ rider_reg.email }}
-                                </a>
-                            </div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Phone:</div>
-                            <div class="col-7 text-muted">
-                                <a href="tel:{{ rider_reg.phone }}" class="text-primary">
-                                    {{ rider_reg.phone|national_phone }}
-                                </a>
-                            </div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Emergency:</div>
-                            <div class="col-7 text-muted">{{ rider_reg.emergency_contact_name }}</div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Emergency phone:</div>
-                            <div class="col-7 text-muted">
-                                <a href="tel:{{ rider_reg.emergency_contact_phone }}" class="text-primary">
-                                    {{ rider_reg.emergency_contact_phone }}
-                                </a>
-                            </div>
-                        </div>
-                        {% else %}
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Email:</div>
-                            <div class="col-7 text-muted fst-italic">(hidden)</div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Phone:</div>
-                            <div class="col-7 text-muted fst-italic">(hidden)</div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Emergency:</div>
-                            <div class="col-7 text-muted fst-italic">(hidden)</div>
-                        </div>
-                        <div class="row mb-1">
-                            <div class="col-5 fw-medium">Emergency phone:</div>
-                            <div class="col-7 text-muted fst-italic">(hidden)</div>
-                        </div>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-                </div>
-            </div>
-        {% endfor %}
-    </div>
-
-    <!-- Desktop view (table-based layout) -->
-    <div class="d-none d-md-block card shadow-sm">
+    <div class="card shadow-sm registrations-table-card">
         <div class="p-4">
             <div class="overflow-auto">
                 {% render_table table %}

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -15,7 +15,7 @@
     }
 
     /* Remove the card styling from table container only */
-    .d-none.d-md-block.card.shadow-sm {
+    .registrations-table-card {
         border: none !important;
         box-shadow: none !important;
         padding: 0 !important;
@@ -23,7 +23,7 @@
     }
 
     /* Remove padding from table container */
-    .d-none.d-md-block.card > .p-4 {
+    .registrations-table-card > .p-4 {
         padding: 0 !important;
         margin: 0 !important;
     }
@@ -110,15 +110,6 @@
 
     .text-primary {
         color: black !important;
-    }
-
-    /* Hide non-essential elements */
-    .d-md-none {
-        display: none !important;
-    }
-
-    .d-none.d-md-block {
-        display: block !important;
     }
 
     /* Table specific adjustments */

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -556,15 +556,6 @@ class EventRegistrationsColumnTests(BaseEventViewTestCase):
         # Assert
         self.assertContains(response, 'Ride leader')
 
-    def test_mobile_view_shows_ride_leader_as_row(self):
-        # Act
-        response = self.client.get(self.url)
-
-        # Assert
-        content = response.content.decode()
-        self.assertIn('Ride leader:', content)
-        self.assertNotIn('badge bg-primary ms-2', content)
-
 
 class EventDetailViewTests(BaseEventViewTestCase):
     """Tests for the event_detail view."""


### PR DESCRIPTION
Replace the mobile card layout with the same django-tables2 table
used on desktop, wrapped in overflow-auto for horizontal scrolling.
Reveals continue to work because the existing table already toggles
contact columns via the contacts_hidden flag on the HTMX swap.

https://claude.ai/code/session_01WexsfrXKQbUek9MFt3sGeL