### PR TITLE
Use emoji in forecast badge and reorder event badges

### DIFF
--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -423,11 +423,11 @@ class Forecast(models.Model):
         RAIN = 'rain', 'Rain'
         THUNDER = 'thunder', 'Thunder'
 
-    PRECIPITATION_ICONS = {
-        Precipitation.SUN: 'bi-sun',
-        Precipitation.CLOUD: 'bi-cloud',
-        Precipitation.RAIN: 'bi-cloud-rain',
-        Precipitation.THUNDER: 'bi-cloud-lightning-rain',
+    PRECIPITATION_EMOJIS = {
+        Precipitation.SUN: '☀️',
+        Precipitation.CLOUD: '☁️',
+        Precipitation.RAIN: '🌧️',
+        Precipitation.THUNDER: '⛈️',
     }
 
     latitude = models.DecimalField(
@@ -481,8 +481,8 @@ class Forecast(models.Model):
         ]
 
     @property
-    def precipitation_icon(self) -> str:
-        return self.PRECIPITATION_ICONS[self.Precipitation(self.precipitation)]
+    def precipitation_emoji(self) -> str:
+        return self.PRECIPITATION_EMOJIS[self.Precipitation(self.precipitation)]
 
     @property
     def aqhi_display(self) -> str:

--- a/backoffice/tests/models/test_forecast.py
+++ b/backoffice/tests/models/test_forecast.py
@@ -109,18 +109,18 @@ class ForecastModelTestCase(TestCase):
         # Act & Assert
         self.assertEqual(forecast.aqhi_display, '10+')
 
-    def test_precipitation_icon_mapping(self):
+    def test_precipitation_emoji_mapping(self):
         # Arrange
         expectations = {
-            Forecast.Precipitation.SUN: 'bi-sun',
-            Forecast.Precipitation.CLOUD: 'bi-cloud',
-            Forecast.Precipitation.RAIN: 'bi-cloud-rain',
-            Forecast.Precipitation.THUNDER: 'bi-cloud-lightning-rain',
+            Forecast.Precipitation.SUN: '☀️',
+            Forecast.Precipitation.CLOUD: '☁️',
+            Forecast.Precipitation.RAIN: '🌧️',
+            Forecast.Precipitation.THUNDER: '⛈️',
         }
 
-        for precipitation, icon in expectations.items():
+        for precipitation, emoji in expectations.items():
             # Act
             forecast = self._build_forecast(precipitation=precipitation)
 
             # Assert
-            self.assertEqual(forecast.precipitation_icon, icon)
+            self.assertEqual(forecast.precipitation_emoji, emoji)

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -1,6 +1,6 @@
 {% if forecast %}
 <span class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted" style="background-color: #6c757d1A;">
-    <i class="bi {{ forecast.precipitation_icon }} me-1" aria-hidden="true"></i><span class="visually-hidden">{{ forecast.get_precipitation_display }},</span>
+    <span aria-hidden="true">{{ forecast.precipitation_emoji }}</span><span class="visually-hidden">{{ forecast.get_precipitation_display }},</span>
     {{ forecast.temperature_min }}..{{ forecast.temperature_max }}° · AQHI&nbsp;{{ forecast.aqhi_display }} <span class="opacity-75">(beta)</span>
 </span>
 {% endif %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -47,12 +47,12 @@
                 {% elif event.location %}
                 <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                 {% endif %}
+                {% include 'web/events/_forecast_badge.html' %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                 <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
                     🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›
                 </a>
                 {% endif %}
-                {% include 'web/events/_forecast_badge.html' %}
             </div>
         </div>
 

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -54,10 +54,10 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                                 {% endif %}
+                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                                 <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
-                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
                             </div>
                         </div>
                     </div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -54,10 +54,10 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
                                 {% endif %}
+                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                                 <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
-                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
                             </div>
                         </div>
                         {% if event.has_rides or event.distance_range %}

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -56,7 +56,7 @@ class ForecastBadgeViewTestCase(TestCase):
         self.assertContains(response, 'AQHI&nbsp;5')
         self.assertContains(response, '12..15°')
         self.assertContains(response, '(beta)')
-        self.assertContains(response, 'bi-cloud-rain')
+        self.assertContains(response, '🌧️')
 
     @override_flag('weather_forecast_badges', active=False)
     def test_upcoming_hides_badge_when_flag_disabled(self):


### PR DESCRIPTION
## Summary

Follow-up to #290/#291, badge polish:

- **Emoji instead of Bootstrap icons** for precipitation — ☀️ / ☁️ / 🌧️ / ⛈️ — matching the existing 🗺️/🚴 pills and giving colour for better visual clarity. `Forecast.precipitation_icon` becomes `precipitation_emoji`; the screen-reader label is unchanged.
- **Badge order** on event list, dense list, and detail pages is now: program, location, weather, registrations (registrations last).

## Testing

- Updated the emoji mapping and badge rendering tests.
- Full suite green: 730 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P)_