### PR TITLE
Show first-time and ride-leader badges on registrations

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from django.contrib.auth.models import User
 from django.core.signing import TimestampSigner, BadSignature, SignatureExpired
-from django.db.models import QuerySet, Subquery, OuterRef
+from django.db.models import QuerySet, Subquery, OuterRef, Count
 from django.utils import timezone
 
 from backoffice.models import Event, Registration, SpeedRange, Ride
@@ -196,6 +196,17 @@ class RegistrationService:
         registration.save()
         self._send_verification_email(registration)
         return RegistrationResult.VERIFICATION_REQUIRED
+
+    def fetch_ride_counts(self, user_ids: list[int]) -> dict[int, int]:
+        rows = (
+            Registration.objects.filter(
+                user_id__in=user_ids,
+                state=Registration.STATE_CONFIRMED,
+            )
+            .values('user_id')
+            .annotate(count=Count('event', distinct=True))
+        )
+        return {row['user_id']: row['count'] for row in rows}
 
     def fetch_confirmed_event_ids(self, user: User, event_ids: list[int]) -> set[int]:
         return set(

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -538,6 +538,94 @@ class FetchCurrentRegistrationsTestCase(TestCase):
         self.assertIn(registrations_for_event[0].state, [Registration.STATE_SUBMITTED, Registration.STATE_CONFIRMED])
 
 
+class FetchRideCountsTestCase(TestCase):
+    def setUp(self):
+        self.service = RegistrationService()
+        self.user = User.objects.create_user(
+            username='counted', email='counted@example.com', password='password'
+        )
+        self.other_user = User.objects.create_user(
+            username='other', email='other@example.com', password='password'
+        )
+        self.program = Program.objects.create(name="Test Program")
+        self.now = timezone.now()
+
+    def _create_event(self, name, offset_days):
+        return Event.objects.create(
+            name=name,
+            program=self.program,
+            starts_at=self.now + datetime.timedelta(days=offset_days),
+            registration_closes_at=self.now + datetime.timedelta(days=offset_days - 1),
+        )
+
+    def _create_confirmed(self, user, event):
+        reg = Registration.objects.create(
+            user=user, event=event, name=user.username, email=user.email,
+            state=Registration.STATE_SUBMITTED,
+        )
+        reg.confirm()
+        reg.save()
+        return reg
+
+    def test_counts_confirmed_registrations_across_events(self):
+        # Arrange
+        for i in range(3):
+            self._create_confirmed(self.user, self._create_event(f"Event {i}", i + 1))
+
+        # Act
+        result = self.service.fetch_ride_counts([self.user.id])
+
+        # Assert
+        self.assertEqual(result, {self.user.id: 3})
+
+    def test_excludes_non_confirmed_registrations(self):
+        # Arrange
+        confirmed_event = self._create_event("Confirmed", 1)
+        self._create_confirmed(self.user, confirmed_event)
+
+        submitted_event = self._create_event("Submitted", 2)
+        Registration.objects.create(
+            user=self.user, event=submitted_event, name=self.user.username,
+            email=self.user.email, state=Registration.STATE_SUBMITTED,
+        )
+
+        withdrawn_event = self._create_event("Withdrawn", 3)
+        reg_w = Registration.objects.create(
+            user=self.user, event=withdrawn_event, name=self.user.username,
+            email=self.user.email, state=Registration.STATE_SUBMITTED,
+        )
+        reg_w.confirm()
+        reg_w.withdraw()
+        reg_w.save()
+
+        # Act
+        result = self.service.fetch_ride_counts([self.user.id])
+
+        # Assert
+        self.assertEqual(result, {self.user.id: 1})
+
+    def test_counts_are_per_user(self):
+        # Arrange
+        event_one = self._create_event("Event One", 1)
+        event_two = self._create_event("Event Two", 2)
+        self._create_confirmed(self.user, event_one)
+        self._create_confirmed(self.user, event_two)
+        self._create_confirmed(self.other_user, event_one)
+
+        # Act
+        result = self.service.fetch_ride_counts([self.user.id, self.other_user.id])
+
+        # Assert
+        self.assertEqual(result, {self.user.id: 2, self.other_user.id: 1})
+
+    def test_user_with_no_confirmed_registrations_absent(self):
+        # Act
+        result = self.service.fetch_ride_counts([self.user.id])
+
+        # Assert
+        self.assertEqual(result, {})
+
+
 class FetchConfirmedEventIdsTestCase(TestCase):
     def setUp(self):
         self.service = RegistrationService()

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -406,3 +406,23 @@ body {
   content: " \2195";
   opacity: 0.25;
 }
+
+.badge-ride-count-1 {
+  background-color: #2563eb;
+  color: #fff;
+}
+
+.badge-ride-count-2 {
+  background-color: #6b93ec;
+  color: #fff;
+}
+
+.badge-ride-count-3 {
+  background-color: #aac3f4;
+  color: #fff;
+}
+
+.badge-ride-leader {
+  background-color: #0d9488;
+  color: #fff;
+}

--- a/web/tables.py
+++ b/web/tables.py
@@ -79,10 +79,11 @@ class RegistrationTable(tables.Table):
 
 
 class PublicRegistrationTable(tables.Table):
+    RIDE_COUNT_LABELS = {1: '1st', 2: '2nd', 3: '3rd'}
+
     name = tables.Column(order_by=('last_name', 'first_name'))
     ride = tables.Column()
     speed_range_preference = tables.Column(verbose_name="Speed group")
-    ride_leader_preference = tables.Column(verbose_name="Ride leader")
     first_time_attendee = tables.Column(verbose_name="First time")
     email = tables.Column()
     phone = tables.Column()
@@ -92,7 +93,7 @@ class PublicRegistrationTable(tables.Table):
     class Meta:
         model = Registration
         fields = (
-            'name', 'ride', 'speed_range_preference', 'ride_leader_preference',
+            'name', 'ride', 'speed_range_preference',
             'first_time_attendee', 'email', 'phone', 'emergency_contact_name', 'emergency_contact_phone',
         )
         attrs = {
@@ -103,25 +104,36 @@ class PublicRegistrationTable(tables.Table):
             'data-registration-id': lambda record: record.id,
         }
 
-    def __init__(self, *args, contacts_hidden=False, **kwargs):
+    def __init__(self, *args, contacts_hidden=False, ride_counts=None, **kwargs):
         self.contacts_hidden = contacts_hidden
+        self.ride_counts = ride_counts or {}
         super().__init__(*args, **kwargs)
 
     def _hidden_placeholder(self):
         return format_html('<span class="small text-muted fst-italic">(hidden)</span>')
 
-    def render_name(self, value):
-        return format_html('<span class="small fw-medium">{}</span>', value)
+    def render_name(self, value, record):
+        html = format_html('<span class="small fw-medium">{}</span>', value)
+
+        if record.ride_leader_preference == Registration.RideLeaderPreference.YES:
+            html = format_html(
+                '{} <span class="badge badge-ride-leader">Leader</span>', html
+            )
+
+        count = self.ride_counts.get(record.user_id)
+        if count in self.RIDE_COUNT_LABELS:
+            html = format_html(
+                '{} <span class="badge badge-ride-count-{}">{} ride</span>',
+                html, count, self.RIDE_COUNT_LABELS[count]
+            )
+
+        return html
 
     def render_ride(self, value):
         return format_html('<span class="small text-muted">{}</span>', value or 'N/A')
 
     def render_speed_range_preference(self, value):
         return format_html('<span class="small text-muted">{}</span>', value or 'N/A')
-
-    def render_ride_leader_preference(self, value, record):
-        display = record.get_ride_leader_preference_display()
-        return format_html('<span class="small text-muted">{}</span>', display)
 
     def render_first_time_attendee(self, value, record):
         display = record.get_first_time_attendee_display()

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -184,6 +184,83 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
         self.assertNotContains(response, '123-456-7890')  # The actual emergency contact phone
         self.assertNotContains(response, 'mailto:regular@example.com')  # Email links
 
+    def _add_confirmed_registration(self, user, days_offset):
+        event = Event.objects.create(
+            program=self.program,
+            name=f'Extra Event {days_offset}',
+            starts_at=self.event_starts_at + timedelta(days=days_offset),
+            registration_closes_at=self.registration_closes_at_time + timedelta(days=days_offset),
+        )
+        return Registration.objects.create(
+            first_name=user.first_name, last_name='User', name=user.get_full_name(),
+            email=user.email, event=event, user=user,
+            ride_leader_preference=Registration.RideLeaderPreference.NO,
+            state=Registration.STATE_CONFIRMED,
+        )
+
+    def test_staff_sees_ride_leader_badge(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertContains(response, 'badge-ride-leader')
+
+    def test_staff_sees_first_ride_badge(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertContains(response, 'badge-ride-count-1')
+        self.assertContains(response, '1st ride')
+
+    def test_ride_leader_sees_ride_count_badge(self):
+        # Arrange
+        self.client.login(username='leader_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertContains(response, 'badge-ride-count-1')
+
+    def test_count_badge_reflects_prior_confirmed_registrations(self):
+        # Arrange
+        self._add_confirmed_registration(self.user, days_offset=30)
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertContains(response, 'badge-ride-count-2')
+        self.assertContains(response, '2nd ride')
+
+    def test_regular_user_does_not_see_ride_count_badge(self):
+        # Arrange
+        self.client.login(username='regular_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertNotContains(response, 'badge-ride-count-1')
+        self.assertNotContains(response, '1st ride')
+
+    def test_ride_leader_column_removed(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertNotContains(response, 'sort=ride_leader_preference')
 
 
 class PastEventRegistrationsVisibilityTests(BaseEventViewTestCase):

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -261,8 +261,14 @@ def _build_registrations_context(request, event, contacts_revealed):
     elif not event.ask_first_time_attendee:
         exclude_columns = ('first_time_attendee',)
 
+    ride_counts = {}
+    if can_access_rider_contacts:
+        user_ids = [r.user_id for r in registration_filter.qs if r.user_id]
+        ride_counts = RegistrationService().fetch_ride_counts(user_ids)
+
     table = PublicRegistrationTable(
-        registration_filter.qs, exclude=exclude_columns, contacts_hidden=contacts_hidden
+        registration_filter.qs, exclude=exclude_columns,
+        contacts_hidden=contacts_hidden, ride_counts=ride_counts,
     )
     RequestConfig(request, paginate=False).configure(table)
 


### PR DESCRIPTION
Closes #253

## What
- Add ride-count badges (`1st`/`2nd`/`3rd ride`) after rider names on the registrations page. Visible only to ride leaders and staff.
- Replace the **Ride leader** column with a `Leader` badge shown after the name (visible to everyone, same as the old column).

## Details
- Ride count = distinct events the user has a **confirmed** registration for, including the current one. 1st = no prior. 4th+ shows no badge.
- New `RegistrationService.fetch_ride_counts(user_ids)` does this in one grouped query (no N+1).
- Badge saturation drops 1st -> 2nd -> 3rd; `Leader` badge uses a distinct color. Custom classes in `styling.css`.
- Existing self-reported **First time** column left untouched.

## Tests
- Service: confirmed-only, cross-event, per-user counting.
- View: Leader badge, ride-count badge tiers, staff/leader gating, column removal.
- Full suite green (139 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)