### PR TITLE
Add registration speed run mode with collapsible contact sections

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -54,19 +54,6 @@ class RegistrationForm(forms.Form):
         requirements = registration_service.get_event_requirements(event)
         rides = registration_service.get_rides_for_event(event)
 
-        if rides.exists():
-            self.fields['ride'] = forms.ModelChoiceField(
-                queryset=rides,
-                label="Ride",
-                required=True
-            )
-
-            self.fields['speed_range_preference'] = forms.ModelChoiceField(
-                queryset=SpeedRange.objects.all(),
-                label="Speed range preference",
-                required=False
-            )
-
         if requirements.requires_emergency_contact:
             self.fields['emergency_contact_name'] = forms.CharField(
                 max_length=128,
@@ -86,6 +73,19 @@ class RegistrationForm(forms.Form):
                     'type': 'tel',
                     'autocomplete': 'off'
                 })
+            )
+
+        if rides.exists():
+            self.fields['ride'] = forms.ModelChoiceField(
+                queryset=rides,
+                label="Ride",
+                required=True
+            )
+
+            self.fields['speed_range_preference'] = forms.ModelChoiceField(
+                queryset=SpeedRange.objects.all(),
+                label="Speed range preference",
+                required=False
             )
 
         if requirements.ride_leaders_wanted:

--- a/web/templates/web/events/_registration_field.html
+++ b/web/templates/web/events/_registration_field.html
@@ -1,0 +1,12 @@
+{% load form_filters %}
+<div class="mb-3">
+    <label for="{{ field.id_for_label }}"
+           class="form-label fw-medium">{{ field.label }}</label>
+    {{ field|addclass:"form-control" }}
+    {% if field.errors %}
+        <div class="small text-danger mt-1">{{ field.errors }}</div>
+    {% endif %}
+    {% if field.help_text %}
+        <div class="form-text small">{{ field.help_text }}</div>
+    {% endif %}
+</div>

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -55,6 +55,7 @@
                     {% endif %}
 
                     <div class="mb-4">
+                        {% if speed_run %}
                         <h3 class="fs-6 fw-semibold mb-3">Your details</h3>
                         {% if contact_collapsed %}
                             <div class="collapse show" id="contact-preview">
@@ -105,9 +106,13 @@
                             <hr class="my-4 opacity-25">
                             <h3 class="fs-6 fw-semibold mb-3">Event details</h3>
                         {% endif %}
+                        {% endif %}
 
                         {% for field in form %}
                             {% if field.name == 'first_name' or field.name == 'last_name' or field.name == 'email' or field.name == 'phone' or field.name == 'emergency_contact_name' or field.name == 'emergency_contact_phone' %}
+                                {% if not speed_run %}
+                                    {% include 'web/events/_registration_field.html' with field=field %}
+                                {% endif %}
                             {% elif field.name == 'ride_leader_preference' or field.name == 'first_time_attendee' %}
                                 <div class="mb-3">
                                     <div class="form-check">

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -61,12 +61,12 @@
                             <div class="collapse show" id="contact-preview">
                                 <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
                                     <div class="min-w-0">
-                                        <div class="fw-medium">{{ form.first_name.value }} {{ form.last_name.value }}</div>
-                                        <div class="text-muted small">{{ form.email.value }} · {{ form.phone.value }}</div>
+                                        <div class="fw-medium" id="contact-preview-name">{{ form.first_name.value }} {{ form.last_name.value }}</div>
+                                        <div class="text-muted small" id="contact-preview-meta">{{ form.email.value }} · {{ form.phone.value }}</div>
                                     </div>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
                                             data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
-                                            aria-expanded="false" aria-controls="contact-fields">
+                                            aria-expanded="false" aria-controls="contact-preview contact-fields">
                                         <i class="bi bi-pencil me-1"></i>Edit
                                     </button>
                                 </div>
@@ -77,6 +77,15 @@
                             {% include 'web/events/_registration_field.html' with field=form.last_name %}
                             {% include 'web/events/_registration_field.html' with field=form.email %}
                             {% include 'web/events/_registration_field.html' with field=form.phone %}
+                            {% if contact_collapsed %}
+                                <div class="text-end mb-3">
+                                    <button type="button" class="btn btn-link btn-sm p-0 text-decoration-none"
+                                            data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
+                                            aria-expanded="true" aria-controls="contact-preview contact-fields">
+                                        <i class="bi bi-chevron-up me-1"></i>Show less
+                                    </button>
+                                </div>
+                            {% endif %}
                         </div>
 
                         {% if form.emergency_contact_name %}
@@ -85,12 +94,12 @@
                                 <div class="collapse show" id="emergency-preview">
                                     <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
                                         <div class="min-w-0">
-                                            <div class="fw-medium">{{ form.emergency_contact_name.value }}</div>
-                                            <div class="text-muted small">{{ form.emergency_contact_phone.value }}</div>
+                                            <div class="fw-medium" id="emergency-preview-name">{{ form.emergency_contact_name.value }}</div>
+                                            <div class="text-muted small" id="emergency-preview-meta">{{ form.emergency_contact_phone.value }}</div>
                                         </div>
                                         <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
                                                 data-bs-toggle="collapse" data-bs-target="#emergency-preview, #emergency-fields"
-                                                aria-expanded="false" aria-controls="emergency-fields">
+                                                aria-expanded="false" aria-controls="emergency-preview emergency-fields">
                                             <i class="bi bi-pencil me-1"></i>Edit
                                         </button>
                                     </div>
@@ -99,6 +108,15 @@
                             <div{% if emergency_collapsed %} class="collapse"{% endif %} id="emergency-fields">
                                 {% include 'web/events/_registration_field.html' with field=form.emergency_contact_name %}
                                 {% include 'web/events/_registration_field.html' with field=form.emergency_contact_phone %}
+                                {% if emergency_collapsed %}
+                                    <div class="text-end mb-3">
+                                        <button type="button" class="btn btn-link btn-sm p-0 text-decoration-none"
+                                                data-bs-toggle="collapse" data-bs-target="#emergency-preview, #emergency-fields"
+                                                aria-expanded="true" aria-controls="emergency-preview emergency-fields">
+                                            <i class="bi bi-chevron-up me-1"></i>Show less
+                                        </button>
+                                    </div>
+                                {% endif %}
                             </div>
                         {% endif %}
 
@@ -196,6 +214,29 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+            function bindPreviewSync(previewId, render) {
+                const preview = document.getElementById(previewId);
+                if (preview) {
+                    preview.addEventListener('show.bs.collapse', render);
+                }
+            }
+
+            bindPreviewSync('contact-preview', function () {
+                const first = document.getElementById('id_first_name').value.trim();
+                const last = document.getElementById('id_last_name').value.trim();
+                const email = document.getElementById('id_email').value.trim();
+                const phone = document.getElementById('id_phone').value.trim();
+                document.getElementById('contact-preview-name').textContent = first + ' ' + last;
+                document.getElementById('contact-preview-meta').textContent = email + ' · ' + phone;
+            });
+
+            bindPreviewSync('emergency-preview', function () {
+                const name = document.getElementById('id_emergency_contact_name').value.trim();
+                const phone = document.getElementById('id_emergency_contact_phone').value.trim();
+                document.getElementById('emergency-preview-name').textContent = name;
+                document.getElementById('emergency-preview-meta').textContent = phone;
+            });
+
             const rideSelect = document.getElementById('id_ride');
             const speedRangeContainer = document.getElementById('speed-range-container');
 

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -55,9 +55,59 @@
                     {% endif %}
 
                     <div class="mb-4">
+                        <h3 class="fs-6 fw-semibold mb-3">Your details</h3>
+                        {% if contact_collapsed %}
+                            <div class="collapse show" id="contact-preview">
+                                <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
+                                    <div class="min-w-0">
+                                        <div class="fw-medium">{{ form.first_name.value }} {{ form.last_name.value }}</div>
+                                        <div class="text-muted small">{{ form.email.value }} · {{ form.phone.value }}</div>
+                                    </div>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
+                                            data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
+                                            aria-expanded="false" aria-controls="contact-fields">
+                                        <i class="bi bi-pencil me-1"></i>Edit
+                                    </button>
+                                </div>
+                            </div>
+                        {% endif %}
+                        <div{% if contact_collapsed %} class="collapse"{% endif %} id="contact-fields">
+                            {% include 'web/events/_registration_field.html' with field=form.first_name %}
+                            {% include 'web/events/_registration_field.html' with field=form.last_name %}
+                            {% include 'web/events/_registration_field.html' with field=form.email %}
+                            {% include 'web/events/_registration_field.html' with field=form.phone %}
+                        </div>
+
+                        {% if form.emergency_contact_name %}
+                            <h3 class="fs-6 fw-semibold mb-3 mt-4">Emergency contact</h3>
+                            {% if emergency_collapsed %}
+                                <div class="collapse show" id="emergency-preview">
+                                    <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
+                                        <div class="min-w-0">
+                                            <div class="fw-medium">{{ form.emergency_contact_name.value }}</div>
+                                            <div class="text-muted small">{{ form.emergency_contact_phone.value }}</div>
+                                        </div>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
+                                                data-bs-toggle="collapse" data-bs-target="#emergency-preview, #emergency-fields"
+                                                aria-expanded="false" aria-controls="emergency-fields">
+                                            <i class="bi bi-pencil me-1"></i>Edit
+                                        </button>
+                                    </div>
+                                </div>
+                            {% endif %}
+                            <div{% if emergency_collapsed %} class="collapse"{% endif %} id="emergency-fields">
+                                {% include 'web/events/_registration_field.html' with field=form.emergency_contact_name %}
+                                {% include 'web/events/_registration_field.html' with field=form.emergency_contact_phone %}
+                            </div>
+                        {% endif %}
+
+                        {% if has_event_fields %}
+                            <hr class="my-4 opacity-25">
+                            <h3 class="fs-6 fw-semibold mb-3">Event details</h3>
+                        {% endif %}
+
                         {% for field in form %}
-                            {% if field.name == 'event' %}
-                                {{ field }} <!-- Hidden field, no need for label -->
+                            {% if field.name == 'first_name' or field.name == 'last_name' or field.name == 'email' or field.name == 'phone' or field.name == 'emergency_contact_name' or field.name == 'emergency_contact_phone' %}
                             {% elif field.name == 'ride_leader_preference' or field.name == 'first_time_attendee' %}
                                 <div class="mb-3">
                                     <div class="form-check">
@@ -111,19 +161,6 @@
                                             <option value="">Please select a ride first</option>
                                         </select>
                                     </div>
-                                    {% if field.errors %}
-                                        <div class="small text-danger mt-1">{{ field.errors }}</div>
-                                    {% endif %}
-                                    {% if field.help_text %}
-                                        <div class="form-text small">{{ field.help_text }}</div>
-                                    {% endif %}
-                                </div>
-                            {% elif field.name == 'emergency_contact_phone' %}
-                                <div class="mb-3">
-                                    <label for="{{ field.id_for_label }}"
-                                           class="form-label fw-medium">{{ field.label }}</label>
-                                    <input type="tel" name="{{ field.name }}" id="{{ field.id_for_label }}"
-                                           value="{{ field.value|default:'' }}" class="form-control" required>
                                     {% if field.errors %}
                                         <div class="small text-danger mt-1">{{ field.errors }}</div>
                                     {% endif %}

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1,4 +1,5 @@
 from django.core.signing import TimestampSigner
+from waffle.testutils import override_flag
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -380,6 +381,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         user.profile.save()
         return user
 
+    @override_flag('registration_speed_run', active=True)
     def test_contact_section_collapsed_for_signed_in_user_with_complete_details(self):
         # Arrange
         user = self._create_user()
@@ -393,6 +395,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertTrue(response.context['contact_collapsed'])
         self.assertTrue(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_contact_section_expanded_for_anonymous_user(self):
         # Act
         response = self.client.get(reverse('registration_create', args=[self.event.id]))
@@ -402,6 +405,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertFalse(response.context['contact_collapsed'])
         self.assertFalse(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_contact_section_expanded_when_phone_missing(self):
         # Arrange
         user = self._create_user(with_phone=False)
@@ -415,6 +419,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertFalse(response.context['contact_collapsed'])
         self.assertTrue(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_emergency_section_expanded_when_no_emergency_contact_on_profile(self):
         # Arrange
         user = self._create_user(with_emergency_contact=False)
@@ -428,6 +433,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertTrue(response.context['contact_collapsed'])
         self.assertFalse(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_emergency_section_not_collapsed_when_event_does_not_require_it(self):
         # Arrange
         event = Event.objects.create(
@@ -449,6 +455,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_contact_section_expanded_when_contact_field_has_error(self):
         # Arrange
         user = self._create_user()
@@ -471,6 +478,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertFalse(response.context['contact_collapsed'])
         self.assertTrue(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_contact_section_stays_collapsed_when_error_is_elsewhere(self):
         # Arrange
         route = Route.objects.create(name="Test Route")
@@ -498,6 +506,7 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.assertTrue(response.context['contact_collapsed'])
         self.assertTrue(response.context['emergency_collapsed'])
 
+    @override_flag('registration_speed_run', active=True)
     def test_event_fields_flag_reflects_form_contents(self):
         # Arrange
         user = self._create_user()
@@ -508,6 +517,47 @@ class RegistrationCollapsedSectionTests(TestCase):
 
         # Assert
         self.assertFalse(response.context['has_event_fields'])
+
+    @override_flag('registration_speed_run', active=False)
+    def test_sections_not_collapsed_when_flag_inactive(self):
+        # Arrange
+        user = self._create_user()
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['speed_run'])
+        self.assertFalse(response.context['contact_collapsed'])
+        self.assertFalse(response.context['emergency_collapsed'])
+
+    @override_flag('registration_speed_run', active=False)
+    def test_field_order_restored_when_flag_inactive(self):
+        # Arrange
+        route = Route.objects.create(name="Test Route")
+        Ride.objects.create(event=self.event, name="Test Ride", route=route)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        field_names = list(response.context['form'].fields)
+        self.assertLess(field_names.index('ride'), field_names.index('emergency_contact_name'))
+
+    @override_flag('registration_speed_run', active=True)
+    def test_field_order_when_flag_active(self):
+        # Arrange
+        route = Route.objects.create(name="Test Route")
+        Ride.objects.create(event=self.event, name="Test Ride", route=route)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        field_names = list(response.context['form'].fields)
+        self.assertLess(field_names.index('emergency_contact_name'), field_names.index('ride'))
 
 
 class RegistrationWithdrawAccessControlTests(TestCase):

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -351,6 +351,165 @@ class RegistrationEmergencyContactTests(TestCase):
         self.assertEqual(user.profile.emergency_contact_phone, '613-555-0100')
 
 
+class RegistrationCollapsedSectionTests(TestCase):
+    def setUp(self):
+        now = timezone.now()
+        self.program = Program.objects.create(name="Test Program")
+        self.event = Event.objects.create(
+            name="Test Event",
+            program=self.program,
+            starts_at=now + timezone.timedelta(days=3),
+            registration_closes_at=now + timezone.timedelta(days=2),
+            requires_emergency_contact=True,
+            ride_leaders_wanted=False,
+            requires_membership=False,
+        )
+
+    def _create_user(self, with_phone=True, with_emergency_contact=True):
+        user = User.objects.create_user(
+            username='collapse@example.com',
+            email='collapse@example.com',
+            first_name='Collapse',
+            last_name='User',
+        )
+        if with_phone:
+            user.profile.phone = '+16135550100'
+        if with_emergency_contact:
+            user.profile.emergency_contact_name = 'Jane Doe'
+            user.profile.emergency_contact_phone = '613-555-0199'
+        user.profile.save()
+        return user
+
+    def test_contact_section_collapsed_for_signed_in_user_with_complete_details(self):
+        # Arrange
+        user = self._create_user()
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['contact_collapsed'])
+        self.assertTrue(response.context['emergency_collapsed'])
+
+    def test_contact_section_expanded_for_anonymous_user(self):
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['contact_collapsed'])
+        self.assertFalse(response.context['emergency_collapsed'])
+
+    def test_contact_section_expanded_when_phone_missing(self):
+        # Arrange
+        user = self._create_user(with_phone=False)
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['contact_collapsed'])
+        self.assertTrue(response.context['emergency_collapsed'])
+
+    def test_emergency_section_expanded_when_no_emergency_contact_on_profile(self):
+        # Arrange
+        user = self._create_user(with_emergency_contact=False)
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['contact_collapsed'])
+        self.assertFalse(response.context['emergency_collapsed'])
+
+    def test_emergency_section_not_collapsed_when_event_does_not_require_it(self):
+        # Arrange
+        event = Event.objects.create(
+            name="No EC Event",
+            program=self.program,
+            starts_at=timezone.now() + timezone.timedelta(days=3),
+            registration_closes_at=timezone.now() + timezone.timedelta(days=2),
+            requires_emergency_contact=False,
+            ride_leaders_wanted=False,
+            requires_membership=False,
+        )
+        user = self._create_user()
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['emergency_collapsed'])
+
+    def test_contact_section_expanded_when_contact_field_has_error(self):
+        # Arrange
+        user = self._create_user()
+        self.client.force_login(user)
+
+        form_data = {
+            'first_name': 'Collapse',
+            'last_name': 'User',
+            'email': 'not-an-email',
+            'phone': '+16135550100',
+            'emergency_contact_name': 'Jane Doe',
+            'emergency_contact_phone': '613-555-0199',
+        }
+
+        # Act
+        response = self.client.post(reverse('registration_create', args=[self.event.id]), form_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['contact_collapsed'])
+        self.assertTrue(response.context['emergency_collapsed'])
+
+    def test_contact_section_stays_collapsed_when_error_is_elsewhere(self):
+        # Arrange
+        route = Route.objects.create(name="Test Route")
+        ride = Ride.objects.create(event=self.event, name="Test Ride", route=route)
+        speed_range = SpeedRange.objects.create(lower_limit=20, upper_limit=25)
+        ride.speed_ranges.add(speed_range)
+        user = self._create_user()
+        self.client.force_login(user)
+
+        form_data = {
+            'first_name': 'Collapse',
+            'last_name': 'User',
+            'email': 'collapse@example.com',
+            'phone': '+16135550100',
+            'emergency_contact_name': 'Jane Doe',
+            'emergency_contact_phone': '613-555-0199',
+        }
+
+        # Act
+        response = self.client.post(reverse('registration_create', args=[self.event.id]), form_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('ride', response.context['form'].errors)
+        self.assertTrue(response.context['contact_collapsed'])
+        self.assertTrue(response.context['emergency_collapsed'])
+
+    def test_event_fields_flag_reflects_form_contents(self):
+        # Arrange
+        user = self._create_user()
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertFalse(response.context['has_event_fields'])
+
+
 class RegistrationWithdrawAccessControlTests(TestCase):
     def setUp(self):
         now = timezone.now()

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -103,7 +103,15 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
             'emergency_contact_phone': user.profile.emergency_contact_phone,
         }
 
+    speed_run = flag_is_active(request, 'registration_speed_run')
+
     form = RegistrationForm(request.POST or None, event=event, initial=initial_data)
+    if not speed_run:
+        form.order_fields([
+            'first_name', 'last_name', 'email', 'phone',
+            'ride', 'speed_range_preference',
+            'emergency_contact_name', 'emergency_contact_phone',
+        ])
 
     if request.method == 'POST':
         if form.is_valid():
@@ -149,9 +157,11 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
         'event': event,
         'form': form,
         'selected_ride_id': selected_ride_id,
-        'contact_collapsed': _is_section_collapsed(form, CONTACT_FIELDS, initial_data),
+        'speed_run': speed_run,
+        'contact_collapsed': speed_run and _is_section_collapsed(form, CONTACT_FIELDS, initial_data),
         'emergency_collapsed': (
-            'emergency_contact_name' in form.fields
+            speed_run
+            and 'emergency_contact_name' in form.fields
             and _is_section_collapsed(form, EMERGENCY_CONTACT_FIELDS, initial_data)
         ),
         'has_event_fields': any(

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -41,6 +41,18 @@ def registration_verify(request: HttpRequest) -> HttpResponse:
     })
 
 
+CONTACT_FIELDS = ('first_name', 'last_name', 'email', 'phone')
+EMERGENCY_CONTACT_FIELDS = ('emergency_contact_name', 'emergency_contact_phone')
+
+
+def _is_section_collapsed(form: RegistrationForm, field_names: tuple, initial_data: dict) -> bool:
+    if not all(initial_data.get(name) for name in field_names):
+        return False
+    if form.is_bound and any(name in form.errors for name in field_names):
+        return False
+    return True
+
+
 def _get_registration_detail(form: RegistrationForm) -> RegistrationDetail:
     ride_leader_raw = form.cleaned_data.get('ride_leader_preference')
     first_time_raw = form.cleaned_data.get('first_time_attendee')
@@ -137,6 +149,14 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
         'event': event,
         'form': form,
         'selected_ride_id': selected_ride_id,
+        'contact_collapsed': _is_section_collapsed(form, CONTACT_FIELDS, initial_data),
+        'emergency_collapsed': (
+            'emergency_contact_name' in form.fields
+            and _is_section_collapsed(form, EMERGENCY_CONTACT_FIELDS, initial_data)
+        ),
+        'has_event_fields': any(
+            name not in CONTACT_FIELDS + EMERGENCY_CONTACT_FIELDS for name in form.fields
+        ),
     })
 
 


### PR DESCRIPTION
## Summary
Implements a "speed run" mode for event registration that allows returning users with complete profile information to quickly register by collapsing their contact details into preview cards. This feature is controlled by a `registration_speed_run` feature flag.

## Key Changes
- **Feature flag integration**: Added `registration_speed_run` flag to control the speed run UI behavior
- **Collapsible sections**: Contact and emergency contact sections collapse into preview cards when user data is complete and no form errors exist
- **Smart field reordering**: When speed run is active, emergency contact fields appear before event-specific fields (ride selection) to prioritize user details; normal field order is restored when the flag is inactive
- **Form validation awareness**: Sections automatically expand if the form has validation errors in those fields, ensuring users can correct mistakes
- **Template refactoring**: Extracted field rendering into `_registration_field.html` partial to reduce duplication and support conditional rendering
- **Context variables**: Added `speed_run`, `contact_collapsed`, `emergency_collapsed`, and `has_event_fields` context variables to control template behavior
- **Helper function**: Implemented `_is_section_collapsed()` to determine collapse state based on initial data and form validation state

## Implementation Details
- Collapse state is determined by: (1) all required fields having initial values, (2) no form errors in those fields, and (3) speed run flag being active
- Emergency contact section only collapses if the event requires emergency contact information
- Event-specific fields (ride, speed range) are only shown if they exist for the event
- The feature gracefully degrades when the flag is inactive, maintaining the original registration flow

https://claude.ai/code/session_015x6PVXZCNPWnZQZf2e6G16