### PR TITLE
Merge Upcoming and Calendar nav items into a single Events item

### DIFF
--- a/web/templates/web/_base_bootstrap.html
+++ b/web/templates/web/_base_bootstrap.html
@@ -46,8 +46,7 @@
               <img src="{% static 'web/obc-logo.png' %}" alt="Ottawa Bicycle Club" height="40">
             </a>
             <div class="d-flex align-items-center nav-links">
-              <a href="{% url 'upcoming' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'upcoming' %} active{% endif %}">Upcoming</a>
-              <a href="{% url 'calendar' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">Calendar</a>
+              <a href="{% url 'events' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'upcoming' or request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">Events</a>
               <a href="{% url 'help' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'help' %} active{% endif %}">Help</a>
               <a href="{% url 'emergency' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'emergency' %} active{% endif %}">Emergency</a>
               {% if user.is_staff %}
@@ -127,8 +126,7 @@
       <!-- Mobile collapse menu -->
       <div class="collapse d-md-none w-100" id="mobileNavMenu">
         <div class="container mobile-nav-menu">
-          <a href="{% url 'upcoming' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'upcoming' %} active{% endif %}">Upcoming</a>
-          <a href="{% url 'calendar' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">Calendar</a>
+          <a href="{% url 'events' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'upcoming' or request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">Events</a>
           <a href="{% url 'help' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'help' %} active{% endif %}">Help</a>
           <a href="{% url 'emergency' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'emergency' %} active{% endif %}">Emergency</a>
           {% if user.is_staff %}

--- a/web/templates/web/_base_bootstrap.html
+++ b/web/templates/web/_base_bootstrap.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load gravatar %}
 {% load waffle_tags %}
+{% load nav_tags %}
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -46,7 +47,7 @@
               <img src="{% static 'web/obc-logo.png' %}" alt="Ottawa Bicycle Club" height="40">
             </a>
             <div class="d-flex align-items-center nav-links">
-              <a href="{% url 'events' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'upcoming' or request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">Events</a>
+              <a href="{% url 'events' %}" class="nav-link-obc{% events_nav_active %}">Events</a>
               <a href="{% url 'help' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'help' %} active{% endif %}">Help</a>
               <a href="{% url 'emergency' %}" class="nav-link-obc{% if request.resolver_match.url_name == 'emergency' %} active{% endif %}">Emergency</a>
               {% if user.is_staff %}
@@ -126,7 +127,7 @@
       <!-- Mobile collapse menu -->
       <div class="collapse d-md-none w-100" id="mobileNavMenu">
         <div class="container mobile-nav-menu">
-          <a href="{% url 'events' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'upcoming' or request.resolver_match.url_name == 'calendar' or request.resolver_match.url_name == 'calendar_month' %} active{% endif %}">Events</a>
+          <a href="{% url 'events' %}" class="mobile-nav-link{% events_nav_active %}">Events</a>
           <a href="{% url 'help' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'help' %} active{% endif %}">Help</a>
           <a href="{% url 'emergency' %}" class="mobile-nav-link{% if request.resolver_match.url_name == 'emergency' %} active{% endif %}">Emergency</a>
           {% if user.is_staff %}

--- a/web/templates/web/events/calendar.html
+++ b/web/templates/web/events/calendar.html
@@ -24,8 +24,8 @@
                 </h1>
             </div>
             <div class="d-flex justify-content-end">
-                <a href="{% url 'upcoming' %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
-                    <i class="bi bi-list-ul me-2"></i> Switch to upcoming
+                <a href="{% url 'upcoming' %}" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;" title="Switch to list view" aria-label="Switch to list view">
+                    <i class="bi bi-list-ul"></i>
                 </a>
             </div>
         </div>

--- a/web/templates/web/events/calendar.html
+++ b/web/templates/web/events/calendar.html
@@ -24,8 +24,8 @@
                 </h1>
             </div>
             <div class="d-flex justify-content-end">
-                <a href="{% url 'upcoming' %}" class="btn btn-light rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px; border: none;" title="Switch to list view" aria-label="Switch to list view">
-                    <i class="bi bi-list-ul"></i>
+                <a href="{% url 'upcoming' %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
+                    <i class="bi bi-list-ul me-2"></i> Switch to upcoming
                 </a>
             </div>
         </div>

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -6,8 +6,8 @@
     <div class="mb-4">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="fs-2 fw-bold mb-0">Upcoming events</h1>
-            <a href="{% url 'calendar' %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
-                <i class="bi bi-calendar3 me-2"></i> Switch to calendar
+            <a href="{% url 'calendar' %}" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;" title="Switch to calendar view" aria-label="Switch to calendar view">
+                <i class="bi bi-calendar3"></i>
             </a>
         </div>
 

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -6,8 +6,8 @@
     <div class="mb-4">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="fs-2 fw-bold mb-0">Upcoming events</h1>
-            <a href="{% url 'calendar' %}" class="btn btn-light rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px; border: none;" title="Switch to calendar view" aria-label="Switch to calendar view">
-                <i class="bi bi-calendar3"></i>
+            <a href="{% url 'calendar' %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
+                <i class="bi bi-calendar3 me-2"></i> Switch to calendar
             </a>
         </div>
 

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -6,8 +6,8 @@
     <div class="mb-4">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="fs-2 fw-bold mb-0">Upcoming events</h1>
-            <a href="{% url 'calendar' %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
-                <i class="bi bi-calendar3 me-2"></i> Switch to calendar
+            <a href="{% url 'calendar' %}" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;" title="Switch to calendar view" aria-label="Switch to calendar view">
+                <i class="bi bi-calendar3"></i>
             </a>
         </div>
 

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -6,8 +6,8 @@
     <div class="mb-4">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="fs-2 fw-bold mb-0">Upcoming events</h1>
-            <a href="{% url 'calendar' %}" class="btn btn-light rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px; border: none;" title="Switch to calendar view" aria-label="Switch to calendar view">
-                <i class="bi bi-calendar3"></i>
+            <a href="{% url 'calendar' %}" class="btn btn-primary btn-sm rounded-pill d-inline-flex align-items-center">
+                <i class="bi bi-calendar3 me-2"></i> Switch to calendar
             </a>
         </div>
 

--- a/web/templatetags/nav_tags.py
+++ b/web/templatetags/nav_tags.py
@@ -1,0 +1,29 @@
+from django import template
+
+register = template.Library()
+
+EVENT_URL_NAMES = {
+    'upcoming',
+    'calendar',
+    'calendar_month',
+    'events',
+    'event_detail',
+    'riders_list',
+    'registration_create',
+    'event_registrations_manage',
+    'staff_registration_add',
+    'staff_registration_edit',
+    'staff_registration_withdraw',
+    'membership_number_capture',
+    'registration_submitted',
+    'registration_verification_sent',
+}
+
+
+@register.simple_tag(takes_context=True)
+def events_nav_active(context):
+    request = context.get('request')
+    resolver_match = getattr(request, 'resolver_match', None)
+    if resolver_match and resolver_match.url_name in EVENT_URL_NAMES:
+        return ' active'
+    return ''


### PR DESCRIPTION
## Summary

Consolidates the Upcoming and Calendar menu bar items into a single **Events** item, and restyles the view-switch buttons on the events pages.

### Menu bar
- The desktop and mobile navbars now show one **Events** link instead of separate Upcoming and Calendar links. It points at the existing `events` URL, which redirects to the user's preferred view (upcoming or calendar) stored in the session.
- Added a `events_nav_active` template tag (`web/templatetags/nav_tags.py`) so the Events item is highlighted as active on all event-related pages — upcoming, calendar, event detail, and registration pages — not just the two list views.

### View-switch buttons
- The top-right button that toggles between the upcoming and calendar views (on `list.html`, `list_dense.html`, and `calendar.html`) is now a more prominent solid blue (`btn-primary`) circular icon button, replacing the subtle light-grey one. Icon-only, so it stays compact on mobile; `title`/`aria-label` describe the action.

## Testing
- Full test suite passes (679 tests).
- Verified rendering locally with Playwright screenshots (desktop + mobile) and confirmed the active nav state on upcoming, calendar, and event detail pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SZearDskQ29d3D2ha3YEU