### PR TITLE
Clarify full name in privacy card and show masked name example

### DIFF
--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -71,7 +71,7 @@
 
                     <form method="post" action="{% url 'profile_name_visibility' %}">
                         {% csrf_token %}
-                        <p class="fw-medium mb-2">When can we show your name on registration lists?</p>
+                        <p class="fw-medium mb-2">When can we show your full name on registration lists?</p>
                         {% for value, label in name_visibility_choices %}
                         <div class="form-check mb-1">
                             <input class="form-check-input" type="radio" name="name_visibility"
@@ -82,6 +82,8 @@
                         </div>
                         {% endfor %}
                     </form>
+
+                    <p class="text-muted small mt-2 mb-0">When your name isn't shown, we'll display a masked version instead, e.g. <strong>{{ masked_name_example }}</strong> for your name.</p>
 
                     <div class="text-muted small mt-3">
                         <p class="mb-2">Your email, phone number and emergency contact details are only available to ride leaders and ride administrators.</p>

--- a/web/tests/views/test_name_visibility_views.py
+++ b/web/tests/views/test_name_visibility_views.py
@@ -267,7 +267,8 @@ class ProfileNameVisibilityTests(TestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['name_visibility'], UserProfile.NameVisibility.PUBLIC)
-        self.assertContains(response, 'When can we show your name on registration lists?')
+        self.assertContains(response, 'When can we show your full name on registration lists?')
+        self.assertContains(response, 'M* U*')
 
     def test_post_updates_name_visibility(self):
         # Arrange

--- a/web/views/profile.py
+++ b/web/views/profile.py
@@ -6,7 +6,7 @@ from waffle import flag_is_active
 
 from backoffice.models import Registration, UserProfile
 from backoffice.services.membership_service import MembershipService
-from backoffice.services.registration_service import RegistrationService
+from backoffice.services.registration_service import RegistrationService, NAME_MASKING_STRATEGY
 from backoffice.services.user_service import UserService
 from web.forms import MembershipNumberForm, NameVisibilityForm
 
@@ -17,12 +17,15 @@ def profile(request: HttpRequest) -> HttpResponse:
     registrations = registration_service.fetch_current_registrations(request.user)
     past_registrations = registration_service.fetch_past_registrations(request.user)
 
+    masked_first_name, masked_last_name = NAME_MASKING_STRATEGY(request.user)
+
     context = {
         'registrations': registrations,
         'past_registrations': past_registrations,
         'name_visibility': request.user.profile.name_visibility,
         'name_visibility_choices': UserProfile.NameVisibility.choices,
         'registration_visibility_hours': settings.REGISTRATION_VISIBILITY_HOURS,
+        'masked_name_example': f'{masked_first_name} {masked_last_name}',
     }
 
     if flag_is_active(request, 'capture_membership_number'):


### PR DESCRIPTION
Explains what a masked name looks like using the actual masking
strategy and the signed-in user's own name.