### PR TITLE
Lock down registration email for signed-in users

### DIFF
--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -24,6 +24,8 @@ PROSE_EDITOR_CONFIG = {
 }
 from phonenumber_field.modelfields import PhoneNumberField
 
+from backoffice.utils import lower_email
+
 
 class Program(models.Model):
     class Article(models.TextChoices):
@@ -705,6 +707,11 @@ class Registration(models.Model):
         return f"{self.name} for {self.event}"
 
     def clean(self):
+        if self.authenticated and self.user_id and lower_email(self.email) != lower_email(self.user.email):
+            raise ValidationError({
+                'email': "Email must match the account email for registrations made while signed in."
+            })
+
         if self.ride and self.ride.event_id != self.event_id:
             raise ValidationError({
                 'ride': f"The ride '{self.ride}' does not belong to this event."

--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -136,9 +136,9 @@ class RegistrationService:
             recipient_list=[registration.email],
         )
 
-    def _should_skip_verification(self, user: User, request_detail: RequestDetail | None,
+    def _should_skip_verification(self, user: User, acting_user: User | None,
                                   force_verification: bool) -> bool:
-        if request_detail and request_detail.authenticated:
+        if acting_user is not None and acting_user.is_authenticated and acting_user.pk == user.pk:
             if not user.profile.email_verified:
                 user.profile.email_verified = True
                 user.profile.save(update_fields=['email_verified'])
@@ -230,7 +230,7 @@ class RegistrationService:
 
         registration = self._create_registration(event, user, user_detail, registration_detail, request_detail)
 
-        if self._should_skip_verification(user, request_detail, force_verification):
+        if self._should_skip_verification(user, acting_user, force_verification):
             self._send_confirmation_email(registration)
             registration.confirm()
             registration.save()

--- a/backoffice/tests/models/test_registration.py
+++ b/backoffice/tests/models/test_registration.py
@@ -246,3 +246,63 @@ class RegistrationCleanTestCase(TestCase):
         with self.assertRaises(ValidationError) as context:
             registration.clean()
         self.assertIn('first_time_attendee', context.exception.message_dict)
+
+
+class RegistrationEmailMatchesUserTestCase(TestCase):
+    def setUp(self):
+        self.program = Program.objects.create(name="Test Program")
+        self.user = User.objects.create_user(username='testuser', email='test@example.com')
+        self.event = Event.objects.create(
+            program=self.program,
+            name="Test Event",
+            starts_at=timezone.now() + timezone.timedelta(days=7),
+            registration_closes_at=timezone.now() + timezone.timedelta(days=6)
+        )
+
+    def _build_registration(self, email, authenticated):
+        return Registration(
+            user=self.user,
+            event=self.event,
+            name="Test User",
+            first_name="Test",
+            last_name="User",
+            email=email,
+            authenticated=authenticated,
+        )
+
+    def test_clean_raises_error_when_authenticated_email_differs_from_user_email(self):
+        # Arrange
+        registration = self._build_registration('other@example.com', authenticated=True)
+
+        # Act & Assert
+        with self.assertRaises(ValidationError) as context:
+            registration.clean()
+        self.assertIn('email', context.exception.message_dict)
+
+    def test_clean_passes_when_authenticated_email_matches_user_email(self):
+        # Arrange
+        registration = self._build_registration('test@example.com', authenticated=True)
+
+        # Act
+        registration.clean()
+
+    def test_clean_ignores_email_case_when_comparing(self):
+        # Arrange
+        registration = self._build_registration('Test@Example.com', authenticated=True)
+
+        # Act
+        registration.clean()
+
+    def test_clean_passes_when_anonymous_email_differs_from_user_email(self):
+        # Arrange
+        registration = self._build_registration('other@example.com', authenticated=False)
+
+        # Act
+        registration.clean()
+
+    def test_clean_passes_when_authenticated_is_none(self):
+        # Arrange
+        registration = self._build_registration('other@example.com', authenticated=None)
+
+        # Act
+        registration.clean()

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -2226,6 +2226,12 @@ class EmailVerificationFlowTestCase(TestCase):
 
     def test_register_authenticated_user_confirms_directly(self):
         # Arrange
+        user = User.objects.create_user(
+            username='test@example.com',
+            email='test@example.com',
+            first_name='Test',
+            last_name='User',
+        )
         request_detail = RequestDetail(
             ip_address='127.0.0.1',
             user_agent='Test',
@@ -2234,7 +2240,8 @@ class EmailVerificationFlowTestCase(TestCase):
 
         # Act
         result = self.service.register(
-            self.user_detail, self.registration_detail, self.event, request_detail
+            self.user_detail, self.registration_detail, self.event, request_detail,
+            acting_user=user,
         )
 
         # Assert
@@ -2244,6 +2251,12 @@ class EmailVerificationFlowTestCase(TestCase):
 
     def test_register_authenticated_user_sets_email_verified(self):
         # Arrange
+        user = User.objects.create_user(
+            username='test@example.com',
+            email='test@example.com',
+            first_name='Test',
+            last_name='User',
+        )
         request_detail = RequestDetail(
             ip_address='127.0.0.1',
             user_agent='Test',
@@ -2252,13 +2265,41 @@ class EmailVerificationFlowTestCase(TestCase):
 
         # Act
         self.service.register(
-            self.user_detail, self.registration_detail, self.event, request_detail
+            self.user_detail, self.registration_detail, self.event, request_detail,
+            acting_user=user,
         )
 
         # Assert
         user = User.objects.get(email='test@example.com')
         user.profile.refresh_from_db()
         self.assertTrue(user.profile.email_verified)
+
+    def test_register_authenticated_user_with_other_email_holds_for_verification(self):
+        # Arrange
+        acting_user = User.objects.create_user(
+            username='someone-else@example.com',
+            email='someone-else@example.com',
+            first_name='Someone',
+            last_name='Else',
+        )
+        request_detail = RequestDetail(
+            ip_address='127.0.0.1',
+            user_agent='Test',
+            authenticated=True,
+        )
+
+        # Act
+        result = self.service.register(
+            self.user_detail, self.registration_detail, self.event, request_detail,
+            acting_user=acting_user,
+        )
+
+        # Assert
+        self.assertEqual(result, RegistrationResult.VERIFICATION_REQUIRED)
+        registration = Registration.objects.get(event=self.event)
+        self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
+        user = User.objects.get(email='test@example.com')
+        self.assertFalse(user.profile.email_verified)
 
     def test_register_unverified_unauthenticated_user_holds_for_verification(self):
         # Arrange
@@ -2309,6 +2350,12 @@ class EmailVerificationFlowTestCase(TestCase):
 
     def test_register_force_verification_confirms_authenticated_user(self):
         # Arrange
+        user = User.objects.create_user(
+            username='test@example.com',
+            email='test@example.com',
+            first_name='Test',
+            last_name='User',
+        )
         request_detail = RequestDetail(
             ip_address='127.0.0.1',
             user_agent='Test',
@@ -2318,7 +2365,7 @@ class EmailVerificationFlowTestCase(TestCase):
         # Act
         result = self.service.register(
             self.user_detail, self.registration_detail, self.event, request_detail,
-            force_verification=True,
+            acting_user=user, force_verification=True,
         )
 
         # Assert

--- a/web/forms.py
+++ b/web/forms.py
@@ -51,7 +51,7 @@ class RegistrationForm(forms.Form):
         assert event
         self.event = event
 
-        if user is not None and user.is_authenticated:
+        if user is not None and user.is_authenticated and user.email:
             self.fields['email'].disabled = True
             self.initial['email'] = user.email
 

--- a/web/forms.py
+++ b/web/forms.py
@@ -45,10 +45,15 @@ class RegistrationForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         event: Event = kwargs.pop('event', None)
+        user = kwargs.pop('user', None)
         super().__init__(*args, **kwargs)
 
         assert event
         self.event = event
+
+        if user is not None and user.is_authenticated:
+            self.fields['email'].disabled = True
+            self.initial['email'] = user.email
 
         registration_service = RegistrationService()
         requirements = registration_service.get_event_requirements(event)

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -463,9 +463,9 @@ class RegistrationCollapsedSectionTests(TestCase):
         self.client.force_login(user)
 
         form_data = {
-            'first_name': 'Collapse',
+            'first_name': 'C',
             'last_name': 'User',
-            'email': 'not-an-email',
+            'email': user.email,
             'phone': '+16135550100',
             'emergency_contact_name': 'Jane Doe',
             'emergency_contact_phone': '613-555-0199',
@@ -1400,3 +1400,82 @@ class RegistrationDisabledTests(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 400)
+
+class RegistrationEmailLockdownTests(TestCase):
+    def setUp(self):
+        self.program = Program.objects.create(name="Test Program")
+        self.event = Event.objects.create(
+            name="Lockdown Event",
+            program=self.program,
+            starts_at=timezone.now() + timezone.timedelta(days=7),
+            registration_closes_at=timezone.now() + timezone.timedelta(days=6),
+            requires_emergency_contact=False,
+            ride_leaders_wanted=False,
+            requires_membership=False,
+        )
+        self.user = User.objects.create_user(
+            username='member@example.com',
+            email='member@example.com',
+            first_name='Member',
+            last_name='User',
+        )
+        mail.outbox = []
+
+    def test_email_field_disabled_when_signed_in(self):
+        # Arrange
+        self.client.force_login(self.user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['form'].fields['email'].disabled)
+
+    def test_email_field_editable_when_anonymous(self):
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['form'].fields['email'].disabled)
+
+    def test_signed_in_user_cannot_register_with_other_email(self):
+        # Arrange
+        self.client.force_login(self.user)
+        form_data = {
+            'first_name': 'Member',
+            'last_name': 'User',
+            'email': 'someone-else@example.invalid',
+            'phone': '+16135550100',
+        }
+
+        # Act
+        response = self.client.post(reverse('registration_create', args=[self.event.id]), form_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        registration = Registration.objects.get(event=self.event)
+        self.assertEqual(registration.email, 'member@example.com')
+        self.assertEqual(registration.user, self.user)
+        self.assertFalse(User.objects.filter(email='someone-else@example.invalid').exists())
+
+    def test_signed_in_registration_marks_own_email_verified(self):
+        # Arrange
+        self.client.force_login(self.user)
+        form_data = {
+            'first_name': 'Member',
+            'last_name': 'User',
+            'email': 'member@example.com',
+            'phone': '+16135550100',
+        }
+
+        # Act
+        response = self.client.post(reverse('registration_create', args=[self.event.id]), form_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        registration = Registration.objects.get(event=self.event)
+        self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.email_verified)

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1479,3 +1479,37 @@ class RegistrationEmailLockdownTests(TestCase):
         self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
         self.user.profile.refresh_from_db()
         self.assertTrue(self.user.profile.email_verified)
+
+    def test_email_field_editable_when_signed_in_user_has_no_email(self):
+        # Arrange
+        user = User.objects.create_user(username='no-email-user', email='')
+        self.client.force_login(user)
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['form'].fields['email'].disabled)
+
+    def test_signed_in_user_without_email_registers_with_verification(self):
+        # Arrange
+        user = User.objects.create_user(username='no-email-user', email='')
+        self.client.force_login(user)
+        form_data = {
+            'first_name': 'Member',
+            'last_name': 'User',
+            'email': 'entered@example.com',
+            'phone': '+16135550100',
+        }
+
+        # Act
+        response = self.client.post(reverse('registration_create', args=[self.event.id]), form_data)
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        registration = Registration.objects.get(event=self.event)
+        self.assertEqual(registration.email, 'entered@example.com')
+        self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
+        registered_user = User.objects.get(email='entered@example.com')
+        self.assertFalse(registered_user.profile.email_verified)

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -117,7 +117,7 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
         if form.is_valid():
             request_detail = request_service.extract_details(request)
             user_detail = _get_user_details(form)
-            if user:
+            if user and user.email:
                 user_detail.email = user.email
             result = registration_service.register(
                 user_detail=user_detail,

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -105,7 +105,7 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
 
     speed_run = flag_is_active(request, 'registration_speed_run')
 
-    form = RegistrationForm(request.POST or None, event=event, initial=initial_data)
+    form = RegistrationForm(request.POST or None, event=event, user=user, initial=initial_data)
     if not speed_run:
         form.order_fields([
             'first_name', 'last_name', 'email', 'phone',
@@ -117,6 +117,8 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
         if form.is_valid():
             request_detail = request_service.extract_details(request)
             user_detail = _get_user_details(form)
+            if user:
+                user_detail.email = user.email
             result = registration_service.register(
                 user_detail=user_detail,
                 registration_detail=_get_registration_detail(form),


### PR DESCRIPTION
## Problem

A signed-in user could edit the email field on the event registration form. Entering a different email created a new user, and because `_should_skip_verification` only checked whether the *request* was authenticated (not whether the authenticated user *is* the registrant), the new user's email was silently marked as verified and the registration confirmed — even for an address nobody demonstrated control of. The same hole allowed registering an existing user for an event and force-verifying their email without consent.

## Fix (three layers)

1. **Form/view**: `RegistrationForm` now disables the email field for authenticated users. Django's `disabled=True` ignores any POSTed value and uses the initial (account email), so a tampered POST can't smuggle a different address through. The view additionally overwrites `user_detail.email` with `request.user.email` as belt-and-braces.
2. **Model**: `Registration.clean()` rejects registrations where `authenticated` is set but the email differs (case-insensitively) from the linked account's email. Anonymous registrations, legacy imports (`authenticated=None`), and staff-created registrations are unaffected.
3. **Service**: `_should_skip_verification` now keys off identity — verification is only skipped (and `email_verified` only set) when the acting user is the user being registered. `email_verified` can now only become true by clicking the verification link or by the account owner registering themselves while signed in.

Edge case (from review feedback): accounts with a blank email keep an editable email field and fall back to the anonymous behavior — the registration is held for email verification rather than the page becoming unusable with a disabled empty field.

Note: staff editing the email of a registration made while signed in will now fail validation, since that email is tied to a verified account.

## Tests

- New `RegistrationEmailLockdownTests` (view level): field disabled when signed in, editable when anonymous or when the account has no email, foreign email in POST is ignored and no new user is created, own registration still marks email verified, blank-email accounts are held for verification.
- New `RegistrationEmailMatchesUserTestCase` (model level): mismatch rejected when authenticated, allowed when anonymous/legacy, case-insensitive comparison.
- New service test: signed-in user registering a different email is held for verification and the target email is not marked verified.
- Updated three existing tests that encoded the old request-authenticated semantics.

Full suite: 668 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYFoULbMXkQ4RcXFibmPjV