### PR TITLE
Extend forecast window to 5 days and expose Forecast in admin

### DIFF
--- a/backoffice/admin.py
+++ b/backoffice/admin.py
@@ -6,7 +6,7 @@ from django.utils.html import format_html
 
 from audit.context import actor
 from backoffice.actions import cancel_event, duplicate_event
-from backoffice.models import Ride, Route, Event, Program, SpeedRange, Registration, Announcement, UserProfile, UserMembershipNumber
+from backoffice.models import Forecast, Ride, Route, Event, Program, SpeedRange, Registration, Announcement, UserProfile, UserMembershipNumber
 from .forms import EventAdminForm
 
 
@@ -117,6 +117,12 @@ class RouteAdmin(AuditedAdminMixin, admin.ModelAdmin):
     search_fields = ('name',)
 
 
+class ForecastAdmin(AuditedAdminMixin, admin.ModelAdmin):
+    list_display = ('time', 'latitude', 'longitude', 'precipitation', 'temperature_min', 'temperature_max', 'aqhi', 'updated_at',)
+    list_filter = ('precipitation',)
+    ordering = ('-time',)
+
+
 class RegistrationAdmin(AuditedAdminMixin, admin.ModelAdmin):
     list_display = ('id', 'state', 'submitted_at', 'username', 'event', 'ride', 'speed_range_preference')
     search_fields = ('user__email', 'user__first_name', 'user__last_name', 'event__name',)
@@ -191,6 +197,7 @@ class UserProfileAdmin(AuditedAdminMixin, admin.ModelAdmin):
 
 admin.site.register(Program, ProgramAdmin)
 admin.site.register(UserProfile, UserProfileAdmin)
+admin.site.register(Forecast, ForecastAdmin)
 admin.site.register(Route, RouteAdmin)
 admin.site.register(SpeedRange, SpeedRangeAdmin)
 admin.site.register(Event, EventAdmin)

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 YOW_LOCATION = (Decimal('45.32250'), Decimal('-75.66920'))
 
 FORECAST_MAX_AGE = timedelta(hours=1)
-FORECAST_WINDOW = timedelta(days=3)
+FORECAST_WINDOW = timedelta(days=5)
 REQUEST_TIMEOUT_SECONDS = 3
 
 WEATHER_URL = 'https://api.open-meteo.com/v1/forecast'
@@ -81,7 +81,7 @@ class ForecastService:
                 'hourly': 'weather_code',
                 'daily': 'temperature_2m_min,temperature_2m_max',
                 'timezone': 'auto',
-                'forecast_days': 4,
+                'forecast_days': 6,
             },
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
@@ -100,7 +100,7 @@ class ForecastService:
                 'longitude': str(longitude),
                 'hourly': 'pm2_5,nitrogen_dioxide,ozone',
                 'timezone': 'auto',
-                'forecast_days': 4,
+                'forecast_days': 6,
             },
             timeout=REQUEST_TIMEOUT_SECONDS,
         )

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -168,9 +168,23 @@ class ForecastServiceTestCase(TestCase):
         self.assertIsNone(forecast)
         mock_get.assert_not_called()
 
+    def test_event_four_days_out_within_window(self):
+        # Arrange
+        starts_at = (timezone.now() + timedelta(days=4)).replace(minute=0, second=0, microsecond=0)
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(starts_at)
+
+            # Act
+            forecast = self.service.get_forecast(self.latitude, self.longitude, starts_at)
+
+        # Assert
+        self.assertIsNotNone(forecast)
+        self.assertEqual(forecast.time, starts_at)
+
     def test_event_beyond_window_returns_none(self):
         # Arrange
-        far_future = timezone.now() + timedelta(days=5)
+        far_future = timezone.now() + timedelta(days=7)
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             # Act
@@ -430,7 +444,7 @@ class ForecastServiceEventsTestCase(TestCase):
 
     def test_events_outside_window_excluded(self):
         # Arrange
-        event = self._create_event('Far out', timezone.now() + timedelta(days=5))
+        event = self._create_event('Far out', timezone.now() + timedelta(days=7))
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             # Act


### PR DESCRIPTION
## Summary

Follow-up to #290:

- **Forecast window extended from 3 to 5 days** — events with rides starting up to 5 days out now show the weather badge. The Open-Meteo requests fetch 6 forecast days to cover the window across local day boundaries.
- **`Forecast` registered in the Django admin** — list view shows time, location, precipitation, min/max temperature, AQHI, and last update, filterable by precipitation and ordered by most recent forecast hour.

## Testing

- Adjusted window-edge tests for the new boundary and added a test that an event 4 days out (previously excluded) now gets a forecast.
- Full suite green: 729 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P)_