### PR TITLE
Extend forecast window to 7 days, harden space before (beta)

### DIFF
--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 YOW_LOCATION = (Decimal('45.32250'), Decimal('-75.66920'))
 
 FORECAST_MAX_AGE = timedelta(hours=1)
-FORECAST_WINDOW = timedelta(days=5)
+FORECAST_WINDOW = timedelta(days=7)
 REQUEST_TIMEOUT_SECONDS = 3
 
 WEATHER_URL = 'https://api.open-meteo.com/v1/forecast'
@@ -81,7 +81,7 @@ class ForecastService:
                 'hourly': 'weather_code',
                 'daily': 'temperature_2m_min,temperature_2m_max',
                 'timezone': 'auto',
-                'forecast_days': 6,
+                'forecast_days': 8,
             },
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
@@ -100,7 +100,7 @@ class ForecastService:
                 'longitude': str(longitude),
                 'hourly': 'pm2_5,nitrogen_dioxide,ozone',
                 'timezone': 'auto',
-                'forecast_days': 6,
+                'forecast_days': 7,
             },
             timeout=REQUEST_TIMEOUT_SECONDS,
         )

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -184,7 +184,7 @@ class ForecastServiceTestCase(TestCase):
 
     def test_event_beyond_window_returns_none(self):
         # Arrange
-        far_future = timezone.now() + timedelta(days=7)
+        far_future = timezone.now() + timedelta(days=9)
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             # Act
@@ -444,7 +444,7 @@ class ForecastServiceEventsTestCase(TestCase):
 
     def test_events_outside_window_excluded(self):
         # Arrange
-        event = self._create_event('Far out', timezone.now() + timedelta(days=7))
+        event = self._create_event('Far out', timezone.now() + timedelta(days=9))
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             # Act

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -1,6 +1,6 @@
 {% if forecast %}
 <span class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted" style="background-color: #6c757d1A;">
     <span aria-hidden="true" class="me-1">{{ forecast.precipitation_emoji }}</span><span class="visually-hidden">{{ forecast.get_precipitation_display }},</span>
-    {{ forecast.temperature_min }}..{{ forecast.temperature_max }}° · AQHI&nbsp;{{ forecast.aqhi_display }} <span class="opacity-75">(beta)</span>
+    {{ forecast.temperature_min }}..{{ forecast.temperature_max }}° · AQHI&nbsp;{{ forecast.aqhi_display }}&nbsp;<span class="opacity-75">(beta)</span>
 </span>
 {% endif %}

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -111,7 +111,7 @@ class ForecastBadgeViewTestCase(TestCase):
     @override_flag('weather_forecast_badges', active=True)
     def test_detail_hides_badge_for_event_beyond_window(self):
         # Arrange
-        far_starts_at = (timezone.now() + timedelta(days=6)).replace(
+        far_starts_at = (timezone.now() + timedelta(days=9)).replace(
             minute=0, second=0, microsecond=0
         )
         event = self._create_event(starts_at=far_starts_at)


### PR DESCRIPTION
## Summary

- **Forecast window extended from 5 to 7 days.** The weather request now fetches 8 forecast days to cover local day boundaries; the air-quality request fetches 7, which is Open-Meteo's maximum for that API. Consequence: an event right at the 7-day edge whose local calendar day falls beyond the air-quality horizon will fail the fetch and simply show no badge (the existing graceful-degradation path) rather than a partial one.
- **Space before "(beta)"** in the badge is now a `&nbsp;` so it can't be collapsed or wrapped away.

## Testing

- Window-edge tests moved to the new boundary (9 days out = no badge).
- Full suite green: 730 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P)_