### PR TITLE
Restructure ride cards with accordion speed range sections

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -426,7 +426,9 @@ body {
   background-color: #0d9488;
   color: #fff;
 }
+
 .speed-range-chevron {
+  display: inline-block;
   transition: transform 0.2s ease-in-out;
 }
 

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -426,3 +426,10 @@ body {
   background-color: #0d9488;
   color: #fff;
 }
+.speed-range-chevron {
+  transition: transform 0.2s ease-in-out;
+}
+
+.speed-range-chevron-open {
+  transform: rotate(180deg);
+}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -162,74 +162,79 @@
                         {% endif %}
                     </h3>
 
+                    {% if ride.description %}
                     <div class="prose mb-3">
                         <p>{{ ride.description|safe }}</p>
                     </div>
+                    {% endif %}
 
-                    <div class="d-flex align-items-center mb-2">
+                    <div class="d-flex align-items-start">
                         <i class="bi bi-map text-muted me-2"></i>
-                        <a href="{{ride.route.url}}" class="text-primary text-decoration-underline d-flex align-items-center" target="_blank" rel="noopener noreferrer">
-                            {{ride.route.name}}
-                            <i class="bi bi-box-arrow-up-right ms-1 small"></i>
+                        <a href="{{ride.route.url}}" class="text-primary text-decoration-underline" target="_blank" rel="noopener noreferrer">
+                            {{ride.route.name}}<i class="bi bi-box-arrow-up-right ms-1 small"></i>
                         </a>
                     </div>
 
                     {% if not registrations_available %}
-                    <div class="mt-4">
-                        <p class="text-muted small">Registration details are no longer available for this event.</p>
-                    </div>
+                    <p class="text-muted small mt-4 mb-0">Registration details are no longer available for this event.</p>
                     {% else %}
                     {% with ride_id=ride.id|stringformat:"s" %}
                     {% if rides and ride_id in rides %}
-                    <div class="mt-4">
                         {% with ride_info=rides|get_item:ride_id %}
-                            {% if ride_info.speed_ranges %}
-                                <div class="d-flex flex-column">
-                                    {% for speed_range_id, speed_range_info in ride_info.speed_ranges.items %}
-                                        <div x-data="{ open: false }">
-                                            <div class="d-flex align-items-center mb-2">
-                                                <i class="bi bi-speedometer2 text-muted me-2"></i>
-                                                <span class="text-body">
-                                                    {% with total_riders_count=speed_range_info.riders|length ride_leader_count_val=speed_range_info.ride_leader_count %}
-                                                        {% if speed_range_info.speed_range %}
-                                                            {{ speed_range_info.speed_range }}
-                                                        {% else %}
-                                                            No Speed Preference
-                                                        {% endif %}
-                                                        ({% if ride_leader_count_val == 0 %}{{ total_riders_count }} rider{{ total_riders_count|pluralize }}{% elif ride_leader_count_val == total_riders_count %}{{ ride_leader_count_val }} leader{{ ride_leader_count_val|pluralize }}{% else %}{{ speed_range_info.non_leader_count }} rider{{ speed_range_info.non_leader_count|pluralize }} + {{ ride_leader_count_val }} leader{{ ride_leader_count_val|pluralize }}{% endif %})
-                                                    {% endwith %}
-                                                </span>
-                                                {% if speed_range_info.riders %}
-                                                <button @click="open = !open" class="btn btn-link btn-sm text-primary p-0 ms-2 text-decoration-underline">
-                                                    <span x-show="!open">(show)</span>
-                                                    <span x-show="open" x-cloak>(hide)</span>
-                                                </button>
-                                                {% endif %}
-                                            </div>
-
-                                            {% if speed_range_info.riders %}
-                                            <div class="ps-4 mb-4" x-show="open" x-cloak>
-                                                {% for rider in speed_range_info.riders %}
-                                                    <div class="small text-muted">
-                                                        {{ rider.name }}{% if rider.is_ride_leader %} <span class="badge text-bg-primary">Ride leader</span>{% endif %}
-                                                    </div>
-                                                {% endfor %}
-                                            </div>
-                                            {% endif %}
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            {% else %}
-                                <p class="text-muted">No speed ranges configured for this ride.</p>
+                            {% if not ride_info.speed_ranges %}
+                            <p class="text-muted mt-4 mb-0">No speed ranges configured for this ride.</p>
                             {% endif %}
                         {% endwith %}
-                    </div>
                     {% else %}
-                        <p class="text-muted">No speed ranges configured for this ride.</p>
+                        <p class="text-muted mt-4 mb-0">No speed ranges configured for this ride.</p>
                     {% endif %}
                     {% endwith %}
                     {% endif %}
                 </div>
+
+                {% if registrations_available %}
+                {% with ride_id=ride.id|stringformat:"s" %}
+                {% if rides and ride_id in rides %}
+                {% with ride_info=rides|get_item:ride_id %}
+                {% if ride_info.speed_ranges %}
+                <div class="list-group list-group-flush">
+                    {% for speed_range_id, speed_range_info in ride_info.speed_ranges.items %}
+                    <div class="list-group-item p-0" x-data="{ open: false }">
+                        <div class="d-flex align-items-start px-4 py-3"
+                             {% if speed_range_info.riders %}role="button" @click="open = !open" :aria-expanded="open"{% endif %}>
+                            <i class="bi bi-speedometer2 text-muted me-2"></i>
+                            <span class="{% if speed_range_info.riders %}text-body{% else %}text-muted{% endif %}">
+                                {% if speed_range_info.speed_range %}
+                                    {{ speed_range_info.speed_range }}
+                                {% else %}
+                                    No Speed Preference
+                                {% endif %}
+                                {% with total_riders_count=speed_range_info.riders|length ride_leader_count_val=speed_range_info.ride_leader_count %}
+                                <span class="text-muted">({% if ride_leader_count_val == 0 %}{{ total_riders_count }} rider{{ total_riders_count|pluralize }}{% elif ride_leader_count_val == total_riders_count %}{{ ride_leader_count_val }} leader{{ ride_leader_count_val|pluralize }}{% else %}{{ speed_range_info.non_leader_count }} rider{{ speed_range_info.non_leader_count|pluralize }} + {{ ride_leader_count_val }} leader{{ ride_leader_count_val|pluralize }}{% endif %})</span>
+                                {% endwith %}
+                            </span>
+                            {% if speed_range_info.riders %}
+                            <i class="bi bi-chevron-down text-muted ms-auto speed-range-chevron" :class="{ 'speed-range-chevron-open': open }"></i>
+                            {% endif %}
+                        </div>
+
+                        {% if speed_range_info.riders %}
+                        <div class="ps-5 pe-4 pb-3" x-show="open" x-cloak>
+                            {% for rider in speed_range_info.riders %}
+                                <div class="small text-muted">
+                                    {{ rider.name }}{% if rider.is_ride_leader %} <span class="badge text-bg-primary">Ride leader</span>{% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endif %}
+                {% endwith %}
+                {% endif %}
+                {% endwith %}
+                {% endif %}
             </div>
             {% endfor %}
         </div>

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -201,7 +201,7 @@
                     {% for speed_range_id, speed_range_info in ride_info.speed_ranges.items %}
                     <div class="list-group-item p-0" x-data="{ open: false }">
                         <div class="d-flex align-items-start px-4 py-3"
-                             {% if speed_range_info.riders %}role="button" @click="open = !open" :aria-expanded="open"{% endif %}>
+                             {% if speed_range_info.riders %}role="button" tabindex="0" @click="open = !open" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open" :aria-expanded="open"{% endif %}>
                             <i class="bi bi-speedometer2 text-muted me-2"></i>
                             <span class="{% if speed_range_info.riders %}text-body{% else %}text-muted{% endif %}">
                                 {% if speed_range_info.speed_range %}


### PR DESCRIPTION
Ride description, route link, and stats now form the top section of
each ride card, followed by full-width divided sections per speed
range. Each section with riders expands via a rotating chevron in the
top-right; the whole header row is the click target. Empty speed
ranges render muted without a chevron. Rider counts are muted to let
the speed range stand out, and route links wrap naturally with their
external-link icon.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PhoUQhyjcoKKGhbyRut4J