### PR TITLE
Quote masked name example in privacy note

### DIFF
--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -84,7 +84,7 @@
                         {% endfor %}
                     </form>
 
-                    <p class="text-muted small mt-2 mb-0">For anyone who isn't allowed to see your full name, we'll show a masked version instead, e.g. <strong>{{ masked_name_example|styled_name }}</strong> for your full name.</p>
+                    <p class="text-muted small mt-2 mb-0">For anyone who isn't allowed to see your full name, we'll show a masked version instead, e.g. "{{ masked_name_example|styled_name }}" for your full name.</p>
 
                     <div class="text-muted small mt-3">
                         <p class="mb-2">Your email, phone number and emergency contact details are only available to ride leaders and ride administrators.</p>


### PR DESCRIPTION
Updates the masking note in the profile page privacy card so the masked name example is surrounded by quotes and no longer rendered in bold.

**Before:** `... e.g. **D······ P····** for your full name.`
**After:** `... e.g. "D······ P····" for your full name.`

Existing `test_name_visibility_views` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEd7B6ayPvnHEp6ua7dc3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEd7B6ayPvnHEp6ua7dc3M)_