### PR TITLE
Fix speed run contact preview overflowing viewport on mobile

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -44,6 +44,10 @@
   display: none !important;
 }
 
+.min-w-0 {
+  min-width: 0;
+}
+
 body {
   font-family: 'Inter', sans-serif;
   min-height: 100vh;

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -44,8 +44,11 @@
   display: none !important;
 }
 
-.min-w-0 {
-  min-width: 0;
+.preview-fade {
+  white-space: nowrap;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 6rem), transparent calc(100% - 2rem));
+  mask-image: linear-gradient(to right, black calc(100% - 6rem), transparent calc(100% - 2rem));
 }
 
 body {

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -59,12 +59,10 @@
                         <h3 class="fs-6 fw-semibold mb-3">Your details</h3>
                         {% if contact_collapsed %}
                             <div class="collapse show" id="contact-preview">
-                                <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
-                                    <div class="min-w-0">
-                                        <div class="fw-medium" id="contact-preview-name">{{ form.first_name.value }} {{ form.last_name.value }}</div>
-                                        <div class="text-muted small text-break" id="contact-preview-meta">{{ form.email.value }} · {{ form.phone.value }}</div>
-                                    </div>
-                                    <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
+                                <div class="position-relative border rounded p-3 bg-body-tertiary mb-3">
+                                    <div class="fw-medium preview-fade" id="contact-preview-name">{{ form.first_name.value }} {{ form.last_name.value }}</div>
+                                    <div class="text-muted small preview-fade" id="contact-preview-meta">{{ form.email.value }} · {{ form.phone.value }}</div>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm position-absolute top-50 end-0 translate-middle-y me-3"
                                             data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
                                             aria-expanded="false" aria-controls="contact-preview contact-fields">
                                         <i class="bi bi-pencil me-1"></i>Edit
@@ -92,12 +90,10 @@
                             <h3 class="fs-6 fw-semibold mb-3 mt-4">Emergency contact</h3>
                             {% if emergency_collapsed %}
                                 <div class="collapse show" id="emergency-preview">
-                                    <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
-                                        <div class="min-w-0">
-                                            <div class="fw-medium" id="emergency-preview-name">{{ form.emergency_contact_name.value }}</div>
-                                            <div class="text-muted small text-break" id="emergency-preview-meta">{{ form.emergency_contact_phone.value }}</div>
-                                        </div>
-                                        <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
+                                    <div class="position-relative border rounded p-3 bg-body-tertiary mb-3">
+                                        <div class="fw-medium preview-fade" id="emergency-preview-name">{{ form.emergency_contact_name.value }}</div>
+                                        <div class="text-muted small preview-fade" id="emergency-preview-meta">{{ form.emergency_contact_phone.value }}</div>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm position-absolute top-50 end-0 translate-middle-y me-3"
                                                 data-bs-toggle="collapse" data-bs-target="#emergency-preview, #emergency-fields"
                                                 aria-expanded="false" aria-controls="emergency-preview emergency-fields">
                                             <i class="bi bi-pencil me-1"></i>Edit

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -61,7 +61,8 @@
                             <div class="collapse show" id="contact-preview">
                                 <div class="position-relative border rounded p-3 bg-body-tertiary mb-3">
                                     <div class="fw-medium preview-fade" id="contact-preview-name">{{ form.first_name.value }} {{ form.last_name.value }}</div>
-                                    <div class="text-muted small preview-fade" id="contact-preview-meta">{{ form.email.value }} · {{ form.phone.value }}</div>
+                                    <div class="text-muted small preview-fade" id="contact-preview-email">{{ form.email.value }}</div>
+                                    <div class="text-muted small preview-fade" id="contact-preview-phone">{{ form.phone.value }}</div>
                                     <button type="button" class="btn btn-outline-secondary btn-sm position-absolute top-50 end-0 translate-middle-y me-3"
                                             data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
                                             aria-expanded="false" aria-controls="contact-preview contact-fields">
@@ -223,7 +224,8 @@
                 const email = document.getElementById('id_email').value.trim();
                 const phone = document.getElementById('id_phone').value.trim();
                 document.getElementById('contact-preview-name').textContent = first + ' ' + last;
-                document.getElementById('contact-preview-meta').textContent = email + ' · ' + phone;
+                document.getElementById('contact-preview-email').textContent = email;
+                document.getElementById('contact-preview-phone').textContent = phone;
             });
 
             bindPreviewSync('emergency-preview', function () {

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -1,5 +1,6 @@
 {% extends 'web/_base_bootstrap.html' %}
 {% load form_filters %}
+{% load phone_filters %}
 {% block title %}Register for {{ event.name }}{% endblock %}
 {% block content %}
     <div class="mb-4">
@@ -62,7 +63,7 @@
                                 <div class="position-relative border rounded p-3 bg-body-tertiary mb-3">
                                     <div class="fw-medium preview-fade" id="contact-preview-name">{{ form.first_name.value }} {{ form.last_name.value }}</div>
                                     <div class="text-muted small preview-fade" id="contact-preview-email">{{ form.email.value }}</div>
-                                    <div class="text-muted small preview-fade" id="contact-preview-phone">{{ form.phone.value }}</div>
+                                    <div class="text-muted small preview-fade" id="contact-preview-phone">{{ form.phone.value|national_phone }}</div>
                                     <button type="button" class="btn btn-outline-secondary btn-sm position-absolute top-50 end-0 translate-middle-y me-3"
                                             data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
                                             aria-expanded="false" aria-controls="contact-preview contact-fields">
@@ -93,7 +94,7 @@
                                 <div class="collapse show" id="emergency-preview">
                                     <div class="position-relative border rounded p-3 bg-body-tertiary mb-3">
                                         <div class="fw-medium preview-fade" id="emergency-preview-name">{{ form.emergency_contact_name.value }}</div>
-                                        <div class="text-muted small preview-fade" id="emergency-preview-meta">{{ form.emergency_contact_phone.value }}</div>
+                                        <div class="text-muted small preview-fade" id="emergency-preview-meta">{{ form.emergency_contact_phone.value|national_phone }}</div>
                                         <button type="button" class="btn btn-outline-secondary btn-sm position-absolute top-50 end-0 translate-middle-y me-3"
                                                 data-bs-toggle="collapse" data-bs-target="#emergency-preview, #emergency-fields"
                                                 aria-expanded="false" aria-controls="emergency-preview emergency-fields">

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -62,7 +62,7 @@
                                 <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
                                     <div class="min-w-0">
                                         <div class="fw-medium" id="contact-preview-name">{{ form.first_name.value }} {{ form.last_name.value }}</div>
-                                        <div class="text-muted small" id="contact-preview-meta">{{ form.email.value }} · {{ form.phone.value }}</div>
+                                        <div class="text-muted small text-break" id="contact-preview-meta">{{ form.email.value }} · {{ form.phone.value }}</div>
                                     </div>
                                     <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
                                             data-bs-toggle="collapse" data-bs-target="#contact-preview, #contact-fields"
@@ -95,7 +95,7 @@
                                     <div class="d-flex justify-content-between align-items-center gap-3 border rounded p-3 bg-body-tertiary mb-3">
                                         <div class="min-w-0">
                                             <div class="fw-medium" id="emergency-preview-name">{{ form.emergency_contact_name.value }}</div>
-                                            <div class="text-muted small" id="emergency-preview-meta">{{ form.emergency_contact_phone.value }}</div>
+                                            <div class="text-muted small text-break" id="emergency-preview-meta">{{ form.emergency_contact_phone.value }}</div>
                                         </div>
                                         <button type="button" class="btn btn-outline-secondary btn-sm flex-shrink-0"
                                                 data-bs-toggle="collapse" data-bs-target="#emergency-preview, #emergency-fields"


### PR DESCRIPTION
The collapsed speed run contact preview used min-w-0, a Tailwind utility
that does not exist in Bootstrap, so the flex child could not shrink and
long email addresses pushed the Edit button off the viewport on mobile.

Rework the preview cards instead of wrapping:

- Name, email, and phone render on their own rows, each kept to a single
  line with a new `.preview-fade` class that fades text out with a CSS
  mask as it passes under the Edit button.
- The Edit button is absolutely positioned at the right center of the
  card, using native Bootstrap utilities.
- Phone numbers in both previews render in national format via the
  existing `national_phone` template filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAXrXaq6EVFHUMinj1KfMh