### PR TITLE
Exclude cancelled events from ride count calculations

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -285,6 +285,7 @@ class RegistrationService:
                 user_id__in=user_ids,
                 state=Registration.STATE_CONFIRMED,
             )
+            .exclude(event__state=Event.STATE_CANCELLED)
             .values('user_id')
             .annotate(count=Count('event', distinct=True))
         )

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -606,6 +606,22 @@ class FetchRideCountsTestCase(TestCase):
         # Assert
         self.assertEqual(result, {self.user.id: 1})
 
+    def test_excludes_registrations_for_cancelled_events(self):
+        # Arrange
+        live_event = self._create_event("Live", 1)
+        self._create_confirmed(self.user, live_event)
+
+        cancelled_event = self._create_event("Cancelled", 2)
+        self._create_confirmed(self.user, cancelled_event)
+        cancelled_event.cancel()
+        cancelled_event.save()
+
+        # Act
+        result = self.service.fetch_ride_counts([self.user.id])
+
+        # Assert
+        self.assertEqual(result, {self.user.id: 1})
+
     def test_counts_are_per_user(self):
         # Arrange
         event_one = self._create_event("Event One", 1)


### PR DESCRIPTION
## Summary
Updated the `fetch_ride_counts` method in the registration service to exclude registrations for cancelled events when calculating user ride counts.

## Changes
- Added `.exclude(event__state=Event.STATE_CANCELLED)` filter to the registration query in `RegistrationService.fetch_ride_counts()`
- Added test case `test_excludes_registrations_for_cancelled_events()` to verify that registrations for cancelled events are not counted toward a user's ride total

## Implementation Details
The fix ensures that when calculating how many rides a user has registered for, only confirmed registrations for non-cancelled events are counted. This prevents cancelled events from inflating ride count metrics.

https://claude.ai/code/session_01RK1PCt2atmTRDhxoQWDVNs