### PR TITLE
Make forecast records immutable

### DIFF
--- a/backoffice/admin.py
+++ b/backoffice/admin.py
@@ -118,9 +118,12 @@ class RouteAdmin(AuditedAdminMixin, admin.ModelAdmin):
 
 
 class ForecastAdmin(AuditedAdminMixin, admin.ModelAdmin):
-    list_display = ('start_time', 'end_time', 'latitude', 'longitude', 'conditions', 'temperature_min', 'temperature_max', 'aqhi_min', 'aqhi_max', 'updated_at',)
+    list_display = ('start_time', 'end_time', 'latitude', 'longitude', 'conditions', 'temperature_min', 'temperature_max', 'aqhi_min', 'aqhi_max', 'prepared_at',)
     list_filter = ('conditions',)
-    ordering = ('-start_time',)
+    ordering = ('-start_time', '-prepared_at',)
+
+    def has_change_permission(self, request, obj=None):
+        return False
 
 
 class RegistrationAdmin(AuditedAdminMixin, admin.ModelAdmin):

--- a/backoffice/admin.py
+++ b/backoffice/admin.py
@@ -121,6 +121,7 @@ class ForecastAdmin(AuditedAdminMixin, admin.ModelAdmin):
     list_display = ('start_time', 'end_time', 'latitude', 'longitude', 'conditions', 'temperature_min', 'temperature_max', 'aqhi_min', 'aqhi_max', 'prepared_at',)
     list_filter = ('conditions',)
     ordering = ('-start_time', '-prepared_at',)
+    readonly_fields = ('latitude', 'longitude', 'start_time', 'end_time', 'prepared_at', 'conditions', 'temperature_min', 'temperature_max', 'aqhi_min', 'aqhi_max',)
 
     def has_change_permission(self, request, obj=None):
         return False

--- a/backoffice/migrations/0086_forecast_immutable.py
+++ b/backoffice/migrations/0086_forecast_immutable.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('backoffice', '0085_forecast_rename_fields'),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name='forecast',
+            name='unique_forecast_location_window',
+        ),
+        migrations.RenameField(
+            model_name='forecast',
+            old_name='updated_at',
+            new_name='prepared_at',
+        ),
+        migrations.AlterField(
+            model_name='forecast',
+            name='prepared_at',
+            field=models.DateTimeField(
+                auto_now_add=True,
+                help_text='When this forecast was fetched from the weather provider. Forecasts are immutable; newer fetches create new records.',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='forecast',
+            name='conditions',
+            field=models.CharField(
+                help_text='Comma-separated weather conditions occurring during the forecast window, most prevalent first.',
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -462,14 +462,14 @@ class Forecast(models.Model):
         help_text='Last hour included in the forecast window, always at the top of the hour.'
     )
 
-    updated_at = models.DateTimeField(
-        auto_now=True,
-        help_text='When this forecast was last fetched from the weather provider.'
+    prepared_at = models.DateTimeField(
+        auto_now_add=True,
+        help_text='When this forecast was fetched from the weather provider. Forecasts are immutable; newer fetches create new records.'
     )
 
     conditions = models.CharField(
         max_length=32,
-        help_text='Comma-separated weather conditions occurring during the forecast window, worst first.'
+        help_text='Comma-separated weather conditions occurring during the forecast window, most prevalent first.'
     )
 
     temperature_min = models.IntegerField(
@@ -491,12 +491,6 @@ class Forecast(models.Model):
     )
 
     class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=['latitude', 'longitude', 'start_time', 'end_time'],
-                name='unique_forecast_location_window',
-            )
-        ]
         indexes = [
             models.Index(fields=['latitude', 'longitude', 'start_time', 'end_time'], name='forecast_location_window_idx'),
         ]

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -35,11 +35,11 @@ class ForecastService:
         if time < self._snap_to_hour(now) or time > now + FORECAST_WINDOW:
             return None
 
-        existing = Forecast.objects.filter(
+        latest = Forecast.objects.filter(
             latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
-        ).first()
-        if existing and existing.updated_at >= now - FORECAST_MAX_AGE:
-            return existing
+        ).order_by('-prepared_at').first()
+        if latest and latest.prepared_at >= now - FORECAST_MAX_AGE:
+            return latest
 
         try:
             metrics = self._fetch_metrics(latitude, longitude, time, end_time)
@@ -48,16 +48,15 @@ class ForecastService:
                 'Forecast fetch failed for (%s, %s) from %s to %s: %s',
                 latitude, longitude, time, end_time, e,
             )
-            return existing
+            return latest
 
-        forecast, _ = Forecast.objects.update_or_create(
+        return Forecast.objects.create(
             latitude=latitude,
             longitude=longitude,
             start_time=time,
             end_time=end_time,
-            defaults=metrics,
+            **metrics,
         )
-        return forecast
 
     def get_forecasts_for_events(self, events) -> dict:
         latitude, longitude = YOW_LOCATION

--- a/backoffice/tests/models/test_forecast.py
+++ b/backoffice/tests/models/test_forecast.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 
@@ -89,13 +88,15 @@ class ForecastModelTestCase(TestCase):
             forecast.full_clean()
         self.assertIn('longitude', ctx.exception.message_dict)
 
-    def test_duplicate_location_and_window_rejected(self):
+    def test_multiple_forecasts_allowed_for_same_location_and_window(self):
         # Arrange
         self._build_forecast().save()
 
-        # Act & Assert
-        with self.assertRaises(IntegrityError):
-            self._build_forecast().save()
+        # Act
+        self._build_forecast().save()
+
+        # Assert
+        self.assertEqual(Forecast.objects.count(), 2)
 
     def test_same_start_different_end_allowed(self):
         # Arrange

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -150,7 +150,7 @@ class ForecastServiceTestCase(TestCase):
         self.assertNotEqual(short.pk, long.pk)
         self.assertEqual(Forecast.objects.count(), 2)
 
-    def test_stale_forecast_refetched_and_updated_in_place(self):
+    def test_stale_forecast_refetched_as_new_record_preserving_old(self):
         # Arrange
         stale = Forecast.objects.create(
             latitude=self.latitude,
@@ -164,7 +164,7 @@ class ForecastServiceTestCase(TestCase):
             aqhi_max=3,
         )
         Forecast.objects.filter(pk=stale.pk).update(
-            updated_at=timezone.now() - timedelta(hours=2)
+            prepared_at=timezone.now() - timedelta(hours=2)
         )
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
@@ -178,11 +178,39 @@ class ForecastServiceTestCase(TestCase):
             forecast = self.service.get_forecast(self.latitude, self.longitude, self.starts_at)
 
         # Assert
-        self.assertEqual(forecast.pk, stale.pk)
+        self.assertNotEqual(forecast.pk, stale.pk)
         self.assertEqual(forecast.conditions, 'rain')
         self.assertEqual(forecast.aqhi_min, 10)
         self.assertEqual(forecast.aqhi_max, 10)
-        self.assertEqual(Forecast.objects.count(), 1)
+        self.assertEqual(Forecast.objects.count(), 2)
+        stale.refresh_from_db()
+        self.assertEqual(stale.conditions, 'sun')
+
+    def test_latest_forecast_returned_when_multiple_exist_for_window(self):
+        # Arrange
+        common = {
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'start_time': self.starts_at,
+            'end_time': self.starts_at + timedelta(hours=1),
+            'temperature_min': 5,
+            'temperature_max': 15,
+            'aqhi_min': 3,
+            'aqhi_max': 3,
+        }
+        old = Forecast.objects.create(conditions='rain', **common)
+        Forecast.objects.filter(pk=old.pk).update(
+            prepared_at=timezone.now() - timedelta(minutes=30)
+        )
+        newer = Forecast.objects.create(conditions='sun', **common)
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecast = self.service.get_forecast(self.latitude, self.longitude, self.starts_at)
+
+        # Assert
+        self.assertEqual(forecast.pk, newer.pk)
+        mock_get.assert_not_called()
 
     def test_start_times_in_same_hour_share_forecast(self):
         # Arrange
@@ -278,7 +306,7 @@ class ForecastServiceTestCase(TestCase):
             aqhi_max=3,
         )
         Forecast.objects.filter(pk=stale.pk).update(
-            updated_at=timezone.now() - timedelta(hours=2)
+            prepared_at=timezone.now() - timedelta(hours=2)
         )
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -81,11 +81,16 @@ For each hour in the window:
 
 ## Caching and refresh
 
-- One `Forecast` row is stored per `(latitude, longitude, time, end_time)`;
-  events sharing the same snapped window share a row and a fetch.
-- A row younger than 1 hour is served as-is. Older rows are refreshed in place
-  (synchronously, on page load) with a 3-second timeout per request.
-- On any fetch or parse error the stale row is served if one exists, otherwise
-  no badge is rendered. A failure never breaks the page and a partial or
+- `Forecast` rows are immutable. Each fetch stores a new row stamped with
+  `prepared_at`; older rows for the same window are preserved, so the history
+  of how the forecast for a given time period evolved can be reconstructed.
+- Lookups key on `(latitude, longitude, start_time, end_time)` and use the row
+  with the latest `prepared_at`; events sharing the same snapped window share
+  rows and fetches.
+- A row younger than 1 hour is served as-is. When the latest row is older, a
+  new one is fetched (synchronously, on page load) with a 3-second timeout per
+  request.
+- On any fetch or parse error the latest stale row is served if one exists,
+  otherwise no badge is rendered. A failure never breaks the page and a partial or
   invalid value is never stored: model validation enforces top-of-hour times,
   ordered min/max pairs, AQHI in 1..11, and known precipitation categories.


### PR DESCRIPTION
## Summary

- **Forecast rows are now immutable.** A stale window triggers a fresh fetch that is stored as a *new* row; the old row is preserved, so the history of how the forecast for a specific time period changed over time can be reconstructed.
- **`updated_at` → `prepared_at`** (`auto_now_add`): the timestamp now describes when that particular forecast was prepared, not when a row was last touched.
- **Unique constraint on `(latitude, longitude, start_time, end_time)` dropped** (migration `0086`) — multiple rows per window are the point. The lookup index is kept; reads take the row with the latest `prepared_at`.
- **Admin**: records can no longer be edited (`has_change_permission` returns `False`), all fields are shown read-only in the detail view (including `prepared_at`, which as a non-editable field would otherwise be hidden), the list shows `prepared_at`, and ordering is by start time then preparation time, newest first.
- Algorithm doc updated to describe the immutable history model.

## Testing

- Service tests: stale refresh creates a new row and preserves the old one unchanged; the newest of several rows for a window is served without refetching; stale-fallback on fetch failure uses `prepared_at`.
- Model test for duplicate windows updated: multiple rows per window are now allowed.
- Full suite green: 754 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LitquWQWjJxsQT4wjnvy9P)_