### PR TITLE
Order forecast conditions by prevalence

### DIFF
--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from collections import Counter
 from datetime import timedelta, timezone as datetime_timezone
 from decimal import Decimal
 
@@ -195,8 +196,12 @@ class ForecastService:
 
     @classmethod
     def _conditions_from_weather_codes(cls, codes: list) -> str:
-        categories = {cls._condition_from_weather_code(int(code)) for code in codes}
-        ordered = [category for category in reversed(Forecast.Condition) if category in categories]
+        hour_counts = Counter(cls._condition_from_weather_code(int(code)) for code in codes)
+        severity = list(reversed(Forecast.Condition))
+        ordered = sorted(
+            hour_counts,
+            key=lambda category: (-hour_counts[category], severity.index(category)),
+        )
         return ','.join(ordered)
 
     @staticmethod

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -94,7 +94,7 @@ class ForecastServiceTestCase(TestCase):
         self.assertIsNotNone(forecast)
         self.assertEqual(forecast.start_time, self.starts_at)
         self.assertEqual(forecast.end_time, window_end)
-        self.assertEqual(forecast.conditions, 'thunder,cloud,sun')
+        self.assertEqual(forecast.conditions, 'sun,thunder,cloud')
         self.assertEqual(forecast.temperature_min, 5)
         self.assertEqual(forecast.temperature_max, 16)
         self.assertEqual(forecast.aqhi_min, 3)
@@ -327,9 +327,29 @@ class ForecastServiceTestCase(TestCase):
             # Assert
             self.assertEqual(result, expected, f'weather code {code}')
 
-    def test_condition_categories_deduplicated_worst_first(self):
+    def test_conditions_ordered_by_prevalence(self):
         # Arrange
-        codes = [95, 0, 61, 71, 0, 3]
+        codes = [61, 61, 61, 0, 3, 3]
+
+        # Act
+        result = ForecastService._conditions_from_weather_codes(codes)
+
+        # Assert
+        self.assertEqual(result, 'rain,cloud,sun')
+
+    def test_mostly_sun_with_some_cloud_puts_sun_first(self):
+        # Arrange
+        codes = [0, 0, 0, 3]
+
+        # Act
+        result = ForecastService._conditions_from_weather_codes(codes)
+
+        # Assert
+        self.assertEqual(result, 'sun,cloud')
+
+    def test_equally_prevalent_conditions_ordered_worst_first(self):
+        # Arrange
+        codes = [95, 0, 61, 71, 3]
 
         # Act
         result = ForecastService._conditions_from_weather_codes(codes)

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -12,9 +12,11 @@ All events except virtual ones that start within the next 7 days get a badge:
 ☁️/☀️ · 12 – 15° · AQHI 3 – 5 (beta)
 ```
 
-- **Conditions**: every weather condition that occurs during the event,
-  slash-separated worst first (thunder ⚡, snow ❄️, rain ☔, cloud ☁️,
-  sun ☀️).
+- **Conditions**: every weather condition that occurs during the event
+  (thunder ⚡, snow ❄️, rain ☔, cloud ☁️, sun ☀️), slash-separated and
+  ordered by prevalence — the condition covering the most hours of the
+  window comes first. Conditions covering the same number of hours are
+  ordered worst first.
 - **Temperature**: minimum and maximum in °C across the event's duration,
   collapsed to a single number when they are equal.
 - **AQHI**: minimum and maximum Canadian Air Quality Health Index across the
@@ -56,7 +58,9 @@ For each hour in the window:
 
 - **Condition category** from the WMO weather code: 95+ thunder,
   71-77 and 85-86 snow, other codes 51-94 rain, 2-50 cloud, otherwise sun.
-  The badge shows the distinct set of categories over the window, worst first.
+  The badge shows the distinct set of categories over the window, ordered by
+  the number of hours each category covers (most prevalent first), with ties
+  broken worst first.
 - **Temperature** is `temperature_2m`; the badge shows the rounded min and max
   over the window.
 - **AQHI** is computed with Environment Canada's formula from the 3-hour


### PR DESCRIPTION
The condition emojis now list the condition covering the most hours of
the event window first, so a mostly sunny ride with some cloud reads
sun/cloud. Conditions covering the same number of hours are ordered
worst first.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P