### PR TITLE
Harden production security configuration

### DIFF
--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -19,8 +19,16 @@ WEB_HOST = os.environ.get('WEB_HOST', 'obcrides.ca')
 RWGPS_ORG_SLUG = os.environ.get('RWGPS_ORG_SLUG', '3471-ottawa-bicycle-club')
 
 if IS_HEROKU_APP:
-    ALLOWED_HOSTS = ["*"]
+    ALLOWED_HOSTS = [WEB_HOST] + [
+        h.strip() for h in os.environ.get('EXTRA_ALLOWED_HOSTS', '').split(',') if h.strip()
+    ]
     SECURE_SSL_REDIRECT = True
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 60 * 60 * 24 * 365
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
     DEBUG = False
     assert SECRET_KEY != SECRET_KEY_FOR_DEVELOPMENT
 else:
@@ -171,13 +179,30 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
 
+SENTRY_SCRUB_QUERY_PARAMS = ('token', 'sesame')
+
+
+def _scrub_sentry_event(event, hint):
+    request = event.get('request')
+    if request and request.get('query_string'):
+        query = request['query_string']
+        if any(param in query for param in SENTRY_SCRUB_QUERY_PARAMS):
+            request['query_string'] = '[Filtered]'
+        url = request.get('url')
+        if url and '?' in url and any(param in url for param in SENTRY_SCRUB_QUERY_PARAMS):
+            request['url'] = url.split('?', 1)[0]
+    return event
+
+
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=os.environ.get('SENTRY_DSN', SENTRY_DSN),
-        send_default_pii=True,
-        traces_sample_rate=1.0,
+        send_default_pii=False,
+        traces_sample_rate=float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', '0.1')),
         integrations=[DjangoIntegration(), CeleryIntegration()],
         release=os.environ.get('HEROKU_RELEASE_VERSION', 'unknown'),
+        before_send=_scrub_sentry_event,
+        before_send_transaction=_scrub_sentry_event,
         _experiments={
             'enable_logs': True,
         }

--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -182,15 +182,26 @@ SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
 SENTRY_SCRUB_QUERY_PARAMS = ('token', 'sesame')
 
 
+def _sentry_traces_sample_rate() -> float:
+    try:
+        return float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', '0.1'))
+    except (TypeError, ValueError):
+        return 0.1
+
+
 def _scrub_sentry_event(event, hint):
     request = event.get('request')
-    if request and request.get('query_string'):
-        query = request['query_string']
-        if any(param in query for param in SENTRY_SCRUB_QUERY_PARAMS):
-            request['query_string'] = '[Filtered]'
-        url = request.get('url')
-        if url and '?' in url and any(param in url for param in SENTRY_SCRUB_QUERY_PARAMS):
-            request['url'] = url.split('?', 1)[0]
+    if not request:
+        return event
+
+    query = request.get('query_string') or ''
+    if any(param in query for param in SENTRY_SCRUB_QUERY_PARAMS):
+        request['query_string'] = '[Filtered]'
+
+    url = request.get('url') or ''
+    if '?' in url and any(param in url for param in SENTRY_SCRUB_QUERY_PARAMS):
+        request['url'] = url.split('?', 1)[0]
+
     return event
 
 
@@ -198,7 +209,7 @@ if SENTRY_DSN:
     sentry_sdk.init(
         dsn=os.environ.get('SENTRY_DSN', SENTRY_DSN),
         send_default_pii=False,
-        traces_sample_rate=float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', '0.1')),
+        traces_sample_rate=_sentry_traces_sample_rate(),
         integrations=[DjangoIntegration(), CeleryIntegration()],
         release=os.environ.get('HEROKU_RELEASE_VERSION', 'unknown'),
         before_send=_scrub_sentry_event,

--- a/web/views/login.py
+++ b/web/views/login.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth import logout
 from django.contrib.auth.models import User
@@ -29,15 +30,13 @@ class LoginFormView(FormView):
             return None
 
     def _create_link(self, user: User) -> str:
-        link = reverse("login")
-        link = self.request.build_absolute_uri(link)
+        link = f"https://{settings.WEB_HOST}{reverse('login')}"
         link += get_query_string(user)
         return link
 
     def _send_email(self, user: User, link: str) -> None:
-        # Build base URL from the request
-        base_url = self.request.build_absolute_uri('/').rstrip('/')
-        
+        base_url = f"https://{settings.WEB_HOST}"
+
         context = {
             'login_link': link,
             'base_url': base_url,

--- a/web/views/login.py
+++ b/web/views/login.py
@@ -35,7 +35,8 @@ class LoginFormView(FormView):
         return link
 
     def _send_email(self, user: User, link: str) -> None:
-        base_url = f"https://{settings.WEB_HOST}"
+        protocol = 'https' if getattr(settings, 'SECURE_SSL_REDIRECT', False) else 'http'
+        base_url = f"{protocol}://{settings.WEB_HOST}"
 
         context = {
             'login_link': link,

--- a/web/views/login.py
+++ b/web/views/login.py
@@ -29,14 +29,17 @@ class LoginFormView(FormView):
         except User.DoesNotExist:
             return None
 
+    def _base_url(self) -> str:
+        protocol = 'https' if getattr(settings, 'SECURE_SSL_REDIRECT', False) else 'http'
+        return f"{protocol}://{settings.WEB_HOST}"
+
     def _create_link(self, user: User) -> str:
-        link = f"https://{settings.WEB_HOST}{reverse('login')}"
+        link = f"{self._base_url()}{reverse('login')}"
         link += get_query_string(user)
         return link
 
     def _send_email(self, user: User, link: str) -> None:
-        protocol = 'https' if getattr(settings, 'SECURE_SSL_REDIRECT', False) else 'http'
-        base_url = f"{protocol}://{settings.WEB_HOST}"
+        base_url = self._base_url()
 
         context = {
             'login_link': link,


### PR DESCRIPTION
Addresses three findings from the 2026-07-04 security audit (config-only; no behavior change for normal traffic).

## Changes

**Finding 2 — Sentry PII exfiltration**
- `send_default_pii=True` -> `False`
- `traces_sample_rate=1.0` -> `0.1` (override via `SENTRY_TRACES_SAMPLE_RATE`)
- Added `before_send`/`before_send_transaction` scrubber that filters `token` and `sesame` query params out of captured request URLs and query strings — these carry login/verification credentials.

**Finding 4 — Host-header poisoning of login links**
- `ALLOWED_HOSTS = [*]` -> `[WEB_HOST]` plus optional comma-separated `EXTRA_ALLOWED_HOSTS`.
- Emailed login links now build from `settings.WEB_HOST` instead of the request `Host` header, so an attacker cannot POST a victim's email with `Host: evil.com` and have the sesame token delivered to their domain. Matches how verification emails already work.

**Finding 5 — Missing production security headers** (inside `IS_HEROKU_APP`)
- `SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')`
- `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`
- HSTS: 1 year, include subdomains, preload

## Deferred (follow-up)
- Finding 1 — anonymous registration overwriting existing users PII
- Finding 3 — rate limiting on public email/user-creation endpoints

Full findings in `security-audit-20260704.md`.

## Testing
- Full suite: 270 tests pass.
- Sentry scrubber verified with a standalone assert check (filters token/sesame URLs, leaves `?q=` untouched).

## Deploy note
Set `EXTRA_ALLOWED_HOSTS` on Heroku if any host other than `WEB_HOST` (e.g. the `*.herokuapp.com` domain) must serve traffic, otherwise those requests will 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrntPbz8tBq7AZ6iYG38ki