### PR TITLE
Make audit action names specific enough to disambiguate

### DIFF
--- a/backoffice/management/commands/importroutes.py
+++ b/backoffice/management/commands/importroutes.py
@@ -1,7 +1,6 @@
 import os
 
-from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from backoffice.services.route_service import ACTION_SKIP, RouteImportService
 
@@ -12,19 +11,12 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('csv_file', type=str)
         parser.add_argument('--dry-run', action='store_true')
-        parser.add_argument('--actor', type=str, required=True,
-                            help='Email of the user running the import, recorded in the audit log.')
 
     def handle(self, *args, **options):
         path = options['csv_file']
         if not os.path.exists(path):
             self.stdout.write(self.style.ERROR(f'File not found: {path}'))
             return
-
-        try:
-            actor = User.objects.get(email=options['actor'])
-        except User.DoesNotExist:
-            raise CommandError(f'No user found with email {options["actor"]!r} for --actor.')
 
         with open(path, 'r', encoding='utf-8-sig') as fh:
             text = fh.read()
@@ -34,7 +26,6 @@ class Command(BaseCommand):
             text,
             on_conflict=lambda *_: ACTION_SKIP,
             dry_run=options['dry_run'],
-            actor=actor,
         )
 
         self._print_summary(stats, options['dry_run'])

--- a/backoffice/management/commands/syncroutes.py
+++ b/backoffice/management/commands/syncroutes.py
@@ -27,14 +27,11 @@ class Command(BaseCommand):
                             help='Skip routes with manual-edit conflicts instead of prompting.')
         parser.add_argument('--url', type=str, default=None,
                             help='Override the CSV URL (defaults to RWGPS_ORG_SLUG).')
-        parser.add_argument('--actor', type=str, required=True,
-                            help='Email of the user running the import, recorded in the audit log.')
 
     def handle(self, *args, **options):
         url = options['url'] or CSV_URL_TEMPLATE.format(slug=settings.RWGPS_ORG_SLUG)
         dry_run = options['dry_run']
         non_interactive = options['non_interactive']
-        actor = self._resolve_actor(options['actor'])
 
         self.stdout.write(f'Fetching {url}')
         try:
@@ -62,17 +59,9 @@ class Command(BaseCommand):
             return self._prompt(route, csv_row, conflict_type, bulk_decisions)
 
         service = RouteImportService()
-        stats = service.import_from_csv_text(text, on_conflict=on_conflict, dry_run=dry_run, actor=actor)
+        stats = service.import_from_csv_text(text, on_conflict=on_conflict, dry_run=dry_run)
 
         self._print_summary(stats, dry_run)
-
-    @staticmethod
-    def _resolve_actor(email):
-        from django.contrib.auth.models import User
-        try:
-            return User.objects.get(email=email)
-        except User.DoesNotExist:
-            raise CommandError(f'No user found with email {email!r} for --actor.')
 
     def _prompt(self, route, csv_row, conflict_type, bulk_decisions):
         self.stdout.write('')

--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -394,7 +394,7 @@ class RegistrationService:
             registration.event.name, registration.event.id,
         )
 
-        self.audit_service.log(staff_user, 'withdrawn', target=registration)
+        self.audit_service.log(staff_user, 'staff_withdrew', target=registration)
 
         if was_confirmed:
             self._send_withdrawal_email(registration)
@@ -424,7 +424,7 @@ class RegistrationService:
             staff_user.email, staff_user.id, user.email, event.name, event.id,
         )
 
-        self.audit_service.log(staff_user, 'registered', target=registration)
+        self.audit_service.log(staff_user, 'staff_registered', target=registration)
 
         self._send_confirmation_email(registration)
         return registration
@@ -445,7 +445,7 @@ class RegistrationService:
             registration.event.id, list(fields.keys()),
         )
 
-        self.audit_service.log(staff_user, 'updated', target=registration)
+        self.audit_service.log(staff_user, 'staff_edited', target=registration)
 
     def _send_withdrawal_email(self, registration: Registration) -> None:
         context = {

--- a/backoffice/services/route_service.py
+++ b/backoffice/services/route_service.py
@@ -7,7 +7,6 @@ from typing import Callable, Optional
 from django.db import transaction
 from django.utils import timezone
 
-from audit.services import AuditService
 from backoffice.models import Route
 
 
@@ -60,11 +59,10 @@ class RouteImportService:
         *,
         on_conflict: Optional[ConflictCallback] = None,
         dry_run: bool = False,
-        actor=None,
     ) -> ImportStats:
         stats = ImportStats()
         rows = self._parse_csv(text, stats)
-        return self._apply(rows, stats=stats, on_conflict=on_conflict, dry_run=dry_run, actor=actor)
+        return self._apply(rows, stats=stats, on_conflict=on_conflict, dry_run=dry_run)
 
     def _parse_csv(self, text: str, stats: ImportStats) -> list[CsvRow]:
         reader = csv.DictReader(StringIO(text))
@@ -122,7 +120,6 @@ class RouteImportService:
         stats: ImportStats,
         on_conflict: Optional[ConflictCallback],
         dry_run: bool,
-        actor=None,
     ) -> ImportStats:
         now = timezone.now()
         creates, updates = self._collect_creates_and_updates(rows, stats, on_conflict, now)
@@ -131,21 +128,13 @@ class RouteImportService:
         if dry_run:
             return stats
 
-        audit_service = AuditService()
-
         with transaction.atomic():
             for route in creates:
                 route.save()
-                if actor is not None:
-                    audit_service.log(actor, 'created', target=route)
             for route in updates:
                 route.save()
-                if actor is not None:
-                    audit_service.log(actor, 'updated', target=route)
             for route in deletes:
                 route.save()
-                if actor is not None:
-                    audit_service.log(actor, 'deleted', target=route)
 
         return stats
 

--- a/backoffice/signals.py
+++ b/backoffice/signals.py
@@ -8,7 +8,6 @@ from .models import (
     Announcement,
     Event,
     Program,
-    Registration,
     Ride,
     Route,
     SpeedRange,
@@ -43,7 +42,6 @@ AUDITED_MODELS = (
     Ride,
     UserProfile,
     UserMembershipNumber,
-    Registration,
     Announcement,
 )
 

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -2606,7 +2606,7 @@ class AuditLoggingTestCase(TestCase):
         # Assert
         audit_event = AuditEvent.objects.get()
         self.assertEqual(audit_event.actor, self.staff_user)
-        self.assertEqual(audit_event.action, 'registered')
+        self.assertEqual(audit_event.action, 'staff_registered')
         self.assertEqual(audit_event.target, registration)
 
     def test_staff_withdraw_creates_audit_event(self):
@@ -2626,7 +2626,7 @@ class AuditLoggingTestCase(TestCase):
         # Assert
         audit_event = AuditEvent.objects.get()
         self.assertEqual(audit_event.actor, self.staff_user)
-        self.assertEqual(audit_event.action, 'withdrawn')
+        self.assertEqual(audit_event.action, 'staff_withdrew')
         self.assertEqual(audit_event.target, registration)
 
     def test_staff_update_registration_creates_audit_event(self):
@@ -2643,7 +2643,7 @@ class AuditLoggingTestCase(TestCase):
         # Assert
         audit_event = AuditEvent.objects.get()
         self.assertEqual(audit_event.actor, self.staff_user)
-        self.assertEqual(audit_event.action, 'updated')
+        self.assertEqual(audit_event.action, 'staff_edited')
         self.assertEqual(audit_event.target, registration)
 
     def test_register_does_not_create_audit_event(self):

--- a/backoffice/tests/services/test_route_service.py
+++ b/backoffice/tests/services/test_route_service.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from django.contrib.auth.models import User
 from django.test import TestCase
 from django.utils import timezone
 
@@ -370,69 +369,16 @@ class RouteImportServiceAuditTests(TestCase):
     def setUp(self):
         # Arrange
         self.service = RouteImportService()
-        self.actor = User.objects.create_user(username='importer', email='importer@example.com')
 
-    def test_import_with_actor_logs_created_audit_event(self):
+    def test_import_does_not_log_audit_events(self):
         # Arrange
         csv_text = make_csv(csv_row(
             url='https://ridewithgps.com/routes/100', name='New Route', distance='50', elevation='10',
         ))
 
         # Act
-        self.service.import_from_csv_text(csv_text, actor=self.actor)
-
-        # Assert
-        route = Route.objects.get(url='https://ridewithgps.com/routes/100')
-        audit_event = AuditEvent.objects.get()
-        self.assertEqual(audit_event.actor, self.actor)
-        self.assertEqual(audit_event.action, 'created')
-        self.assertEqual(audit_event.target, route)
-
-    def test_import_with_actor_logs_updated_audit_event(self):
-        # Arrange
-        url = 'https://ridewithgps.com/routes/101'
-        ts = timezone.now() - timedelta(days=1)
-        route = Route.objects.create(name='Old', url=url, distance=100, elevation_gain=200)
-        Route.objects.filter(pk=route.pk).update(last_imported_at=ts, updated_at=ts)
-        csv_text = make_csv(csv_row(url=url, name='Updated', distance='150', elevation='300'))
-
-        # Act
-        self.service.import_from_csv_text(csv_text, actor=self.actor)
-
-        # Assert
-        updated_route = Route.objects.get(url=url)
-        audit_event = AuditEvent.objects.get()
-        self.assertEqual(audit_event.actor, self.actor)
-        self.assertEqual(audit_event.action, 'updated')
-        self.assertEqual(audit_event.target, updated_route)
-
-    def test_import_with_actor_logs_deleted_audit_event(self):
-        # Arrange
-        keep_url = 'https://ridewithgps.com/routes/102'
-        gone_url = 'https://ridewithgps.com/routes/103'
-        ts = timezone.now() - timedelta(days=1)
-        for url in (keep_url, gone_url):
-            route = Route.objects.create(name='Existing', url=url, distance=100, elevation_gain=200)
-            Route.objects.filter(pk=route.pk).update(last_imported_at=ts, updated_at=ts)
-        csv_text = make_csv(csv_row(url=keep_url, name='Existing', distance='100', elevation='200'))
-
-        # Act
-        self.service.import_from_csv_text(csv_text, actor=self.actor)
-
-        # Assert
-        gone_route = Route.objects.get(url=gone_url)
-        audit_event = AuditEvent.objects.get(action='deleted')
-        self.assertEqual(audit_event.actor, self.actor)
-        self.assertEqual(audit_event.target, gone_route)
-
-    def test_import_without_actor_does_not_log_audit_event(self):
-        # Arrange
-        csv_text = make_csv(csv_row(
-            url='https://ridewithgps.com/routes/104', name='New Route', distance='50', elevation='10',
-        ))
-
-        # Act
         self.service.import_from_csv_text(csv_text)
 
         # Assert
+        Route.objects.get(url='https://ridewithgps.com/routes/100')
         self.assertFalse(AuditEvent.objects.exists())

--- a/backoffice/tests/test_syncroutes_command.py
+++ b/backoffice/tests/test_syncroutes_command.py
@@ -1,7 +1,6 @@
 from io import StringIO
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -29,11 +28,6 @@ class FakeResponse:
 
 
 class SyncRoutesCommandTests(TestCase):
-    def setUp(self):
-        self.actor = User.objects.create_user(
-            username='importer', email='importer@example.com', password='password123'
-        )
-
     @patch('backoffice.management.commands.syncroutes.requests.get')
     def test_fetches_csv_and_imports(self, mock_get):
         # Arrange
@@ -41,7 +35,7 @@ class SyncRoutesCommandTests(TestCase):
         out = StringIO()
 
         # Act
-        call_command('syncroutes', '--non-interactive', '--actor', self.actor.email, stdout=out)
+        call_command('syncroutes', '--non-interactive', stdout=out)
 
         # Assert
         mock_get.assert_called_once()
@@ -52,34 +46,15 @@ class SyncRoutesCommandTests(TestCase):
         self.assertEqual(route.elevation_gain, 123)
 
     @patch('backoffice.management.commands.syncroutes.requests.get')
-    def test_import_logs_audit_event_per_row(self, mock_get):
+    def test_import_does_not_log_audit_events(self, mock_get):
         # Arrange
         mock_get.return_value = FakeResponse(CSV_TEXT)
 
         # Act
-        call_command('syncroutes', '--non-interactive', '--actor', self.actor.email, stdout=StringIO())
+        call_command('syncroutes', '--non-interactive', stdout=StringIO())
 
         # Assert
-        audit_event = AuditEvent.objects.get()
-        self.assertEqual(audit_event.actor, self.actor)
-        self.assertEqual(audit_event.action, 'created')
-        self.assertEqual(audit_event.target, Route.objects.first())
-
-    @patch('backoffice.management.commands.syncroutes.requests.get')
-    def test_unknown_actor_aborts_with_command_error(self, mock_get):
-        # Arrange
-        mock_get.return_value = FakeResponse(CSV_TEXT)
-
-        # Act / Assert
-        with self.assertRaises(CommandError):
-            call_command('syncroutes', '--non-interactive', '--actor', 'nobody@example.com',
-                         stdout=StringIO())
-        self.assertEqual(Route.objects.count(), 0)
-
-    def test_missing_actor_aborts_with_command_error(self):
-        # Act / Assert
-        with self.assertRaises(CommandError):
-            call_command('syncroutes', '--non-interactive', stdout=StringIO())
+        self.assertFalse(AuditEvent.objects.exists())
 
     @patch('backoffice.management.commands.syncroutes.requests.get')
     def test_dry_run_does_not_persist(self, mock_get):
@@ -87,8 +62,7 @@ class SyncRoutesCommandTests(TestCase):
         mock_get.return_value = FakeResponse(CSV_TEXT)
 
         # Act
-        call_command('syncroutes', '--non-interactive', '--dry-run', '--actor', self.actor.email,
-                     stdout=StringIO())
+        call_command('syncroutes', '--non-interactive', '--dry-run', stdout=StringIO())
 
         # Assert
         self.assertEqual(Route.objects.count(), 0)
@@ -101,7 +75,7 @@ class SyncRoutesCommandTests(TestCase):
 
         # Act
         call_command('syncroutes', '--non-interactive', '--url', 'https://example.test/x.csv',
-                     '--actor', self.actor.email, stdout=StringIO())
+                     stdout=StringIO())
 
         # Assert
         called_url = mock_get.call_args[0][0]
@@ -114,5 +88,4 @@ class SyncRoutesCommandTests(TestCase):
 
         # Act / Assert
         with self.assertRaises(CommandError):
-            call_command('syncroutes', '--non-interactive', '--actor', self.actor.email,
-                         stdout=StringIO())
+            call_command('syncroutes', '--non-interactive', stdout=StringIO())

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -467,7 +467,7 @@ class EventEmergencyContactsViewTests(BaseEventViewTestCase):
         # Assert
         self.assertEqual(AuditEvent.objects.count(), 1)
         audit_event = AuditEvent.objects.get()
-        self.assertEqual(audit_event.action, 'revealed')
+        self.assertEqual(audit_event.action, 'emergency_contacts_revealed')
         self.assertEqual(audit_event.target, self.event)
 
     def test_staff_reveal_logs_audit_event(self):
@@ -480,7 +480,7 @@ class EventEmergencyContactsViewTests(BaseEventViewTestCase):
         # Assert
         self.assertEqual(AuditEvent.objects.count(), 1)
         audit_event = AuditEvent.objects.get()
-        self.assertEqual(audit_event.action, 'revealed')
+        self.assertEqual(audit_event.action, 'emergency_contacts_revealed')
         self.assertEqual(audit_event.target, self.event)
 
     def test_regular_user_denied_logs_no_audit_event(self):
@@ -513,7 +513,7 @@ class EventEmailsViewTests(BaseEventViewTestCase):
         self.assertIn('regular@example.com', emails)
         self.assertIn('leader@example.com', emails)
         audit_event = AuditEvent.objects.get()
-        self.assertEqual(audit_event.action, 'copied')
+        self.assertEqual(audit_event.action, 'all_emails_copied')
         self.assertEqual(audit_event.target, self.event)
 
     def test_leaders_type_returns_only_ride_leader_emails(self):
@@ -527,7 +527,7 @@ class EventEmailsViewTests(BaseEventViewTestCase):
         emails = response.content.decode()
         self.assertIn('leader@example.com', emails)
         self.assertNotIn('regular@example.com', emails)
-        self.assertEqual(AuditEvent.objects.get().action, 'copied')
+        self.assertEqual(AuditEvent.objects.get().action, 'ride_leader_emails_copied')
 
     def test_ride_leader_fetch_logs_audit_event(self):
         # Arrange
@@ -538,7 +538,7 @@ class EventEmailsViewTests(BaseEventViewTestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(AuditEvent.objects.get().action, 'copied')
+        self.assertEqual(AuditEvent.objects.get().action, 'all_emails_copied')
 
     def test_regular_user_denied(self):
         # Arrange

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -336,7 +336,7 @@ def event_emergency_contacts(request: HttpRequest, event_id: int) -> HttpRespons
     if not request.headers.get('HX-Request'):
         return redirect('riders_list', event_id=event_id)
 
-    AuditService().log(request.user, 'revealed', target=event)
+    AuditService().log(request.user, 'emergency_contacts_revealed', target=event)
 
     context = _build_registrations_context(request, event, contacts_revealed=True)
     return render(request, 'web/events/_registrations_list.html', context=context)
@@ -349,11 +349,11 @@ def event_emails(request: HttpRequest, event_id: int) -> HttpResponse:
     if not _is_confirmed_ride_leader(event_id, request.user) and not request.user.is_staff:
         raise PermissionDenied
 
-    emails = RegistrationService().fetch_confirmed_emails(
-        event, ride_leaders_only=request.GET.get('type') == 'leaders'
-    )
+    ride_leaders_only = request.GET.get('type') == 'leaders'
+    emails = RegistrationService().fetch_confirmed_emails(event, ride_leaders_only=ride_leaders_only)
 
-    AuditService().log(request.user, 'copied', target=event)
+    action = 'ride_leader_emails_copied' if ride_leaders_only else 'all_emails_copied'
+    AuditService().log(request.user, action, target=event)
     return HttpResponse(', '.join(emails), content_type='text/plain')
 
 


### PR DESCRIPTION
## Summary
- Renamed ambiguous audit action strings so the log can be scanned reliably: `revealed`→`emergency_contacts_revealed`, `copied`→`all_emails_copied`/`ride_leader_emails_copied` (split by which set of emails was fetched), `withdrawn`→`staff_withdrew`, staff `registered`→`staff_registered`, staff registration `updated`→`staff_edited`.
- Removed `Registration` from `backoffice/signals.py`'s `AUDITED_MODELS` — all registration mutations go through `RegistrationService`, which already logs its own specific action, so the generic signal was redundant.
- Route sync/import (`syncroutes`/`importroutes` commands) no longer write audit events — only admin-interface edits to routes should be audited. Dropped the now-unused `--actor` CLI arg from both commands.

## Test plan
- [x] `uv run python manage.py test backoffice audit web` — 610 tests pass