### PR TITLE
Replace event details card with metadata pills

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -77,9 +77,14 @@ body {
   display: inline-flex;
   align-items: center;
   padding: 0.35rem 0.85rem;
-  border-radius: 50rem;
+  border-radius: 0.375rem;
   font-size: 0.9rem;
   line-height: 1.3;
+}
+
+.meta-pill-sm {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
 }
 
 .meta-pill-link {

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -73,6 +73,28 @@ body {
   border-color: var(--bs-primary-hover);
 }
 
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 50rem;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+.meta-pill-link {
+  background-color: rgba(37, 99, 235, 0.08);
+  color: var(--bs-primary);
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.meta-pill-link:hover, .meta-pill-link:focus {
+  background-color: rgba(37, 99, 235, 0.16);
+  color: var(--bs-primary-hover);
+  text-decoration: underline;
+}
+
 .btn-danger {
   background-color: #dc2626;
   border-color: #dc2626;

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -41,18 +41,14 @@
                 <a href="{{ event.location_url }}"
                    class="meta-pill meta-pill-link"
                    target="_blank" rel="noopener noreferrer">
-                    <i class="bi bi-geo-alt me-2"></i>
-                    {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
-                    <i class="bi bi-box-arrow-up-right ms-2 small"></i>
+                    📍 {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
                 </a>
                 {% elif event.location %}
-                <span class="meta-pill text-muted" style="background-color: #6c757d1A;"><i class="bi bi-geo-alt me-2"></i>{{ event.location }}</span>
+                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
                 {% endif %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                 <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
-                    <i class="bi bi-people me-2"></i>
-                    {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered
-                    <i class="bi bi-chevron-right ms-2 small"></i>
+                    👥 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›
                 </a>
                 {% endif %}
             </div>

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -41,14 +41,14 @@
                 <a href="{{ event.location_url }}"
                    class="meta-pill meta-pill-link"
                    target="_blank" rel="noopener noreferrer">
-                    📍 {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
+                    🗺️ {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
                 </a>
                 {% elif event.location %}
-                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
+                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                 {% endif %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                 <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
-                    👥 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›
+                    🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›
                 </a>
                 {% endif %}
             </div>

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -35,39 +35,28 @@
             <h1 class="fs-2 fw-bold mb-2">
                 {% if event.cancelled %}<span class="text-decoration-line-through">{{ event.name }}</span> (cancelled){% else %}{{ event.name }}{% endif %}
             </h1>
-            <span class="badge fw-normal text-muted" style="font-size: 0.85rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+            <div class="d-flex flex-wrap gap-2 align-items-center">
+                <span class="meta-pill text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+                {% if event.location_url %}
+                <a href="{{ event.location_url }}"
+                   class="meta-pill meta-pill-link"
+                   target="_blank" rel="noopener noreferrer">
+                    <i class="bi bi-geo-alt me-2"></i>
+                    {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
+                    <i class="bi bi-box-arrow-up-right ms-2 small"></i>
+                </a>
+                {% elif event.location %}
+                <span class="meta-pill text-muted" style="background-color: #6c757d1A;"><i class="bi bi-geo-alt me-2"></i>{{ event.location }}</span>
+                {% endif %}
+                {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
+                <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
+                    <i class="bi bi-people me-2"></i>
+                    {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered
+                    <i class="bi bi-chevron-right ms-2 small"></i>
+                </a>
+                {% endif %}
+            </div>
         </div>
-
-        {% if event.location or event.location_url or not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-        <div class="card shadow-sm p-4 mb-4">
-            <div class="d-flex flex-wrap gap-3 small">
-                    {% if event.location or event.location_url %}
-                    <div class="d-inline-flex align-items-center text-muted">
-                        <i class="bi bi-geo-alt me-2"></i>
-                        {% if event.location_url %}
-                        <a href="{{ event.location_url }}"
-                           class="text-primary text-decoration-underline d-flex align-items-center"
-                           target="_blank" rel="noopener noreferrer">
-                            {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
-                            <i class="bi bi-box-arrow-up-right ms-1 small"></i>
-                        </a>
-                        {% else %}
-                        <span>{{ event.location }}</span>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-
-                    {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                    <div class="d-inline-flex align-items-center text-muted">
-                        <i class="bi bi-people me-2"></i>
-                        <a href="{% url 'riders_list' event.id %}" class="text-primary text-decoration-underline">
-                            {{ event.registration_count }} registered{% if not event.has_capacity_available %} (full){% elif event.capacity_remaining is not None %}, {{ event.capacity_remaining }} remaining{% endif %}
-                        </a>
-                    </div>
-                    {% endif %}
-                </div>
-        </div>
-        {% endif %}
 
         <h2 class="fs-5 fw-medium mb-3">About the event</h2>
         <div class="card shadow-sm mb-4">

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -49,22 +49,13 @@
                             <h3 class="fs-5 fw-medium mb-1 text-dark">
                                 {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
                             </h3>
-                            <div class="mb-2">
-                                <span class="badge fw-normal text-muted small" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
-                            </div>
-                            <div class="d-flex flex-wrap gap-3 small text-muted">
+                            <div class="d-flex flex-wrap gap-2 align-items-center">
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
                                 {% if event.location %}
-                                <div class="d-inline-flex align-items-center">
-                                    <i class="bi bi-geo-alt me-2"></i>
-                                    <span>{{ event.location }}</span>
-                                </div>
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
                                 {% endif %}
-
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                <div class="d-inline-flex align-items-center">
-                                    <i class="bi bi-people me-2"></i>
-                                    <span>{{ event.registration_count }} registered{% if not event.has_capacity_available %} (full){% endif %}</span>
-                                </div>
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">👥 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -52,10 +52,10 @@
                             <div class="d-flex flex-wrap gap-2 align-items-center">
                                 <span class="meta-pill meta-pill-sm text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
                                 {% if event.location %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                                 {% endif %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">👥 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -49,21 +49,20 @@
                             <div class="fs-6 fw-medium text-dark">
                                 {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
                             </div>
-                            <div>
-                                <span class="badge fw-normal text-muted" style="font-size: 0.75rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
+                            <div class="d-flex flex-wrap gap-2 align-items-center">
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
+                                {% if event.location %}
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
+                                {% endif %}
+                                {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">👥 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
+                                {% endif %}
                             </div>
                         </div>
-                        {% if event.location or event.has_rides or event.distance_range or not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
+                        {% if event.has_rides or event.distance_range %}
                         <hr class="my-0 opacity-25">
                         <div class="px-3 py-2">
                             <div class="d-flex flex-wrap gap-2 text-muted" style="font-size: 0.8rem;">
-                                {% if event.location %}
-                                <div class="d-inline-flex align-items-center">
-                                    <i class="bi bi-geo-alt me-1"></i>
-                                    <span>{{ event.location }}</span>
-                                </div>
-                                {% endif %}
-
                                 {% if event.has_rides %}
                                 <div class="d-inline-flex align-items-center">
                                     <i class="bi bi-bicycle me-1"></i>
@@ -75,13 +74,6 @@
                                 <div class="d-inline-flex align-items-center">
                                     <i class="bi bi-signpost-split me-1"></i>
                                     <span>{% if event.distance_range.0 == event.distance_range.1 %}{{ event.distance_range.0 }} km{% else %}{{ event.distance_range.0 }}-{{ event.distance_range.1 }} km{% endif %}</span>
-                                </div>
-                                {% endif %}
-
-                                {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                <div class="d-inline-flex align-items-center">
-                                    <i class="bi bi-people me-1"></i>
-                                    <span>{{ event.registration_count }} registered{% if not event.has_capacity_available %} (full){% endif %}</span>
                                 </div>
                                 {% endif %}
                             </div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -52,10 +52,10 @@
                             <div class="d-flex flex-wrap gap-2 align-items-center">
                                 <span class="meta-pill meta-pill-sm text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
                                 {% if event.location %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                                 {% endif %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">👥 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
+                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -31,10 +31,10 @@
                 <a href="{{ event.location_url }}"
                    class="meta-pill meta-pill-link"
                    target="_blank" rel="noopener noreferrer">
-                    📍 {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
+                    🗺️ {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
                 </a>
                 {% elif event.location %}
-                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
+                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                 {% endif %}
             </div>
         </div>

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -25,28 +25,21 @@
             <h1 class="fs-2 fw-bold mb-2">
                 {% if event.cancelled %}<span class="text-decoration-line-through">{{ event.name }}</span> (cancelled){% else %}{{ event.name }}{% endif %}
             </h1>
-            <span class="badge fw-normal text-muted" style="font-size: 0.85rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+            <div class="d-flex flex-wrap gap-2 align-items-center">
+                <span class="meta-pill text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+                {% if event.location_url %}
+                <a href="{{ event.location_url }}"
+                   class="meta-pill meta-pill-link"
+                   target="_blank" rel="noopener noreferrer">
+                    <i class="bi bi-geo-alt me-2"></i>
+                    {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
+                    <i class="bi bi-box-arrow-up-right ms-2 small"></i>
+                </a>
+                {% elif event.location %}
+                <span class="meta-pill text-muted" style="background-color: #6c757d1A;"><i class="bi bi-geo-alt me-2"></i>{{ event.location }}</span>
+                {% endif %}
+            </div>
         </div>
-
-        {% if event.location or event.location_url %}
-        <div class="card shadow-sm p-4 mb-4">
-            <div class="d-flex flex-wrap gap-3 small">
-                    <div class="d-inline-flex align-items-center text-muted">
-                        <i class="bi bi-geo-alt me-2"></i>
-                        {% if event.location_url %}
-                        <a href="{{ event.location_url }}"
-                           class="text-primary text-decoration-underline d-flex align-items-center"
-                           target="_blank" rel="noopener noreferrer">
-                            {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
-                            <i class="bi bi-box-arrow-up-right ms-1 small"></i>
-                        </a>
-                        {% else %}
-                        <span>{{ event.location }}</span>
-                        {% endif %}
-                    </div>
-                </div>
-        </div>
-        {% endif %}
 
         <form method="post">
             {% csrf_token %}

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -31,12 +31,10 @@
                 <a href="{{ event.location_url }}"
                    class="meta-pill meta-pill-link"
                    target="_blank" rel="noopener noreferrer">
-                    <i class="bi bi-geo-alt me-2"></i>
-                    {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
-                    <i class="bi bi-box-arrow-up-right ms-2 small"></i>
+                    📍 {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
                 </a>
                 {% elif event.location %}
-                <span class="meta-pill text-muted" style="background-color: #6c757d1A;"><i class="bi bi-geo-alt me-2"></i>{{ event.location }}</span>
+                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
                 {% endif %}
             </div>
         </div>

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -181,12 +181,10 @@
             <a href="{{ event.location_url }}"
                class="meta-pill meta-pill-link"
                target="_blank" rel="noopener noreferrer">
-                <i class="bi bi-geo-alt me-2"></i>
-                {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
-                <i class="bi bi-box-arrow-up-right ms-2 small"></i>
+                📍 {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
             </a>
             {% elif event.location %}
-            <span class="meta-pill text-muted" style="background-color: #6c757d1A;"><i class="bi bi-geo-alt me-2"></i>{{ event.location }}</span>
+            <span class="meta-pill text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
             {% endif %}
         </div>
     </div>

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -7,13 +7,6 @@
         display: none !important;
     }
 
-    /* Ensure the event details card is visible */
-    .mb-5 > .card.shadow-sm.p-4.mb-4 {
-        display: block !important;
-        border: 1px solid #ddd !important;
-        margin-bottom: 15px !important;
-    }
-
     /* Remove the card styling from table container only */
     .registrations-table-card {
         border: none !important;
@@ -182,28 +175,21 @@
         <h1 class="fs-2 fw-bold mb-2">
             {% if event.cancelled %}<span class="text-decoration-line-through">{{ event.name }}</span> (cancelled){% else %}{{ event.name }}{% endif %}
         </h1>
-        <span class="badge fw-normal text-muted" style="font-size: 0.85rem; background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+            <span class="meta-pill text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+            {% if event.location_url %}
+            <a href="{{ event.location_url }}"
+               class="meta-pill meta-pill-link"
+               target="_blank" rel="noopener noreferrer">
+                <i class="bi bi-geo-alt me-2"></i>
+                {% if event.location %}{{ event.location }}{% else %}See location{% endif %}
+                <i class="bi bi-box-arrow-up-right ms-2 small"></i>
+            </a>
+            {% elif event.location %}
+            <span class="meta-pill text-muted" style="background-color: #6c757d1A;"><i class="bi bi-geo-alt me-2"></i>{{ event.location }}</span>
+            {% endif %}
+        </div>
     </div>
-
-    {% if event.location or event.location_url %}
-    <div class="card shadow-sm p-4 mb-4">
-        <div class="d-flex flex-wrap gap-3 small">
-                <div class="d-inline-flex align-items-center text-muted">
-                    <i class="bi bi-geo-alt me-2"></i>
-                    {% if event.location_url %}
-                    <a href="{{ event.location_url }}"
-                       class="text-primary text-decoration-underline d-flex align-items-center"
-                       target="_blank" rel="noopener noreferrer">
-                        {{ event.location }}
-                        <i class="bi bi-box-arrow-up-right ms-1 small"></i>
-                    </a>
-                    {% else %}
-                    <span>{{ event.location }}</span>
-                    {% endif %}
-                </div>
-            </div>
-    </div>
-    {% endif %}
 
     {% if not registrations_available %}
     <h2 class="fs-5 fw-medium mb-3">Registered riders ({{ registration_count }})</h2>

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -181,10 +181,10 @@
             <a href="{{ event.location_url }}"
                class="meta-pill meta-pill-link"
                target="_blank" rel="noopener noreferrer">
-                📍 {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
+                🗺️ {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
             </a>
             {% elif event.location %}
-            <span class="meta-pill text-muted" style="background-color: #6c757d1A;">📍 {{ event.location }}</span>
+            <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
             {% endif %}
         </div>
     </div>

--- a/web/tests/acceptance/features/event_capacity.feature
+++ b/web/tests/acceptance/features/event_capacity.feature
@@ -3,46 +3,40 @@ Feature: Event Capacity
   Scenario: No limit set
     Given an event
       And the event registration limit is empty
+      And the event has 1 registration
     When visiting the event detail page
-    Then the event does not show registrations remaining
+    Then the event shows 1 registered
 
   Scenario: Limit two, zero registration
     Given an event
       And the event registration limit is 2
       And the event has 0 registration
     When visiting the event detail page
-    Then the event shows 0 registered
-     And the event shows 2 registrations remaining
+    Then the event does not show registrations
 
   Scenario: Limit two, one registration
     Given an event
       And the event registration limit is 2
       And the event has 1 registration
     When visiting the event detail page
-    Then the event shows 1 registered
-     And the event shows 1 registration remaining
+    Then the event shows 1/2 registered
 
   Scenario: Limit two, two registrations
     Given an event
       And the event registration limit is 2
       And the event has 2 registration
     When visiting the event detail page
-    Then the event shows 2 registered
-     And the event does not show registrations remaining
-     And the event shows it is fully registered
+    Then the event shows 2/2 registered
 
   Scenario: Limit two, three registrations
     Given an event
       And the event registration limit is 2
       And the event has 3 registration
     When visiting the event detail page
-    Then the event shows 3 registered
-     And the event does not show registrations remaining
-     And the event shows it is fully registered
+    Then the event shows 3/2 registered
 
   Scenario: External registration has no count
     Given an event
       And the event has external registration
     When visiting the event detail page
-    Then the event does not show registrations remaining
-     And the event does not show registrations
+    Then the event does not show registrations

--- a/web/tests/acceptance/steps/event.py
+++ b/web/tests/acceptance/steps/event.py
@@ -55,15 +55,9 @@ def step_impl(context):
     context.test.assertEqual(200, context.scenario_objects['response'].status_code)
 
 
-@then('the event shows {count:d} registered')
+@then('the event shows {count} registered')
 def step_impl(context, count):
     context.test.assertContains(context.scenario_objects['response'], f"{count} registered")
-
-
-@then('the event shows {count:d} registration remaining')
-@then('the event shows {count:d} registrations remaining')
-def step_impl(context, count):
-    context.test.assertContains(context.scenario_objects['response'], f"{count} remaining")
 
 
 @step("the event has {count:d} registration")
@@ -75,7 +69,7 @@ def step_impl(context, count):
             first_name=f'John {k}',
             last_name='Doe',
             email=email,
-            phone=f'+123456789{k}',
+            phone=f'+1613555{1000 + k}',
         )
         registration_detail = RegistrationDetail(
             ride=None,
@@ -85,12 +79,10 @@ def step_impl(context, count):
             emergency_contact_phone=''
         )
         rs.register(user_detail, registration_detail, context.scenario_objects['event'])
+        registration = Registration.objects.get(user__email=email, event=context.scenario_objects['event'])
+        registration.confirm()
+        registration.save()
     context.test.assertEqual(count, context.scenario_objects['event'].registration_count)
-
-
-@then("the event does not show registrations remaining")
-def step_impl(context):
-    context.test.assertNotContains(context.scenario_objects['response'], f"remaining")
 
 
 @step("the event does not show registrations")
@@ -107,11 +99,6 @@ def step_impl(context):
 @then("the event ical feed contains the event")
 def step_impl(context):
     context.test.assertContains(context.scenario_objects['response'], TEST_EVENT_NAME_TOKEN)
-
-
-@step("the event shows it is fully registered")
-def step_impl(context):
-    context.test.assertContains(context.scenario_objects['response'], "(full)")
 
 
 @then("the event shows when registration closes")


### PR DESCRIPTION
The location and registration count previously sat in a heavy card
below the event header, which looked inconsistent with the pill
styling around it, especially on mobile. They now join the program
pill in a single wrapping row of pills. Clickable pills use a blue
tint with primary-colored text and a trailing icon (external-link
for location, chevron for the registration list) to signal they
are links, while static pills keep the muted tinted look.

The registration count is now compact (e.g. 3/12 registered) and
the capacity remaining and full suffixes are gone. The acceptance
feature is updated to the new copy, and its registration step now
confirms registrations and uses valid phone numbers so the
previously erroring scenarios run again.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016iwSZKq57Cz4hrUyECPtWx