### PR TITLE
Render masked names as faded dots with seeded lengths

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import random
 import string
@@ -21,6 +22,16 @@ VERIFICATION_TOKEN_MAX_AGE = 86400
 VERIFICATION_TOKEN_SALT = 'email-verification'
 
 
+MASK_DOT = '·'
+MASK_DOT_MIN = 3
+MASK_DOT_MAX = 6
+
+
+def _seeded_dot_count(name: str) -> int:
+    digest = hashlib.sha256(name.strip().lower().encode('utf-8')).digest()
+    return MASK_DOT_MIN + digest[0] % (MASK_DOT_MAX - MASK_DOT_MIN + 1)
+
+
 def mask_name_with_initials(registration: 'Registration') -> tuple[str, str]:
     return f"{registration.first_name[:1].upper()}*", f"{registration.last_name[:1].upper()}*"
 
@@ -29,7 +40,14 @@ def mask_name_with_random_letters(registration: 'Registration') -> tuple[str, st
     return random.choice(string.ascii_uppercase), random.choice(string.ascii_uppercase)
 
 
-NAME_MASKING_STRATEGY = mask_name_with_initials
+def mask_name_with_dots(registration: 'Registration') -> tuple[str, str]:
+    return (
+        f"{registration.first_name[:1].upper()}{MASK_DOT * _seeded_dot_count(registration.first_name)}",
+        f"{registration.last_name[:1].upper()}{MASK_DOT * _seeded_dot_count(registration.last_name)}",
+    )
+
+
+NAME_MASKING_STRATEGY = mask_name_with_dots
 
 
 class RegistrationResult(Enum):

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -11,6 +11,7 @@ from backoffice.models import Event, Registration, Program, UserProfile, Ride, R
 from backoffice.services.registration_service import (
     RegistrationService, UserDetail, RegistrationDetail, RegistrationResult,
     VERIFICATION_TOKEN_SALT, mask_name_with_initials, mask_name_with_random_letters,
+    mask_name_with_dots,
 )
 from backoffice.services.request_service import RequestDetail
 
@@ -2435,6 +2436,43 @@ class MaskHiddenNamesTestCase(TestCase):
         # Assert
         self.assertRegex(first_name, r'^[A-Z]$')
         self.assertRegex(last_name, r'^[A-Z]$')
+
+    def test_mask_name_with_dots_uses_initial_followed_by_dots(self):
+        # Arrange
+        registration = self._create_registration('john@example.com', 'John', 'Doe')
+
+        # Act
+        first_name, last_name = mask_name_with_dots(registration)
+
+        # Assert
+        self.assertRegex(first_name, r'^J·{3,6}$')
+        self.assertRegex(last_name, r'^D·{3,6}$')
+
+    def test_mask_name_with_dots_is_stable_for_same_name(self):
+        # Arrange
+        first = self._create_registration('john@example.com', 'John', 'Doe')
+        second = self._create_registration('john.b@example.com', 'John', 'Doe')
+
+        # Act
+        first_result = mask_name_with_dots(first)
+        second_result = mask_name_with_dots(second)
+
+        # Assert
+        self.assertEqual(first_result, second_result)
+
+    def test_mask_name_with_dots_does_not_reveal_name_length(self):
+        # Arrange
+        short_name = self._create_registration('al@example.com', 'Al', 'Ek')
+        long_name = self._create_registration('alexandra@example.com', 'Alexandra', 'Ekelundsson')
+
+        # Act
+        short_first, short_last = mask_name_with_dots(short_name)
+        long_first, long_last = mask_name_with_dots(long_name)
+
+        # Assert
+        self.assertNotEqual(len(short_first), len('Al'))
+        self.assertNotEqual(len(long_first), len('Alexandra'))
+        self.assertNotEqual(len(long_last), len('Ekelundsson'))
 
     def test_public_name_never_masked(self):
         # Arrange

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -462,3 +462,8 @@ body {
 .speed-range-chevron-open {
   transform: rotate(180deg);
 }
+
+.name-mask {
+  opacity: 0.45;
+  letter-spacing: 0.13em;
+}

--- a/web/tables.py
+++ b/web/tables.py
@@ -2,6 +2,7 @@ import django_tables2 as tables
 from django.utils.html import format_html
 
 from backoffice.models import Registration
+from web.templatetags.name_filters import styled_name
 from web.templatetags.phone_filters import national_phone
 
 
@@ -113,7 +114,7 @@ class PublicRegistrationTable(tables.Table):
         return format_html('<span class="small text-muted fst-italic">(hidden)</span>')
 
     def render_name(self, value, record):
-        html = format_html('<span class="small fw-medium">{}</span>', value)
+        html = format_html('<span class="small fw-medium">{}</span>', styled_name(value))
 
         if record.ride_leader_preference == Registration.RideLeaderPreference.YES:
             html = format_html(

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -1,6 +1,7 @@
 {% extends 'web/_base_bootstrap.html' %}
 {% load form_filters %}
 {% load dict_filters %}
+{% load name_filters %}
 {% block title %}{{ event.name }} - Event Details{% endblock %}
 {% block content %}
     <div class="mb-4">
@@ -207,7 +208,7 @@
                         <div class="ps-5 pe-4 pb-3" x-show="open" x-cloak>
                             {% for rider in speed_range_info.riders %}
                                 <div class="small text-muted">
-                                    {{ rider.name }}{% if rider.is_ride_leader %} <span class="badge text-bg-primary">Ride leader</span>{% endif %}
+                                    {{ rider.name|styled_name }}{% if rider.is_ride_leader %} <span class="badge text-bg-primary">Ride leader</span>{% endif %}
                                 </div>
                             {% endfor %}
                         </div>

--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -1,6 +1,7 @@
 {% extends 'web/_base_bootstrap.html' %}
 {% load waffle_tags %}
 {% load phone_filters %}
+{% load name_filters %}
 {% block title %}My profile{% endblock %}
 {% block content %}
 <div class="mb-4">
@@ -83,7 +84,7 @@
                         {% endfor %}
                     </form>
 
-                    <p class="text-muted small mt-2 mb-0">When your name isn't shown, we'll display a masked version instead, e.g. <strong>{{ masked_name_example }}</strong> for your name.</p>
+                    <p class="text-muted small mt-2 mb-0">When your name isn't shown, we'll display a masked version instead, e.g. <strong>{{ masked_name_example|styled_name }}</strong> for your name.</p>
 
                     <div class="text-muted small mt-3">
                         <p class="mb-2">Your email, phone number and emergency contact details are only available to ride leaders and ride administrators.</p>

--- a/web/templatetags/name_filters.py
+++ b/web/templatetags/name_filters.py
@@ -1,0 +1,21 @@
+import re
+
+from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+MASK_DOT_RUN = re.compile('·+')
+
+
+@register.filter(name='styled_name')
+def styled_name(value):
+    if not value:
+        return value
+    escaped = escape(value)
+    styled = MASK_DOT_RUN.sub(
+        lambda match: f'<span class="name-mask" aria-hidden="true">{match.group(0)}</span>',
+        escaped,
+    )
+    return mark_safe(styled)

--- a/web/tests/views/test_name_visibility_views.py
+++ b/web/tests/views/test_name_visibility_views.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from backoffice.models import Event, Program, Registration, Ride, Route, SpeedRange, UserProfile
 
-MASKED_NAME_PATTERN = re.compile(r'^[A-Z]\* [A-Z]\*$')
+MASKED_NAME_PATTERN = re.compile(r'^[A-Z]·{3,6} [A-Z]·{3,6}$')
 
 
 class BaseNameVisibilityTestCase(TestCase):
@@ -173,7 +173,8 @@ class EventDetailNameVisibilityTests(BaseNameVisibilityTestCase):
 
         # Assert
         self.assertNotIn('Nora Nouser', names)
-        self.assertIn('N* N*', names)
+        masked = [name for name in names if MASKED_NAME_PATTERN.match(name)]
+        self.assertTrue(any(name.startswith('N') for name in masked))
 
     def test_registration_without_user_is_visible_to_staff(self):
         # Arrange
@@ -268,7 +269,7 @@ class ProfileNameVisibilityTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['name_visibility'], UserProfile.NameVisibility.PUBLIC)
         self.assertContains(response, 'When can we show your full name on registration lists?')
-        self.assertContains(response, 'M* U*')
+        self.assertRegex(response.context['masked_name_example'], MASKED_NAME_PATTERN)
 
     def test_post_updates_name_visibility(self):
         # Arrange


### PR DESCRIPTION
## What

Replaces the `D* P*` masked-name rendering with a quieter, clearly-deliberate treatment: the initial followed by a run of middle dots (e.g. `D······ P····`), rendered faded and letter-spaced.

## How

- New `mask_name_with_dots` strategy in `registration_service.py`, now the active `NAME_MASKING_STRATEGY`. The dot count (3–6) is derived from a sha256 hash of the lowercased name, so it is stable for a given name across renders and deploys, but does not correlate with the actual name length.
- New `styled_name` template filter (`web/templatetags/name_filters.py`) wraps dot runs in a `<span class="name-mask" aria-hidden="true">` so screen readers only announce the initials. Names without dots pass through unchanged.
- Applied in the public riders table (`PublicRegistrationTable.render_name`), the event detail rider lists, and the profile privacy card's masked-name example.
- `.name-mask` in `styling.css` fades the dots (opacity 0.45) and adds letter-spacing.

## Tests

- Service tests for the new strategy: initial + 3–6 dots, stable for the same name, masked length independent of real name length.
- View tests updated from the `[A-Z]\*` pattern to the dot pattern; full suite passes (579 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jqdnpL6Le4Gq6xYL3VR6W

---
_Generated by [Claude Code](https://claude.ai/code/session_012jqdnpL6Le4Gq6xYL3VR6W)_