### PR TITLE
Fix logout after registration for signed-in users

### DIFF
--- a/backoffice/services/user_service.py
+++ b/backoffice/services/user_service.py
@@ -39,7 +39,7 @@ class UserService(object):
 
         match self.find_by_email(lowercase_email):
             case Some(user):
-                if not user.is_staff:
+                if not user.is_staff and user.has_usable_password():
                     user.set_unusable_password()
 
                 user.first_name = user_detail.first_name

--- a/backoffice/tests/services/test_user_service.py
+++ b/backoffice/tests/services/test_user_service.py
@@ -245,6 +245,43 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         profile = UserProfile.objects.get(user=found_staff)
         self.assertEqual(profile.phone, "+16135552222")
 
+    def test_find_by_email_or_create_keeps_unusable_password_unchanged(self):
+        # Arrange
+        user = User.objects.get(email=self.non_staff_email)
+        password_before = user.password
+        user_detail = UserDetail(
+            first_name="Test",
+            last_name="User",
+            email=self.non_staff_email,
+            phone="+16135552222",
+        )
+
+        # Act
+        self.service.find_by_email_or_create(user_detail)
+
+        # Assert
+        user.refresh_from_db()
+        self.assertEqual(user.password, password_before)
+
+    def test_find_by_email_or_create_makes_usable_password_unusable_for_non_staff(self):
+        # Arrange
+        user = User.objects.get(email=self.non_staff_email)
+        user.set_password("secret123")
+        user.save()
+        user_detail = UserDetail(
+            first_name="Test",
+            last_name="User",
+            email=self.non_staff_email,
+            phone="+16135552222",
+        )
+
+        # Act
+        self.service.find_by_email_or_create(user_detail)
+
+        # Assert
+        user.refresh_from_db()
+        self.assertFalse(user.has_usable_password())
+
     def test_find_by_email_or_create_saves_emergency_contact_to_new_profile(self):
         # Arrange
         user_detail = UserDetail(


### PR DESCRIPTION
## Problem

Signed-in users were logged out immediately after submitting an event registration (reproduced via /registrations/submitted, then /profile showing logged out).

## Root cause

`UserService.find_by_email_or_create` called `set_unusable_password()` unconditionally for existing non-staff users. Django generates a *new random* unusable password string on every call, so `user.password` changed on every registration. The session auth hash is an HMAC of the password field, so the next request failed the hash check in `AuthenticationMiddleware` and the session was discarded.

History: this bug was originally fixed in cc8ba51 (2025-05-12, "Don't rest password for existing users") and accidentally reintroduced 22 minutes later in 7c7224f ("Only update if not staff"). It has been live since.

## Fix

Only reset the password when it is currently usable:

```python
if not user.is_staff and user.has_usable_password():
    user.set_unusable_password()
```

Repeat registrations no longer touch the password field, so the session stays valid. The security intent (non-staff users cannot keep a usable password) is preserved.

Known edge case: a non-staff user who somehow has a usable password still gets logged out once, on their first registration, when it is made unusable. That path is intended behavior.

## Tests

- `test_find_by_email_or_create_keeps_unusable_password_unchanged` (regression)
- `test_find_by_email_or_create_makes_usable_password_unusable_for_non_staff`

All 20 user service tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrntPbz8tBq7AZ6iYG38ki