### PR TITLE
Widen gap between forecast emoji and temperature

### DIFF
--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -1,6 +1,6 @@
 {% if forecast %}
 <span class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted" style="background-color: #6c757d1A;">
-    <span aria-hidden="true">{{ forecast.precipitation_emoji }}</span><span class="visually-hidden">{{ forecast.get_precipitation_display }},</span>
+    <span aria-hidden="true" class="me-1">{{ forecast.precipitation_emoji }}</span><span class="visually-hidden">{{ forecast.get_precipitation_display }},</span>
     {{ forecast.temperature_min }}..{{ forecast.temperature_max }}° · AQHI&nbsp;{{ forecast.aqhi_display }} <span class="opacity-75">(beta)</span>
 </span>
 {% endif %}


### PR DESCRIPTION
## Summary

Tiny follow-up to #292, which merged just before this fix landed on its branch: the weather emoji sat visually tighter against the temperature than e.g. the 🚴 registration pill, because the weather glyphs carry less side bearing. Adds `me-1` to the emoji span so the spacing matches the other pills.

## Testing

- Badge view tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P)_