### PR TITLE
Show Masked badge to leaders and staff on registration list

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -238,6 +238,13 @@ class RegistrationService:
                 registration.name = f"{registration.first_name} {registration.last_name}"
         return registrations
 
+    def masked_registration_ids(self, registrations: list[Registration]) -> set[int]:
+        return {
+            registration.id for registration in registrations
+            if not self._name_visible_to_viewer(registration, viewer_is_authenticated=False,
+                                                viewer_is_privileged=False)
+        }
+
     def fetch_ride_counts(self, user_ids: list[int]) -> dict[int, int]:
         rows = (
             Registration.objects.filter(

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -2531,3 +2531,57 @@ class MaskHiddenNamesTestCase(TestCase):
         # Assert
         registration.refresh_from_db(fields=['name', 'first_name', 'last_name'])
         self.assertEqual(registration.name, 'John Doe')
+
+
+class MaskedRegistrationIdsTestCase(TestCase):
+    def setUp(self):
+        self.service = RegistrationService()
+        self.program = Program.objects.create(name="Test Program")
+        self.event = Event.objects.create(
+            name="Test Event",
+            program=self.program,
+            starts_at=timezone.now() + datetime.timedelta(days=3),
+            registration_closes_at=timezone.now() + datetime.timedelta(days=2),
+        )
+
+    def _create_registration(self, email, first_name, last_name, name_visibility=None, with_user=True):
+        user = None
+        if with_user:
+            user = User.objects.create_user(
+                username=email,
+                email=email,
+                first_name=first_name,
+                last_name=last_name,
+            )
+            if name_visibility:
+                user.profile.name_visibility = name_visibility
+                user.profile.save()
+
+        return Registration.objects.create(
+            first_name=first_name,
+            last_name=last_name,
+            name=f"{first_name} {last_name}",
+            email=email,
+            event=self.event,
+            user=user,
+            state=Registration.STATE_CONFIRMED,
+        )
+
+    def test_returns_ids_of_registrations_hidden_from_public(self):
+        # Arrange
+        public = self._create_registration('public@example.com', 'Pat', 'Public')
+        only_users = self._create_registration(
+            'users@example.com', 'Uma', 'Usersonly',
+            name_visibility=UserProfile.NameVisibility.ONLY_USERS,
+        )
+        only_required = self._create_registration(
+            'required@example.com', 'Rex', 'Requiredonly',
+            name_visibility=UserProfile.NameVisibility.ONLY_REQUIRED_USERS,
+        )
+        no_user = self._create_registration('nouser@example.com', 'Nora', 'Nouser', with_user=False)
+
+        # Act
+        masked_ids = self.service.masked_registration_ids([public, only_users, only_required, no_user])
+
+        # Assert
+        self.assertEqual(masked_ids, {only_users.id, only_required.id, no_user.id})

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -454,6 +454,11 @@ body {
   color: #fff;
 }
 
+.badge-masked {
+  background-color: #6c757d;
+  color: #fff;
+}
+
 .speed-range-chevron {
   display: inline-block;
   transition: transform 0.2s ease-in-out;

--- a/web/tables.py
+++ b/web/tables.py
@@ -104,9 +104,10 @@ class PublicRegistrationTable(tables.Table):
             'data-registration-id': lambda record: record.id,
         }
 
-    def __init__(self, *args, contacts_hidden=False, ride_counts=None, **kwargs):
+    def __init__(self, *args, contacts_hidden=False, ride_counts=None, masked_ids=None, **kwargs):
         self.contacts_hidden = contacts_hidden
         self.ride_counts = ride_counts or {}
+        self.masked_ids = masked_ids or set()
         super().__init__(*args, **kwargs)
 
     def _hidden_placeholder(self):
@@ -125,6 +126,11 @@ class PublicRegistrationTable(tables.Table):
             html = format_html(
                 '{} <span class="badge badge-ride-count-{}">{} ride</span>',
                 html, count, self.RIDE_COUNT_LABELS[count]
+            )
+
+        if record.id in self.masked_ids:
+            html = format_html(
+                '{} <span class="badge badge-masked">Masked</span>', html
             )
 
         return html

--- a/web/tests/views/test_name_visibility_views.py
+++ b/web/tests/views/test_name_visibility_views.py
@@ -306,3 +306,68 @@ class ProfileNameVisibilityTests(TestCase):
         # Assert
         self.assertEqual(response.status_code, 302)
         self.assertIn('login', response.url)
+
+
+class MaskedBadgeTests(BaseNameVisibilityTestCase):
+    def _get_riders_list_response(self):
+        response = self.client.get(reverse('riders_list', args=[self.event.id]))
+        self.assertEqual(response.status_code, 200)
+        return response
+
+    def test_staff_viewer_sees_masked_badges(self):
+        # Arrange
+        self.client.force_login(self.staff_user)
+
+        # Act
+        response = self._get_riders_list_response()
+
+        # Assert
+        self.assertContains(response, 'badge-masked', count=2)
+
+    def test_ride_leader_viewer_sees_masked_badges(self):
+        # Arrange
+        self.client.force_login(self.leader_user)
+
+        # Act
+        response = self._get_riders_list_response()
+
+        # Assert
+        self.assertContains(response, 'badge-masked', count=2)
+
+    def test_anonymous_viewer_does_not_see_masked_badges(self):
+        # Act
+        response = self._get_riders_list_response()
+
+        # Assert
+        self.assertNotContains(response, 'badge-masked')
+
+    def test_signed_in_viewer_does_not_see_masked_badges(self):
+        # Arrange
+        self.client.force_login(self.viewer_user)
+
+        # Act
+        response = self._get_riders_list_response()
+
+        # Assert
+        self.assertNotContains(response, 'badge-masked')
+
+    def test_staff_viewer_sees_badge_for_registration_without_user(self):
+        # Arrange
+        Registration.objects.create(
+            first_name='Nora',
+            last_name='Nouser',
+            name='Nora Nouser',
+            email='nouser@example.com',
+            event=self.event,
+            ride=self.ride,
+            speed_range_preference=self.speed_range,
+            ride_leader_preference=Registration.RideLeaderPreference.NO,
+            state=Registration.STATE_CONFIRMED,
+        )
+        self.client.force_login(self.staff_user)
+
+        # Act
+        response = self._get_riders_list_response()
+
+        # Assert
+        self.assertContains(response, 'badge-masked', count=3)

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -284,13 +284,16 @@ def _build_registrations_context(request, event, contacts_revealed):
         exclude_columns = ('first_time_attendee',)
 
     ride_counts = {}
+    masked_ids = set()
     if can_access_rider_contacts:
         user_ids = [r.user_id for r in filtered_riders if r.user_id]
         ride_counts = RegistrationService().fetch_ride_counts(user_ids)
+        masked_ids = RegistrationService().masked_registration_ids(filtered_riders)
 
     table = PublicRegistrationTable(
         filtered_riders, exclude=exclude_columns,
         contacts_hidden=contacts_hidden, ride_counts=ride_counts,
+        masked_ids=masked_ids,
     )
     RequestConfig(request, paginate=False).configure(table)
 


### PR DESCRIPTION
Follow-up to #262 (refs #261).

Riders whose names are hidden from the public now get a small "Masked" badge after their name on the registration list, so ride leaders and staff can tell which names are masked on the public views.

- New `RegistrationService.masked_registration_ids` returns the ids of registrations whose names are hidden from anonymous viewers (non-public preference or no linked user account).
- `PublicRegistrationTable` renders the badge after the rider's name, alongside the existing Leader and 1st/2nd/3rd ride badges.
- The badge is only computed and passed to the table when the viewer can access rider contacts (confirmed ride leader for the event, or staff); anonymous and regular signed-in users never see it.
- New `.badge-masked` style in `styling.css`, matching the existing badge styles.
- Tests cover badge visibility per viewer role, including registrations without a user account. Full suite passes (582 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVwQR1fdV7gVs3P4Ku3bzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVwQR1fdV7gVs3P4Ku3bzy)_