### PR TITLE
Remove email verification flag and require verification for all anonymous registrations

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -136,16 +136,13 @@ class RegistrationService:
             recipient_list=[registration.email],
         )
 
-    def _should_skip_verification(self, user: User, acting_user: User | None,
-                                  force_verification: bool) -> bool:
+    def _should_skip_verification(self, user: User, acting_user: User | None) -> bool:
         if acting_user is not None and acting_user.is_authenticated and acting_user.pk == user.pk:
             if not user.profile.email_verified:
                 user.profile.email_verified = True
                 user.profile.save(update_fields=['email_verified'])
             return True
-        if force_verification:
-            return False
-        return user.profile.email_verified
+        return False
 
     def _send_verification_email(self, registration: Registration) -> None:
         signer = TimestampSigner(salt=VERIFICATION_TOKEN_SALT)
@@ -208,8 +205,8 @@ class RegistrationService:
         return registration, None
 
     def register(self, user_detail: UserDetail, registration_detail: RegistrationDetail, event: Event,
-                 request_detail: RequestDetail | None = None, acting_user: User | None = None,
-                 force_verification: bool = False) -> RegistrationResult:
+                 request_detail: RequestDetail | None = None,
+                 acting_user: User | None = None) -> RegistrationResult:
         update_existing = (
             acting_user is not None
             and acting_user.is_authenticated
@@ -230,7 +227,7 @@ class RegistrationService:
 
         registration = self._create_registration(event, user, user_detail, registration_detail, request_detail)
 
-        if self._should_skip_verification(user, acting_user, force_verification):
+        if self._should_skip_verification(user, acting_user):
             self._send_confirmation_email(registration)
             registration.confirm()
             registration.save()

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -823,14 +823,14 @@ class RegistrationServiceEmailTests(TestCase):
         )
 
         # Act
-        self.service.register(user_detail, registration_detail, self.event)
+        self.service.register(user_detail, registration_detail, self.event, acting_user=self.user)
 
         # Assert
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
 
         expected_profile_url = f"https://{settings.WEB_HOST}{reverse('profile')}"
-        
+
         # HTML part (if multipart)
         if email.alternatives:
             html_body = email.alternatives[0][0]
@@ -862,7 +862,7 @@ class RegistrationServiceEmailTests(TestCase):
         )
 
         # Act
-        self.service.register(user_detail, registration_detail, self.event)
+        self.service.register(user_detail, registration_detail, self.event, acting_user=ride_leader_user)
 
         # Assert
         self.assertEqual(len(mail.outbox), 1)
@@ -2066,14 +2066,14 @@ class RegisterMethodTestCase(TestCase):
             emergency_contact_phone=None
         )
 
-        self.service.register(user_detail, registration_detail, self.event)
+        self.service.register(user_detail, registration_detail, self.event, acting_user=user)
 
         registrations = Registration.objects.filter(user=user, event=self.event)
         self.assertEqual(registrations.count(), 2)
         new_registration = registrations.exclude(pk=old_registration.pk).first()
         self.assertEqual(new_registration.state, Registration.STATE_CONFIRMED)
 
-    def test_register_sets_registration_state_to_confirmed_for_verified_user(self):
+    def test_register_sets_registration_state_to_unverified_for_anonymous_verified_user(self):
         # Arrange
         user = User.objects.create_user(
             username='confirmed@example.com',
@@ -2103,9 +2103,9 @@ class RegisterMethodTestCase(TestCase):
 
         # Assert
         registration = Registration.objects.get(event=self.event)
-        self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
+        self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
 
-    def test_register_sends_confirmation_email_for_verified_user(self):
+    def test_register_sends_confirmation_email_for_authenticated_user(self):
         # Arrange
         user = User.objects.create_user(
             username='emailtest@example.com',
@@ -2131,7 +2131,7 @@ class RegisterMethodTestCase(TestCase):
         )
 
         # Act
-        self.service.register(user_detail, registration_detail, self.event)
+        self.service.register(user_detail, registration_detail, self.event, acting_user=user)
 
         # Assert
         self.assertEqual(len(mail.outbox), 1)
@@ -2205,7 +2205,7 @@ class EmailVerificationFlowTestCase(TestCase):
         )
         mail.outbox = []
 
-    def test_register_verified_user_confirms_directly(self):
+    def test_register_verified_anonymous_user_holds_for_verification(self):
         # Arrange
         user = User.objects.create_user(
             username='test@example.com',
@@ -2220,9 +2220,9 @@ class EmailVerificationFlowTestCase(TestCase):
         result = self.service.register(self.user_detail, self.registration_detail, self.event)
 
         # Assert
-        self.assertEqual(result, RegistrationResult.CONFIRMED)
+        self.assertEqual(result, RegistrationResult.VERIFICATION_REQUIRED)
         registration = Registration.objects.get(event=self.event)
-        self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
+        self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
 
     def test_register_authenticated_user_confirms_directly(self):
         # Arrange
@@ -2319,7 +2319,7 @@ class EmailVerificationFlowTestCase(TestCase):
         registration = Registration.objects.get(event=self.event)
         self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
 
-    def test_register_force_verification_holds_verified_unauthenticated_user(self):
+    def test_register_verified_unauthenticated_user_receives_verification_email(self):
         # Arrange
         user = User.objects.create_user(
             username='test@example.com',
@@ -2338,7 +2338,6 @@ class EmailVerificationFlowTestCase(TestCase):
         # Act
         result = self.service.register(
             self.user_detail, self.registration_detail, self.event, request_detail,
-            force_verification=True,
         )
 
         # Assert
@@ -2347,57 +2346,6 @@ class EmailVerificationFlowTestCase(TestCase):
         self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("Verify", mail.outbox[0].subject)
-
-    def test_register_force_verification_confirms_authenticated_user(self):
-        # Arrange
-        user = User.objects.create_user(
-            username='test@example.com',
-            email='test@example.com',
-            first_name='Test',
-            last_name='User',
-        )
-        request_detail = RequestDetail(
-            ip_address='127.0.0.1',
-            user_agent='Test',
-            authenticated=True,
-        )
-
-        # Act
-        result = self.service.register(
-            self.user_detail, self.registration_detail, self.event, request_detail,
-            acting_user=user, force_verification=True,
-        )
-
-        # Assert
-        self.assertEqual(result, RegistrationResult.CONFIRMED)
-        registration = Registration.objects.get(event=self.event)
-        self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
-
-    def test_register_without_force_verification_confirms_verified_user(self):
-        # Arrange
-        user = User.objects.create_user(
-            username='test@example.com',
-            email='test@example.com',
-            first_name='Test',
-            last_name='User',
-        )
-        user.profile.email_verified = True
-        user.profile.save()
-        request_detail = RequestDetail(
-            ip_address='127.0.0.1',
-            user_agent='Test',
-            authenticated=False,
-        )
-
-        # Act
-        result = self.service.register(
-            self.user_detail, self.registration_detail, self.event, request_detail,
-        )
-
-        # Assert
-        self.assertEqual(result, RegistrationResult.CONFIRMED)
-        registration = Registration.objects.get(event=self.event)
-        self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
 
     def test_register_sends_verification_email_not_confirmation(self):
         # Arrange

--- a/docs/users-authentication.md
+++ b/docs/users-authentication.md
@@ -10,8 +10,7 @@ manage their registrations, so the system is designed to establish and preserve
 authenticated sessions wherever possible:
 
 - Verifying an email at registration signs the user in, not just confirms the registration
-- The `require_email_verification` flag routes all anonymous registrations through
-  that sign-in-producing verification step
+- All anonymous registrations go through that sign-in-producing verification step
 - Sessions last 90 days and roll forward on every visit (`SESSION_COOKIE_AGE`,
   `SESSION_SAVE_EVERY_REQUEST` in `settings.py`), so a member only gets signed out
   after 90 days of inactivity
@@ -87,16 +86,13 @@ Traditional username/password authentication is available only through the Djang
 
 ## Email Verification at Event Registration
 
-Anonymous event registrations by users without a verified email are held in an
-`unverified` state until the registrant clicks a verification link sent by email.
-Clicking the link confirms the registration, marks the email as verified, and signs
-the user in. Signed-in users are confirmed directly and their email is considered
-verified automatically.
-
-**Feature flag**: The Waffle flag `require_email_verification` extends this to all
-anonymous registrations, including those whose email was previously verified. This
-nudges returning members to sign in (or verify again) rather than registering
-anonymously. Enable it incrementally via Django Admin > Waffle > Flags.
+All anonymous event registrations are held in an `unverified` state until the
+registrant clicks a verification link sent by email — having verified the email
+in the past is not sufficient. Clicking the link confirms the registration, marks
+the email as verified, and signs the user in. Signed-in users registering for
+themselves are confirmed directly and their email is considered verified
+automatically. This nudges returning members to sign in rather than registering
+anonymously.
 
 ## User Lifecycle
 

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1176,7 +1176,7 @@ class RegistrationFullFlowTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn('verification-sent', response.url)
 
-    def test_verified_user_redirects_to_submitted(self):
+    def test_anonymous_verified_user_redirects_to_verification_sent(self):
         # Arrange
         user = User.objects.create_user(
             username='verified@example.com',
@@ -1209,10 +1209,10 @@ class RegistrationFullFlowTests(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 302)
-        self.assertIn('submitted', response.url)
+        self.assertIn('verification-sent', response.url)
 
 
-class RequireEmailVerificationFlagTests(TestCase):
+class AnonymousRegistrationVerificationTests(TestCase):
     def setUp(self):
         self.program = Program.objects.create(name="Test Program")
         self.event = Event.objects.create(
@@ -1240,8 +1240,7 @@ class RequireEmailVerificationFlagTests(TestCase):
         }
         mail.outbox = []
 
-    @override_flag('require_email_verification', active=True)
-    def test_anonymous_verified_user_held_for_verification_when_flag_active(self):
+    def test_anonymous_verified_user_held_for_verification(self):
         # Act
         response = self.client.post(reverse('registration_create', args=[self.event.id]), self.form_data)
 
@@ -1253,8 +1252,7 @@ class RequireEmailVerificationFlagTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('Verify', mail.outbox[0].subject)
 
-    @override_flag('require_email_verification', active=True)
-    def test_signed_in_user_confirmed_directly_when_flag_active(self):
+    def test_signed_in_user_confirmed_directly(self):
         # Arrange
         self.client.force_login(self.user)
 
@@ -1267,16 +1265,19 @@ class RequireEmailVerificationFlagTests(TestCase):
         registration = Registration.objects.get(event=self.event)
         self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
 
-    @override_flag('require_email_verification', active=False)
-    def test_anonymous_verified_user_confirmed_directly_when_flag_inactive(self):
+    def test_anonymous_unverified_user_held_for_verification(self):
+        # Arrange
+        self.user.profile.email_verified = False
+        self.user.profile.save()
+
         # Act
         response = self.client.post(reverse('registration_create', args=[self.event.id]), self.form_data)
 
         # Assert
         self.assertEqual(response.status_code, 302)
-        self.assertIn('submitted', response.url)
+        self.assertIn('verification-sent', response.url)
         registration = Registration.objects.get(event=self.event)
-        self.assertEqual(registration.state, Registration.STATE_CONFIRMED)
+        self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
 
 
 class RegistrationVerifyViewTests(TestCase):

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -124,8 +124,7 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
                 registration_detail=_get_registration_detail(form),
                 event=event,
                 request_detail=request_detail,
-                acting_user=request.user if request.user.is_authenticated else None,
-                force_verification=flag_is_active(request, 'require_email_verification'))
+                acting_user=request.user if request.user.is_authenticated else None)
 
             if result == RegistrationResult.VERIFICATION_REQUIRED:
                 return redirect('registration_verification_sent')


### PR DESCRIPTION
This change removes the `require_email_verification` feature flag and makes email verification mandatory for all anonymous event registrations, regardless of prior email verification status.

## Summary
Previously, anonymous users with a verified email could register directly without re-verification. The `require_email_verification` flag allowed this behavior to be toggled. This change removes that flag and the conditional logic, requiring all anonymous registrations to go through email verification.

## Key Changes
- **Removed `force_verification` parameter** from `RegistrationService.register()` method
- **Simplified `_should_skip_verification()` logic** to only skip verification when the acting user is authenticated and registering for themselves
- **Updated registration flow** so anonymous users always receive a verification email, even if their email was previously verified
- **Removed feature flag usage** from `registration_create` view and related test infrastructure
- **Updated test suite** to reflect new behavior:
  - Renamed tests to clarify that anonymous verified users now require verification
  - Removed tests for the `force_verification` parameter
  - Updated assertions to expect `STATE_UNVERIFIED` and `VERIFICATION_REQUIRED` for anonymous registrations
  - Removed `@override_flag` decorators from tests
- **Updated documentation** in `docs/users-authentication.md` to remove references to the feature flag and clarify that all anonymous registrations require verification

## Implementation Details
The change simplifies the registration logic by removing conditional behavior based on a feature flag. Anonymous users now consistently go through the verification flow, which nudges returning members to sign in rather than registering anonymously. This aligns with the system design goal of establishing and preserving authenticated sessions.

https://claude.ai/code/session_01SYEu7LvLKLHZrUGUh37EHt