### PR TITLE
Fix blank first-time attendee column for NO and N/A rows

### DIFF
--- a/web/tables.py
+++ b/web/tables.py
@@ -66,8 +66,9 @@ class RegistrationTable(tables.Table):
 
     def render_first_time_attendee(self, value, record):
         if value == Registration.FirstTimeAttendee.YES:
-            return format_html('<span class="badge bg-info">First time</span>')
-        return format_html('')
+            return format_html('<span class="badge bg-primary">Yes</span>')
+        display = record.get_first_time_attendee_display()
+        return format_html('<span class="small text-muted">{}</span>', display)
 
     def render_emergency_contact_name(self, value):
         return format_html('<span class="small text-muted">{}</span>', value)
@@ -119,15 +120,12 @@ class PublicRegistrationTable(tables.Table):
         return format_html('<span class="small text-muted">{}</span>', value or 'N/A')
 
     def render_ride_leader_preference(self, value, record):
-        if value == Registration.RideLeaderPreference.YES:
-            return format_html('<span class="badge bg-primary">Yes</span>')
         display = record.get_ride_leader_preference_display()
         return format_html('<span class="small text-muted">{}</span>', display)
 
     def render_first_time_attendee(self, value, record):
-        if value == Registration.FirstTimeAttendee.YES:
-            return format_html('<span class="badge bg-info">First time</span>')
-        return format_html('')
+        display = record.get_first_time_attendee_display()
+        return format_html('<span class="small text-muted">{}</span>', display)
 
     def render_email(self, value):
         if self.contacts_hidden:


### PR DESCRIPTION
## Summary
- `render_first_time_attendee` returned an empty string for NO/N/A, leaving cells blank on both manage and public registration tables.
- Mirror `render_ride_leader_preference`: `bg-primary` "Yes" badge for YES, muted display text for NO/N/A.
- Drop badges from `PublicRegistrationTable` for both `ride_leader_preference` and `first_time_attendee` to match the no-badges-on-public-UI guidance.

## Test plan
- [ ] Visit `/events/<id>/registrations/manage` for an event with `ask_first_time_attendee=True`; confirm Yes shows a blue badge, No/N/A render as muted text.
- [ ] Visit `/events/<id>/registrations` (public); confirm first-time and ride-leader columns render plain muted text with no badges.
- [ ] Confirm the column stays hidden when `ask_first_time_attendee=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)