### PR TITLE
Polish forecast badge and admin

### DIFF
--- a/backoffice/admin.py
+++ b/backoffice/admin.py
@@ -118,9 +118,9 @@ class RouteAdmin(AuditedAdminMixin, admin.ModelAdmin):
 
 
 class ForecastAdmin(AuditedAdminMixin, admin.ModelAdmin):
-    list_display = ('time', 'end_time', 'latitude', 'longitude', 'precipitation', 'temperature_min', 'temperature_max', 'aqhi_min', 'aqhi_max', 'updated_at',)
-    list_filter = ('precipitation',)
-    ordering = ('-time',)
+    list_display = ('start_time', 'end_time', 'latitude', 'longitude', 'conditions', 'temperature_min', 'temperature_max', 'aqhi_min', 'aqhi_max', 'updated_at',)
+    list_filter = ('conditions',)
+    ordering = ('-start_time',)
 
 
 class RegistrationAdmin(AuditedAdminMixin, admin.ModelAdmin):

--- a/backoffice/migrations/0085_forecast_rename_fields.py
+++ b/backoffice/migrations/0085_forecast_rename_fields.py
@@ -1,0 +1,67 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('backoffice', '0084_forecast_duration_window'),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name='forecast',
+            name='unique_forecast_location_window',
+        ),
+        migrations.RemoveIndex(
+            model_name='forecast',
+            name='forecast_location_window_idx',
+        ),
+        migrations.RenameField(
+            model_name='forecast',
+            old_name='time',
+            new_name='start_time',
+        ),
+        migrations.RenameField(
+            model_name='forecast',
+            old_name='precipitation',
+            new_name='conditions',
+        ),
+        migrations.AlterField(
+            model_name='forecast',
+            name='conditions',
+            field=models.CharField(
+                max_length=32,
+                help_text='Comma-separated weather conditions occurring during the forecast window, worst first.',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='forecast',
+            name='aqhi_min',
+            field=models.PositiveIntegerField(
+                verbose_name='AQHI min',
+                help_text='Lowest Canadian Air Quality Health Index during the forecast window (1-10, 11 means above 10).',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='forecast',
+            name='aqhi_max',
+            field=models.PositiveIntegerField(
+                verbose_name='AQHI max',
+                help_text='Highest Canadian Air Quality Health Index during the forecast window (1-10, 11 means above 10).',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='forecast',
+            constraint=models.UniqueConstraint(
+                fields=('latitude', 'longitude', 'start_time', 'end_time'),
+                name='unique_forecast_location_window',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='forecast',
+            index=models.Index(
+                fields=['latitude', 'longitude', 'start_time', 'end_time'],
+                name='forecast_location_window_idx',
+            ),
+        ),
+    ]

--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -427,19 +427,19 @@ class Route(models.Model):
 
 
 class Forecast(models.Model):
-    class Precipitation(models.TextChoices):
+    class Condition(models.TextChoices):
         SUN = 'sun', 'Sun'
         CLOUD = 'cloud', 'Cloud'
         RAIN = 'rain', 'Rain'
         SNOW = 'snow', 'Snow'
         THUNDER = 'thunder', 'Thunder'
 
-    PRECIPITATION_EMOJIS = {
-        Precipitation.SUN: '☀️',
-        Precipitation.CLOUD: '☁️',
-        Precipitation.RAIN: '☔',
-        Precipitation.SNOW: '❄️',
-        Precipitation.THUNDER: '⚡',
+    CONDITION_EMOJIS = {
+        Condition.SUN: '☀️',
+        Condition.CLOUD: '☁️',
+        Condition.RAIN: '☔',
+        Condition.SNOW: '❄️',
+        Condition.THUNDER: '⚡',
     }
 
     latitude = models.DecimalField(
@@ -454,7 +454,7 @@ class Forecast(models.Model):
         help_text='Longitude of the forecast location.'
     )
 
-    time = models.DateTimeField(
+    start_time = models.DateTimeField(
         help_text='Hour the forecast window starts at, always at the top of the hour.'
     )
 
@@ -467,9 +467,9 @@ class Forecast(models.Model):
         help_text='When this forecast was last fetched from the weather provider.'
     )
 
-    precipitation = models.CharField(
+    conditions = models.CharField(
         max_length=32,
-        help_text='Comma-separated precipitation categories occurring during the forecast window.'
+        help_text='Comma-separated weather conditions occurring during the forecast window, worst first.'
     )
 
     temperature_min = models.IntegerField(
@@ -481,35 +481,43 @@ class Forecast(models.Model):
     )
 
     aqhi_min = models.PositiveIntegerField(
+        verbose_name='AQHI min',
         help_text='Lowest Canadian Air Quality Health Index during the forecast window (1-10, 11 means above 10).'
     )
 
     aqhi_max = models.PositiveIntegerField(
+        verbose_name='AQHI max',
         help_text='Highest Canadian Air Quality Health Index during the forecast window (1-10, 11 means above 10).'
     )
 
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=['latitude', 'longitude', 'time', 'end_time'],
+                fields=['latitude', 'longitude', 'start_time', 'end_time'],
                 name='unique_forecast_location_window',
             )
         ]
         indexes = [
-            models.Index(fields=['latitude', 'longitude', 'time', 'end_time'], name='forecast_location_window_idx'),
+            models.Index(fields=['latitude', 'longitude', 'start_time', 'end_time'], name='forecast_location_window_idx'),
         ]
 
     @property
-    def precipitation_categories(self) -> list:
-        return [self.Precipitation(value) for value in self.precipitation.split(',')]
+    def condition_categories(self) -> list:
+        return [self.Condition(value) for value in self.conditions.split(',')]
 
     @property
-    def precipitation_emojis(self) -> str:
-        return '/'.join(self.PRECIPITATION_EMOJIS[category] for category in self.precipitation_categories)
+    def condition_emojis(self) -> str:
+        return '/'.join(self.CONDITION_EMOJIS[category] for category in self.condition_categories)
 
     @property
-    def precipitation_display(self) -> str:
-        return '/'.join(category.label for category in self.precipitation_categories)
+    def condition_display(self) -> str:
+        return '/'.join(category.label for category in self.condition_categories)
+
+    @property
+    def temperature_display(self) -> str:
+        if self.temperature_min == self.temperature_max:
+            return str(self.temperature_min)
+        return f'{self.temperature_min} – {self.temperature_max}'
 
     @property
     def aqhi_display(self) -> str:
@@ -534,23 +542,23 @@ class Forecast(models.Model):
                 'longitude': 'Longitude must be between -180 and 180.'
             })
 
-        for field, label in (('time', 'Start time'), ('end_time', 'End time')):
+        for field, label in (('start_time', 'Start time'), ('end_time', 'End time')):
             value = getattr(self, field)
             if value and (value.minute or value.second or value.microsecond):
                 raise ValidationError({
                     field: f'{label} must be at the top of the hour.'
                 })
 
-        if self.time and self.end_time and self.end_time < self.time:
+        if self.start_time and self.end_time and self.end_time < self.start_time:
             raise ValidationError({
                 'end_time': 'End time cannot be before the start time.'
             })
 
-        if self.precipitation:
-            valid = set(self.Precipitation.values)
-            if not all(value in valid for value in self.precipitation.split(',')):
+        if self.conditions:
+            valid = set(self.Condition.values)
+            if not all(value in valid for value in self.conditions.split(',')):
                 raise ValidationError({
-                    'precipitation': 'Precipitation must be a comma-separated list of valid categories.'
+                    'conditions': 'Conditions must be a comma-separated list of valid categories.'
                 })
 
         if self.temperature_min is not None and self.temperature_max is not None:
@@ -573,7 +581,7 @@ class Forecast(models.Model):
                 })
 
     def __str__(self):
-        return f'({self.latitude}, {self.longitude}) from {self.time} to {self.end_time}'
+        return f'({self.latitude}, {self.longitude}) from {self.start_time} to {self.end_time}'
 
 
 class SpeedRange(models.Model):

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import requests
 from django.utils import timezone
 
-from backoffice.models import Forecast, Ride
+from backoffice.models import Forecast
 
 logger = logging.getLogger(__name__)
 
@@ -63,12 +63,8 @@ class ForecastService:
         forecasts_by_window: dict = {}
         forecasts_by_event_id: dict = {}
 
-        event_ids_with_rides = set(
-            Ride.objects.filter(event__in=events).values_list('event_id', flat=True)
-        )
-
         for event in events:
-            if event.id not in event_ids_with_rides:
+            if event.virtual:
                 continue
             ends_at = event.starts_at + event.duration
             window = (self._snap_to_hour(event.starts_at), self._snap_to_hour_ceiling(ends_at))

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -35,7 +35,7 @@ class ForecastService:
             return None
 
         existing = Forecast.objects.filter(
-            latitude=latitude, longitude=longitude, time=time, end_time=end_time
+            latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
         ).first()
         if existing and existing.updated_at >= now - FORECAST_MAX_AGE:
             return existing
@@ -52,7 +52,7 @@ class ForecastService:
         forecast, _ = Forecast.objects.update_or_create(
             latitude=latitude,
             longitude=longitude,
-            time=time,
+            start_time=time,
             end_time=end_time,
             defaults=metrics,
         )
@@ -131,7 +131,7 @@ class ForecastService:
         ]
 
         return {
-            'precipitation': self._precipitation_from_weather_codes(weather_codes),
+            'conditions': self._conditions_from_weather_codes(weather_codes),
             'temperature_min': round(min(temperatures)),
             'temperature_max': round(max(temperatures)),
             'aqhi_min': min(aqhi_values),
@@ -198,19 +198,19 @@ class ForecastService:
         return local.strftime('%Y-%m-%dT%H:%M'), local.strftime('%Y-%m-%d')
 
     @classmethod
-    def _precipitation_from_weather_codes(cls, codes: list) -> str:
-        categories = {cls._precipitation_from_weather_code(int(code)) for code in codes}
-        ordered = [category for category in Forecast.Precipitation if category in categories]
+    def _conditions_from_weather_codes(cls, codes: list) -> str:
+        categories = {cls._condition_from_weather_code(int(code)) for code in codes}
+        ordered = [category for category in reversed(Forecast.Condition) if category in categories]
         return ','.join(ordered)
 
     @staticmethod
-    def _precipitation_from_weather_code(code: int) -> str:
+    def _condition_from_weather_code(code: int) -> str:
         if code >= 95:
-            return Forecast.Precipitation.THUNDER
+            return Forecast.Condition.THUNDER
         if 71 <= code <= 77 or code in (85, 86):
-            return Forecast.Precipitation.SNOW
+            return Forecast.Condition.SNOW
         if code >= 51:
-            return Forecast.Precipitation.RAIN
+            return Forecast.Condition.RAIN
         if code >= 2:
-            return Forecast.Precipitation.CLOUD
-        return Forecast.Precipitation.SUN
+            return Forecast.Condition.CLOUD
+        return Forecast.Condition.SUN

--- a/backoffice/tests/models/test_forecast.py
+++ b/backoffice/tests/models/test_forecast.py
@@ -17,9 +17,9 @@ class ForecastModelTestCase(TestCase):
         fields = {
             'latitude': Decimal('45.32250'),
             'longitude': Decimal('-75.66920'),
-            'time': self.time,
+            'start_time': self.time,
             'end_time': self.time + timedelta(hours=2),
-            'precipitation': 'sun',
+            'conditions': 'sun',
             'temperature_min': 5,
             'temperature_max': 15,
             'aqhi_min': 3,
@@ -37,12 +37,12 @@ class ForecastModelTestCase(TestCase):
 
     def test_time_not_at_top_of_hour_rejected(self):
         # Arrange
-        forecast = self._build_forecast(time=self.time + timedelta(minutes=30))
+        forecast = self._build_forecast(start_time=self.time + timedelta(minutes=30))
 
         # Act & Assert
         with self.assertRaises(ValidationError) as ctx:
             forecast.full_clean()
-        self.assertIn('time', ctx.exception.message_dict)
+        self.assertIn('start_time', ctx.exception.message_dict)
 
     def test_end_time_not_at_top_of_hour_rejected(self):
         # Arrange
@@ -134,14 +134,14 @@ class ForecastModelTestCase(TestCase):
             forecast.full_clean()
         self.assertIn('aqhi_max', ctx.exception.message_dict)
 
-    def test_unknown_precipitation_category_rejected(self):
+    def test_unknown_condition_category_rejected(self):
         # Arrange
-        forecast = self._build_forecast(precipitation='sun,hail')
+        forecast = self._build_forecast(conditions='sun,hail')
 
         # Act & Assert
         with self.assertRaises(ValidationError) as ctx:
             forecast.full_clean()
-        self.assertIn('precipitation', ctx.exception.message_dict)
+        self.assertIn('conditions', ctx.exception.message_dict)
 
     def test_aqhi_display_collapses_equal_range(self):
         # Arrange
@@ -164,21 +164,35 @@ class ForecastModelTestCase(TestCase):
         # Act & Assert
         self.assertEqual(forecast.aqhi_display, '9 – 10+')
 
-    def test_precipitation_emojis_joined_with_slash(self):
+    def test_temperature_display_collapses_equal_range(self):
         # Arrange
-        forecast = self._build_forecast(precipitation='sun,cloud')
+        forecast = self._build_forecast(temperature_min=12, temperature_max=12)
 
         # Act & Assert
-        self.assertEqual(forecast.precipitation_emojis, '☀️/☁️')
+        self.assertEqual(forecast.temperature_display, '12')
 
-    def test_precipitation_display_joined_with_slash(self):
+    def test_temperature_display_shows_range(self):
         # Arrange
-        forecast = self._build_forecast(precipitation='rain,thunder')
+        forecast = self._build_forecast(temperature_min=12, temperature_max=15)
 
         # Act & Assert
-        self.assertEqual(forecast.precipitation_display, 'Rain/Thunder')
+        self.assertEqual(forecast.temperature_display, '12 – 15')
 
-    def test_precipitation_emoji_mapping(self):
+    def test_condition_emojis_joined_with_slash(self):
+        # Arrange
+        forecast = self._build_forecast(conditions='cloud,sun')
+
+        # Act & Assert
+        self.assertEqual(forecast.condition_emojis, '☁️/☀️')
+
+    def test_condition_display_joined_with_slash(self):
+        # Arrange
+        forecast = self._build_forecast(conditions='thunder,rain')
+
+        # Act & Assert
+        self.assertEqual(forecast.condition_display, 'Thunder/Rain')
+
+    def test_condition_emoji_mapping(self):
         # Arrange
         expectations = {
             'sun': '☀️',
@@ -188,9 +202,9 @@ class ForecastModelTestCase(TestCase):
             'thunder': '⚡',
         }
 
-        for precipitation, emoji in expectations.items():
+        for condition, emoji in expectations.items():
             # Act
-            forecast = self._build_forecast(precipitation=precipitation)
+            forecast = self._build_forecast(conditions=condition)
 
             # Assert
-            self.assertEqual(forecast.precipitation_emojis, emoji)
+            self.assertEqual(forecast.condition_emojis, emoji)

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -92,9 +92,9 @@ class ForecastServiceTestCase(TestCase):
 
         # Assert
         self.assertIsNotNone(forecast)
-        self.assertEqual(forecast.time, self.starts_at)
+        self.assertEqual(forecast.start_time, self.starts_at)
         self.assertEqual(forecast.end_time, window_end)
-        self.assertEqual(forecast.precipitation, 'sun,cloud,thunder')
+        self.assertEqual(forecast.conditions, 'thunder,cloud,sun')
         self.assertEqual(forecast.temperature_min, 5)
         self.assertEqual(forecast.temperature_max, 16)
         self.assertEqual(forecast.aqhi_min, 3)
@@ -117,9 +117,9 @@ class ForecastServiceTestCase(TestCase):
         Forecast.objects.create(
             latitude=self.latitude,
             longitude=self.longitude,
-            time=self.starts_at,
+            start_time=self.starts_at,
             end_time=self.starts_at + timedelta(hours=1),
-            precipitation='sun',
+            conditions='sun',
             temperature_min=5,
             temperature_max=15,
             aqhi_min=3,
@@ -155,9 +155,9 @@ class ForecastServiceTestCase(TestCase):
         stale = Forecast.objects.create(
             latitude=self.latitude,
             longitude=self.longitude,
-            time=self.starts_at,
+            start_time=self.starts_at,
             end_time=self.starts_at + timedelta(hours=1),
-            precipitation='sun',
+            conditions='sun',
             temperature_min=5,
             temperature_max=15,
             aqhi_min=3,
@@ -179,7 +179,7 @@ class ForecastServiceTestCase(TestCase):
 
         # Assert
         self.assertEqual(forecast.pk, stale.pk)
-        self.assertEqual(forecast.precipitation, 'rain')
+        self.assertEqual(forecast.conditions, 'rain')
         self.assertEqual(forecast.aqhi_min, 10)
         self.assertEqual(forecast.aqhi_max, 10)
         self.assertEqual(Forecast.objects.count(), 1)
@@ -269,9 +269,9 @@ class ForecastServiceTestCase(TestCase):
         stale = Forecast.objects.create(
             latitude=self.latitude,
             longitude=self.longitude,
-            time=self.starts_at,
+            start_time=self.starts_at,
             end_time=self.starts_at + timedelta(hours=1),
-            precipitation='cloud',
+            conditions='cloud',
             temperature_min=5,
             temperature_max=15,
             aqhi_min=3,
@@ -301,41 +301,41 @@ class ForecastServiceTestCase(TestCase):
         # Assert
         self.assertIsNone(forecast)
 
-    def test_precipitation_mapping_from_weather_codes(self):
+    def test_condition_mapping_from_weather_codes(self):
         # Arrange
         expectations = {
-            0: Forecast.Precipitation.SUN,
-            1: Forecast.Precipitation.SUN,
-            2: Forecast.Precipitation.CLOUD,
-            45: Forecast.Precipitation.CLOUD,
-            51: Forecast.Precipitation.RAIN,
-            61: Forecast.Precipitation.RAIN,
-            82: Forecast.Precipitation.RAIN,
-            71: Forecast.Precipitation.SNOW,
-            75: Forecast.Precipitation.SNOW,
-            77: Forecast.Precipitation.SNOW,
-            85: Forecast.Precipitation.SNOW,
-            86: Forecast.Precipitation.SNOW,
-            95: Forecast.Precipitation.THUNDER,
-            99: Forecast.Precipitation.THUNDER,
+            0: Forecast.Condition.SUN,
+            1: Forecast.Condition.SUN,
+            2: Forecast.Condition.CLOUD,
+            45: Forecast.Condition.CLOUD,
+            51: Forecast.Condition.RAIN,
+            61: Forecast.Condition.RAIN,
+            82: Forecast.Condition.RAIN,
+            71: Forecast.Condition.SNOW,
+            75: Forecast.Condition.SNOW,
+            77: Forecast.Condition.SNOW,
+            85: Forecast.Condition.SNOW,
+            86: Forecast.Condition.SNOW,
+            95: Forecast.Condition.THUNDER,
+            99: Forecast.Condition.THUNDER,
         }
 
         for code, expected in expectations.items():
             # Act
-            result = ForecastService._precipitation_from_weather_code(code)
+            result = ForecastService._condition_from_weather_code(code)
 
             # Assert
             self.assertEqual(result, expected, f'weather code {code}')
 
-    def test_precipitation_categories_deduplicated_in_severity_order(self):
+    def test_condition_categories_deduplicated_worst_first(self):
         # Arrange
         codes = [95, 0, 61, 71, 0, 3]
 
         # Act
-        result = ForecastService._precipitation_from_weather_codes(codes)
+        result = ForecastService._conditions_from_weather_codes(codes)
 
         # Assert
-        self.assertEqual(result, 'sun,cloud,rain,snow,thunder')
+        self.assertEqual(result, 'thunder,snow,rain,cloud,sun')
 
 
 class AqhiComputationTestCase(TestCase):

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -476,7 +476,7 @@ class ForecastServiceEventsTestCase(TestCase):
             minute=0, second=0, microsecond=0
         )
 
-    def _create_event(self, name, starts_at, ends_at=None, with_ride=True, cancelled=False):
+    def _create_event(self, name, starts_at, ends_at=None, with_ride=True, cancelled=False, virtual=False):
         event = Event.objects.create(
             program=self.program,
             name=name,
@@ -484,6 +484,7 @@ class ForecastServiceEventsTestCase(TestCase):
             starts_at=starts_at,
             ends_at=ends_at,
             registration_closes_at=starts_at - timedelta(hours=1),
+            virtual=virtual,
         )
         if with_ride:
             Ride.objects.create(name=f'{name} ride', event=event, route=self.route)
@@ -521,9 +522,22 @@ class ForecastServiceEventsTestCase(TestCase):
         # Assert
         self.assertNotEqual(forecasts[short.id].pk, forecasts[long.id].pk)
 
-    def test_events_without_rides_skipped(self):
+    def test_events_without_rides_included(self):
         # Arrange
         event = self._create_event('No rides', self.starts_at, with_ride=False)
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            forecasts = self.service.get_forecasts_for_events([event])
+
+        # Assert
+        self.assertIn(event.id, forecasts)
+
+    def test_virtual_events_skipped(self):
+        # Arrange
+        event = self._create_event('Virtual', self.starts_at, virtual=True)
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             # Act

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -9,18 +9,20 @@ events (`/upcoming` and `/event/<id>`). The implementation lives in
 Events that have at least one ride and start within the next 7 days get a badge:
 
 ```
-☀️/☁️ · 12 – 15° · AQHI 3 – 5 (beta)
+☁️/☀️ · 12 – 15° · AQHI 3 – 5 (beta)
 ```
 
-- **Conditions**: every precipitation category that occurs during the event,
-  slash-separated in severity order (sun ☀️, cloud ☁️, rain ☔, snow ❄️,
-  thunder ⚡).
-- **Temperature**: minimum and maximum in °C across the event's duration.
+- **Conditions**: every weather condition that occurs during the event,
+  slash-separated worst first (thunder ⚡, snow ❄️, rain ☔, cloud ☁️,
+  sun ☀️).
+- **Temperature**: minimum and maximum in °C across the event's duration,
+  collapsed to a single number when they are equal.
 - **AQHI**: minimum and maximum Canadian Air Quality Health Index across the
   event's duration, collapsed to a single value when they are equal, and shown
   as `10+` above 10.
 
-The badge is gated behind the `weather_forecast_badges` waffle flag.
+The badge is gated behind the `weather_forecast_badges` waffle flag and
+credits its source: Open-Meteo.
 
 ## Data source
 
@@ -52,9 +54,9 @@ returned UTC offset. All events currently use a single fixed location, YOW
 
 For each hour in the window:
 
-- **Precipitation category** from the WMO weather code: 95+ thunder,
+- **Condition category** from the WMO weather code: 95+ thunder,
   71-77 and 85-86 snow, other codes 51-94 rain, 2-50 cloud, otherwise sun.
-  The badge shows the distinct set of categories over the window.
+  The badge shows the distinct set of categories over the window, worst first.
 - **Temperature** is `temperature_2m`; the badge shows the rounded min and max
   over the window.
 - **AQHI** is computed with Environment Canada's formula from the 3-hour

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -6,7 +6,7 @@ events (`/upcoming` and `/event/<id>`). The implementation lives in
 
 ## What is shown
 
-Events that have at least one ride and start within the next 7 days get a badge:
+All events except virtual ones that start within the next 7 days get a badge:
 
 ```
 ☁️/☀️ · 12 – 15° · AQHI 3 – 5 (beta)

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -1,6 +1,6 @@
 {% if forecast %}
-<span class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted" style="background-color: #6c757d1A;">
-    <span aria-hidden="true">{{ forecast.precipitation_emojis }}</span><span class="visually-hidden">{{ forecast.precipitation_display }},</span>
-    · {{ forecast.temperature_min }}&nbsp;–&nbsp;{{ forecast.temperature_max }}° · AQHI&nbsp;{{ forecast.aqhi_display }}&nbsp;<span class="opacity-75">(beta)</span>
+<span class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted" style="background-color: #6c757d1A;" title="Weather forecast from Open-Meteo">
+    <span aria-hidden="true" class="me-1">{{ forecast.condition_emojis }}</span><span class="visually-hidden">{{ forecast.condition_display }},</span>
+    · {{ forecast.temperature_display }}° · AQHI&nbsp;{{ forecast.aqhi_display }}&nbsp;<span class="opacity-75">(beta)</span><span class="visually-hidden">, forecast from Open-Meteo</span>
 </span>
 {% endif %}

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -37,9 +37,9 @@ class ForecastBadgeViewTestCase(TestCase):
         return Forecast.objects.create(
             latitude=self.latitude,
             longitude=self.longitude,
-            time=time,
+            start_time=time,
             end_time=time + timedelta(hours=1),
-            precipitation='cloud,rain',
+            conditions='rain,cloud',
             temperature_min=12,
             temperature_max=15,
             aqhi_min=5,
@@ -57,9 +57,24 @@ class ForecastBadgeViewTestCase(TestCase):
 
         # Assert
         self.assertContains(response, 'AQHI&nbsp;5')
-        self.assertContains(response, '· 12&nbsp;–&nbsp;15°')
+        self.assertContains(response, '· 12 – 15°')
         self.assertContains(response, '(beta)')
-        self.assertContains(response, '☁️/☔')
+        self.assertContains(response, '☔/☁️')
+        self.assertContains(response, 'Open-Meteo')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_shows_single_temperature_when_min_equals_max(self):
+        # Arrange
+        self._create_event()
+        forecast = self._create_forecast()
+        Forecast.objects.filter(pk=forecast.pk).update(temperature_min=12, temperature_max=12)
+
+        # Act
+        response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertContains(response, '· 12°')
+        self.assertNotContains(response, '12 – 12')
 
     @override_flag('weather_forecast_badges', active=False)
     def test_upcoming_hides_badge_when_flag_disabled(self):

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -19,7 +19,7 @@ class ForecastBadgeViewTestCase(TestCase):
         )
         self.latitude, self.longitude = YOW_LOCATION
 
-    def _create_event(self, name='Test Event', starts_at=None, with_ride=True):
+    def _create_event(self, name='Test Event', starts_at=None, with_ride=True, virtual=False):
         starts_at = starts_at or self.starts_at
         event = Event.objects.create(
             program=self.program,
@@ -27,6 +27,7 @@ class ForecastBadgeViewTestCase(TestCase):
             description='Description',
             starts_at=starts_at,
             registration_closes_at=starts_at - timedelta(hours=1),
+            virtual=virtual,
         )
         if with_ride:
             Ride.objects.create(name=f'{name} ride', event=event, route=self.route)
@@ -91,13 +92,37 @@ class ForecastBadgeViewTestCase(TestCase):
         mock_get.assert_not_called()
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_upcoming_hides_badge_for_event_without_rides(self):
+    def test_upcoming_shows_badge_for_event_without_rides(self):
         # Arrange
         self._create_event(with_ride=False)
         self._create_forecast()
 
         # Act
         response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertContains(response, 'AQHI&nbsp;5')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_hides_badge_for_virtual_event(self):
+        # Arrange
+        self._create_event(virtual=True)
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertNotContains(response, 'AQHI')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_hides_badge_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_detail', args=[event.id]))
 
         # Assert
         self.assertNotContains(response, 'AQHI')

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -183,7 +183,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
         ).exists()
 
     forecast = None
-    if flag_is_active(request, 'weather_forecast_badges') and event.has_rides:
+    if flag_is_active(request, 'weather_forecast_badges') and not event.virtual:
         latitude, longitude = YOW_LOCATION
         forecast = ForecastService().get_forecast(
             latitude, longitude, event.starts_at, event.starts_at + event.duration


### PR DESCRIPTION
## Summary

Follow-up polish to the forecast badge:

- **Conditions ordered worst to best** — thunder ⚡, snow ❄️, rain ☔, cloud ☁️, sun ☀️ (e.g. `☔/☁️` instead of `☁️/☔`).
- **Wider gap** between the condition emojis and the first `·` separator (`me-1` on the emoji span).
- **Equal temperatures collapse** to a single number: `· 12°` instead of `· 12 – 12°`, via a new `temperature_display` property mirroring `aqhi_display`.
- **Field renames**: `Forecast.time` → `start_time`, `Forecast.precipitation` → `conditions` (it represents the overall weather condition from the API's `weather_code`, not just precipitation). Enum, properties, service, admin, and unique constraint/index follow (migration `0085`).
- **Source credited**: the badge carries `title="Weather forecast from Open-Meteo"` plus screen-reader text, and the algorithm doc states it.
- **Admin shows "AQHI min" / "AQHI max"** via `verbose_name`, instead of the auto-formatted "Aqhi min".
- **Eligibility rule changed**: all events except virtual ones get a forecast badge (previously only events with at least one ride).

## Testing

- Model tests for `temperature_display`, renamed fields, and worst-first ordering; service tests updated for the new ordering, field names, and virtual-event exclusion; view tests for the collapsed single temperature, Open-Meteo attribution, badge on ride-less events, and no badge on virtual events.
- Full suite green: 751 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P