### PR TITLE
Stop anonymous registration from overwriting an existing user's PII

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -15,6 +15,7 @@ from backoffice.models import Event, Registration, SpeedRange, Ride, UserProfile
 from backoffice.services.email_service import EmailService
 from backoffice.services.request_service import RequestDetail
 from backoffice.services.user_service import UserService, UserDetail
+from backoffice.utils import lower_email
 from ridehub import settings
 
 logger = logging.getLogger(__name__)
@@ -82,17 +83,18 @@ class RegistrationService:
         self.email_service = EmailService()
         self.audit_service = AuditService()
 
-    def _create_registration(self, event: Event, user: User, registration_detail: RegistrationDetail,
+    def _create_registration(self, event: Event, user: User, user_detail: UserDetail,
+                             registration_detail: RegistrationDetail,
                              request_detail: RequestDetail | None = None) -> Registration:
         registration = Registration()
         registration.event = event
         registration.user = user
 
-        registration.name = user.get_full_name()
-        registration.first_name = user.first_name
-        registration.last_name = user.last_name
+        registration.name = f"{user_detail.first_name} {user_detail.last_name}"
+        registration.first_name = user_detail.first_name
+        registration.last_name = user_detail.last_name
         registration.email = user.email
-        registration.phone = user.profile.phone
+        registration.phone = user_detail.phone
 
         if event.has_rides:
             registration.ride = registration_detail.ride
@@ -203,8 +205,13 @@ class RegistrationService:
         return registration, None
 
     def register(self, user_detail: UserDetail, registration_detail: RegistrationDetail, event: Event,
-                 request_detail: RequestDetail | None = None) -> RegistrationResult:
-        user = self.user_service.find_by_email_or_create(user_detail)
+                 request_detail: RequestDetail | None = None, acting_user: User | None = None) -> RegistrationResult:
+        update_existing = (
+            acting_user is not None
+            and acting_user.is_authenticated
+            and lower_email(acting_user.email) == lower_email(user_detail.email)
+        )
+        user = self.user_service.find_by_email_or_create(user_detail, update_existing=update_existing)
 
         active_registrations = Registration.objects.filter(
             user=user, event=event,
@@ -217,7 +224,7 @@ class RegistrationService:
             )
             return RegistrationResult.DUPLICATE
 
-        registration = self._create_registration(event, user, registration_detail, request_detail)
+        registration = self._create_registration(event, user, user_detail, registration_detail, request_detail)
 
         if self._should_skip_verification(user, request_detail):
             self._send_confirmation_email(registration)
@@ -401,7 +408,7 @@ class RegistrationService:
 
     def staff_register(self, user_detail: UserDetail, registration_detail: RegistrationDetail,
                        event: Event, staff_user) -> Registration | None:
-        user = self.user_service.find_by_email_or_create(user_detail)
+        user = self.user_service.find_by_email_or_create(user_detail, update_existing=True)
 
         existing = Registration.objects.filter(
             user=user, event=event,
@@ -415,7 +422,7 @@ class RegistrationService:
             )
             return None
 
-        registration = self._create_registration(event, user, registration_detail)
+        registration = self._create_registration(event, user, user_detail, registration_detail)
         registration.confirm()
         registration.save()
 

--- a/backoffice/services/user_service.py
+++ b/backoffice/services/user_service.py
@@ -34,42 +34,34 @@ class UserService(object):
         else:
             return Nothing
 
-    def find_by_email_or_create(self, user_detail: UserDetail) -> User:
+    def _apply_user_detail(self, user: User, user_detail: UserDetail) -> None:
+        if not user.is_staff and user.has_usable_password():
+            user.set_unusable_password()
+
+        user.first_name = user_detail.first_name
+        user.last_name = user_detail.last_name
+        user.save()
+
+        user.profile.phone = user_detail.phone
+        if user_detail.emergency_contact_name:
+            user.profile.emergency_contact_name = user_detail.emergency_contact_name
+        if user_detail.emergency_contact_phone:
+            user.profile.emergency_contact_phone = user_detail.emergency_contact_phone
+        user.profile.save()
+
+    def find_by_email_or_create(self, user_detail: UserDetail, update_existing: bool = False) -> User:
         lowercase_email = lower_email(user_detail.email)
 
         match self.find_by_email(lowercase_email):
             case Some(user):
-                if not user.is_staff and user.has_usable_password():
-                    user.set_unusable_password()
-
-                user.first_name = user_detail.first_name
-                user.last_name = user_detail.last_name
-                user.save()
-
-                user.profile.phone = user_detail.phone
-                if user_detail.emergency_contact_name:
-                    user.profile.emergency_contact_name = user_detail.emergency_contact_name
-                if user_detail.emergency_contact_phone:
-                    user.profile.emergency_contact_phone = user_detail.emergency_contact_phone
-                user.profile.save()
-
+                if update_existing:
+                    self._apply_user_detail(user, user_detail)
                 return user
             case _:
                 user = User.objects.create_user(
                     username=lowercase_email,
                     email=lowercase_email,
-                    first_name=user_detail.first_name,
-                    last_name=user_detail.last_name,
                 )
-
                 user.set_unusable_password()
-                user.save()
-
-                user.profile.phone = user_detail.phone
-                if user_detail.emergency_contact_name:
-                    user.profile.emergency_contact_name = user_detail.emergency_contact_name
-                if user_detail.emergency_contact_phone:
-                    user.profile.emergency_contact_phone = user_detail.emergency_contact_phone
-                user.profile.save()
-
+                self._apply_user_detail(user, user_detail)
                 return user

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -1769,6 +1769,109 @@ class RegisterMethodTestCase(TestCase):
         self.assertEqual(registration.user, user)
         self.assertEqual(registration.email, "existing@example.com")
 
+    def test_register_does_not_overwrite_existing_user_pii_when_anonymous(self):
+        # Arrange
+        user = User.objects.create_user(
+            username='victim',
+            email='victim@example.com',
+            first_name='Real',
+            last_name='Member',
+        )
+        user.profile.phone = "+16135551111"
+        user.profile.save()
+
+        attacker_detail = UserDetail(
+            first_name="Injected",
+            last_name="Name",
+            email="victim@example.com",
+            phone="+16135559999",
+        )
+        registration_detail = RegistrationDetail(
+            ride=None, ride_leader_preference=None, speed_range_preference=None,
+            emergency_contact_name=None, emergency_contact_phone=None,
+        )
+
+        # Act
+        self.service.register(attacker_detail, registration_detail, self.event, acting_user=None)
+
+        # Assert
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, "Real")
+        self.assertEqual(user.last_name, "Member")
+        user.profile.refresh_from_db()
+        self.assertEqual(user.profile.phone, "+16135551111")
+
+    def test_register_updates_existing_user_pii_when_authenticated_self(self):
+        # Arrange
+        user = User.objects.create_user(
+            username='selfreg',
+            email='selfreg@example.com',
+            first_name='Old',
+            last_name='Name',
+        )
+        user.profile.phone = "+16135551111"
+        user.profile.email_verified = True
+        user.profile.save()
+
+        updated_detail = UserDetail(
+            first_name="New",
+            last_name="Name",
+            email="selfreg@example.com",
+            phone="+16135552222",
+        )
+        registration_detail = RegistrationDetail(
+            ride=None, ride_leader_preference=None, speed_range_preference=None,
+            emergency_contact_name=None, emergency_contact_phone=None,
+        )
+
+        # Act
+        self.service.register(updated_detail, registration_detail, self.event, acting_user=user)
+
+        # Assert
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, "New")
+        user.profile.refresh_from_db()
+        self.assertEqual(user.profile.phone, "+16135552222")
+
+    def test_register_does_not_overwrite_other_users_pii_when_authenticated(self):
+        # Arrange
+        victim = User.objects.create_user(
+            username='othervictim',
+            email='othervictim@example.com',
+            first_name='Real',
+            last_name='Member',
+        )
+        victim.profile.phone = "+16135551111"
+        victim.profile.save()
+
+        attacker = User.objects.create_user(
+            username='attacker',
+            email='attacker@example.com',
+            first_name='Mal',
+            last_name='Actor',
+        )
+
+        forged_detail = UserDetail(
+            first_name="Injected",
+            last_name="Name",
+            email="othervictim@example.com",
+            phone="+16135559999",
+        )
+        registration_detail = RegistrationDetail(
+            ride=None, ride_leader_preference=None, speed_range_preference=None,
+            emergency_contact_name=None, emergency_contact_phone=None,
+        )
+
+        # Act
+        self.service.register(forged_detail, registration_detail, self.event, acting_user=attacker)
+
+        # Assert
+        victim.refresh_from_db()
+        self.assertEqual(victim.first_name, "Real")
+        self.assertEqual(victim.last_name, "Member")
+        victim.profile.refresh_from_db()
+        self.assertEqual(victim.profile.phone, "+16135551111")
+
     def test_register_creates_new_user_when_email_not_exists(self):
         user_detail = UserDetail(
             first_name="New",

--- a/backoffice/tests/services/test_user_service.py
+++ b/backoffice/tests/services/test_user_service.py
@@ -163,6 +163,35 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         # Check it was actually created
         self.assertTrue(User.objects.filter(email=self.test_email).exists())
 
+    def test_find_by_email_or_create_does_not_update_existing_by_default(self):
+        # Arrange
+        user = User.objects.get(email=self.non_staff_email)
+        user.profile.emergency_contact_name = "Original Contact"
+        user.profile.emergency_contact_phone = "613-555-0100"
+        user.profile.save()
+
+        attacker_detail = UserDetail(
+            first_name="Attacker",
+            last_name="Injected",
+            email=self.non_staff_email,
+            phone="+16135550000",
+            emergency_contact_name="Attacker Contact",
+            emergency_contact_phone="613-555-9999",
+        )
+
+        # Act
+        result = self.service.find_by_email_or_create(attacker_detail)
+
+        # Assert
+        self.assertEqual(result.pk, user.pk)
+        result.refresh_from_db()
+        self.assertEqual(result.first_name, "Old")
+        self.assertEqual(result.last_name, "Name")
+        result.profile.refresh_from_db()
+        self.assertEqual(result.profile.phone, "+16135558888")
+        self.assertEqual(result.profile.emergency_contact_name, "Original Contact")
+        self.assertEqual(result.profile.emergency_contact_phone, "613-555-0100")
+
     def test_find_by_email_or_create_when_non_staff_user_exists(self):
         # Arrange
         user_detail_upper = UserDetail(
@@ -173,7 +202,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
 
         # Act
-        user = self.service.find_by_email_or_create(user_detail_upper)
+        user = self.service.find_by_email_or_create(user_detail_upper, update_existing=True)
 
         # Assert
         self.assertEqual(user.email, self.non_staff_email) # Original email
@@ -199,7 +228,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
         
         # Act
-        user = self.service.find_by_email_or_create(user_detail_mixed)
+        user = self.service.find_by_email_or_create(user_detail_mixed, update_existing=True)
 
         # Assert
         self.assertEqual(user.email, self.staff_email) # Original email
@@ -215,7 +244,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         non_staff_detail_upper = UserDetail("NewNon", "Staff", "NONSTAFFCASING@EXAMPLE.COM", "+16135552222")
         
         # Act
-        updated_non_staff = self.service.find_by_email_or_create(non_staff_detail_upper)
+        updated_non_staff = self.service.find_by_email_or_create(non_staff_detail_upper, update_existing=True)
         
         # Assert
         self.assertEqual(updated_non_staff.email, self.non_staff_casing_email)
@@ -235,7 +264,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         staff_detail_mixed = UserDetail("New", "Staff", "StaffCasing@Example.com", "+16135552222")
 
         # Act
-        found_staff = self.service.find_by_email_or_create(staff_detail_mixed)
+        found_staff = self.service.find_by_email_or_create(staff_detail_mixed, update_existing=True)
 
         # Assert
         self.assertEqual(found_staff.email, self.staff_casing_email)
@@ -257,7 +286,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
 
         # Act
-        self.service.find_by_email_or_create(user_detail)
+        self.service.find_by_email_or_create(user_detail, update_existing=True)
 
         # Assert
         user.refresh_from_db()
@@ -276,7 +305,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
 
         # Act
-        self.service.find_by_email_or_create(user_detail)
+        self.service.find_by_email_or_create(user_detail, update_existing=True)
 
         # Assert
         user.refresh_from_db()
@@ -313,7 +342,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
 
         # Act
-        user = self.service.find_by_email_or_create(user_detail)
+        user = self.service.find_by_email_or_create(user_detail, update_existing=True)
 
         # Assert
         profile = UserProfile.objects.get(user=user)
@@ -335,7 +364,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
 
         # Act
-        self.service.find_by_email_or_create(user_detail)
+        self.service.find_by_email_or_create(user_detail, update_existing=True)
 
         # Assert
         user.profile.refresh_from_db()
@@ -359,7 +388,7 @@ class TestUserServiceFindByEmailOrCreate(TestCase):
         )
 
         # Act
-        self.service.find_by_email_or_create(user_detail)
+        self.service.find_by_email_or_create(user_detail, update_existing=True)
 
         # Assert
         user.profile.refresh_from_db()

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -141,6 +141,35 @@ class RegistrationViewPhoneTests(TestCase):
         self.assertTrue(hasattr(user, 'profile'))
         self.assertEqual(str(user.profile.phone), '+16139876543')
 
+    def test_anonymous_registration_does_not_overwrite_existing_user_pii(self):
+        # Arrange
+        user = User.objects.create_user(
+            username='victim@example.com',
+            email='victim@example.com',
+            first_name='Real',
+            last_name='Member',
+        )
+        user.profile.phone = '+16135550100'
+        user.profile.save()
+
+        form_data = {
+            'first_name': 'Injected',
+            'last_name': 'Name',
+            'email': 'victim@example.com',
+            'phone': '+16139999999',
+        }
+
+        # Act - anonymous (not logged in) submission targeting the victim's email
+        response = self.client.post(reverse('registration_create', args=[self.event.id]), form_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, 'Real')
+        self.assertEqual(user.last_name, 'Member')
+        user.profile.refresh_from_db()
+        self.assertEqual(str(user.profile.phone), '+16135550100')
+
     def test_registration_form_stores_phone_in_registration_record(self):
         # Arrange
         user = User.objects.create_user(
@@ -149,7 +178,7 @@ class RegistrationViewPhoneTests(TestCase):
             first_name='Phone',
             last_name='Test'
         )
-        
+
         self.client.force_login(user)
 
         form_data = {

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -101,7 +101,8 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
                 user_detail=user_detail,
                 registration_detail=_get_registration_detail(form),
                 event=event,
-                request_detail=request_detail)
+                request_detail=request_detail,
+                acting_user=request.user if request.user.is_authenticated else None)
 
             if result == RegistrationResult.VERIFICATION_REQUIRED:
                 return redirect('registration_verification_sent')


### PR DESCRIPTION
Fixes finding 1 from the 2026-07-04 security audit (the highest-severity item).

## The vulnerability
The public registration form (`/events/<id>/registration`, no login required) called `UserService.find_by_email_or_create`. When the submitted email matched an existing account, it **immediately overwrote** that account's `first_name`, `last_name`, `phone`, and emergency contacts with whatever the submitter typed — before any email verification. Anyone who knew a member's email could corrupt their profile, and the injected name then appeared on public rider lists.

## Root cause
Two coupled problems:
1. `find_by_email_or_create` mutated existing accounts unconditionally.
2. `_create_registration` snapshotted the registration from the (just-mutated) `User` object, so the mutation looked necessary.

## Fix
Separate the shared account from the per-registration snapshot:

- **`find_by_email_or_create(user_detail, update_existing=False)`** — existing accounts are no longer touched unless the caller opts in. New accounts are still populated (nothing to protect). The mutation logic is extracted into `_apply_user_detail`.
- **`register(...)`** sets `update_existing=True` only when the acting user is authenticated **and** owns the submitted email (`acting_user.email == user_detail.email`), so a logged-in user cannot overwrite someone *else's* account either. The view passes `acting_user=request.user` when authenticated.
- **`staff_register(...)`** passes `update_existing=True` (staff are trusted).
- **`_create_registration`** now snapshots `first_name`/`last_name`/`phone` from the submitted `user_detail`, so the registration record is correct without mutating the account.

## Behavior preserved
- Authenticated users registering themselves still get their profile updated (existing test `test_registration_form_submission_updates_existing_profile` still passes).
- New-user registration unchanged.
- Staff add/edit unchanged.

## Tests (all 615 pass)
- `test_anonymous_registration_does_not_overwrite_existing_user_pii` — full HTTP view, the actual attack.
- `test_register_does_not_overwrite_existing_user_pii_when_anonymous`
- `test_register_updates_existing_user_pii_when_authenticated_self`
- `test_register_does_not_overwrite_other_users_pii_when_authenticated`
- `test_find_by_email_or_create_does_not_update_existing_by_default`
- Existing user-service tests that asserted updates now pass `update_existing=True` explicitly.

## Note / follow-up (out of scope)
A separate weakness remains: for an account with `email_verified=True`, an anonymous registration auto-confirms without the account owner acting (creating a spurious confirmed registration in their name). That is registration/identity spoofing, tied to the deferred authentication hardening task — not this PII-overwrite fix. Worth tracking there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrntPbz8tBq7AZ6iYG38ki