### PR TITLE
Update meta pill link colors to neutral gray

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -90,14 +90,14 @@ body {
 }
 
 .meta-pill-link {
-  background-color: rgba(37, 99, 235, 0.08);
+  background-color: rgba(108, 117, 125, 0.1);
   color: var(--bs-primary);
   text-decoration: none;
   transition: background-color 0.2s ease;
 }
 
 .meta-pill-link:hover, .meta-pill-link:focus {
-  background-color: rgba(37, 99, 235, 0.16);
+  background-color: rgba(108, 117, 125, 0.2);
   color: var(--bs-primary-hover);
   text-decoration: underline;
 }


### PR DESCRIPTION
Changes the background color scheme for `.meta-pill-link` elements from blue to neutral gray, improving visual consistency with the overall design system.

**Key changes:**
- Updated `.meta-pill-link` background color from `rgba(37, 99, 235, 0.08)` to `rgba(108, 117, 125, 0.1)` (neutral gray)
- Updated `.meta-pill-link:hover` and `.meta-pill-link:focus` background color from `rgba(37, 99, 235, 0.16)` to `rgba(108, 117, 125, 0.2)` (darker neutral gray)

The text color (`var(--bs-primary)`) and hover text color (`var(--bs-primary-hover)`) remain unchanged, maintaining the blue accent for text while using a neutral background.

https://claude.ai/code/session_01K6LE6MzCtRAQ8myDSg1dq6