### PR TITLE
Add /events/<id>/forecasts endpoint

### DIFF
--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -3,7 +3,8 @@ from datetime import date, datetime, timedelta
 from django.db.models import Count, Max, Min, Q, QuerySet
 from django.utils import timezone
 
-from backoffice.models import Event, Registration, Ride
+from backoffice.models import Event, Forecast, Registration, Ride
+from backoffice.services.forecast_service import ForecastService, YOW_LOCATION
 
 
 class EventService:
@@ -105,6 +106,34 @@ class EventService:
         self._copy_rides(source_event, new_event)
 
         return new_event
+
+    def fetch_current_forecast(self, event: Event) -> Forecast | None:
+        if event.virtual:
+            return None
+        latitude, longitude = YOW_LOCATION
+        return ForecastService().get_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
+
+    def fetch_forecasts(self, events) -> dict:
+        windows_by_event_id = {
+            event.id: (event.starts_at, event.starts_at + event.duration)
+            for event in events
+            if not event.virtual
+        }
+        forecasts_by_window = ForecastService().get_forecasts_for_windows(windows_by_event_id.values())
+
+        return {
+            event_id: forecasts_by_window[window]
+            for event_id, window in windows_by_event_id.items()
+            if forecasts_by_window[window]
+        }
+
+    def fetch_forecast_history(self, event: Event) -> QuerySet:
+        if event.virtual:
+            return Forecast.objects.none()
+        latitude, longitude = YOW_LOCATION
+        return ForecastService().get_forecast_history(
+            latitude, longitude, event.starts_at, event.starts_at + event.duration
+        )
 
     def _copy_rides(self, source_event: Event, target_event: Event) -> None:
         for ride in source_event.ride_set.all():

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -5,6 +5,7 @@ from datetime import timedelta, timezone as datetime_timezone
 from decimal import Decimal
 
 import requests
+from django.db.models import QuerySet
 from django.utils import timezone
 
 from backoffice.models import Forecast
@@ -76,6 +77,20 @@ class ForecastService:
                 forecasts_by_event_id[event.id] = forecasts_by_window[window]
 
         return forecasts_by_event_id
+
+    def get_forecasts_for_event(self, event) -> QuerySet:
+        if event.virtual:
+            return Forecast.objects.none()
+
+        latitude, longitude = YOW_LOCATION
+        ends_at = event.starts_at + event.duration
+
+        return Forecast.objects.filter(
+            latitude=latitude,
+            longitude=longitude,
+            start_time=self._snap_to_hour(event.starts_at),
+            end_time=self._snap_to_hour_ceiling(ends_at),
+        ).order_by('-prepared_at')
 
     @staticmethod
     def _snap_to_hour(value):

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -59,45 +59,29 @@ class ForecastService:
             **metrics,
         )
 
-    def get_current_forecast_for_event(self, event) -> Forecast | None:
-        if event.virtual:
-            return None
+    def get_forecasts_for_windows(self, windows) -> dict:
         latitude, longitude = YOW_LOCATION
-        return self.get_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
-
-    def get_forecasts_for_events(self, events) -> dict:
-        latitude, longitude = YOW_LOCATION
+        forecasts_by_snapped_window: dict = {}
         forecasts_by_window: dict = {}
-        forecasts_by_event_id: dict = {}
 
-        for event in events:
-            if event.virtual:
-                continue
-            window = self._window_for_event(event)
-            if window not in forecasts_by_window:
-                forecasts_by_window[window] = self.get_forecast(
-                    latitude, longitude, event.starts_at, event.starts_at + event.duration
+        for window in windows:
+            starts_at, ends_at = window
+            snapped_window = (self._snap_to_hour(starts_at), self._snap_to_hour_ceiling(ends_at))
+            if snapped_window not in forecasts_by_snapped_window:
+                forecasts_by_snapped_window[snapped_window] = self.get_forecast(
+                    latitude, longitude, starts_at, ends_at
                 )
-            if forecasts_by_window[window]:
-                forecasts_by_event_id[event.id] = forecasts_by_window[window]
+            forecasts_by_window[window] = forecasts_by_snapped_window[snapped_window]
 
-        return forecasts_by_event_id
+        return forecasts_by_window
 
-    def get_forecasts_for_event(self, event) -> QuerySet:
-        if event.virtual:
-            return Forecast.objects.none()
-
-        latitude, longitude = YOW_LOCATION
-        start_time, end_time = self._window_for_event(event)
+    def get_forecast_history(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> QuerySet:
+        time = self._snap_to_hour(starts_at)
+        end_time = self._snap_to_hour_ceiling(ends_at) if ends_at else time + timedelta(hours=1)
 
         return Forecast.objects.filter(
-            latitude=latitude, longitude=longitude, start_time=start_time, end_time=end_time
+            latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
         ).order_by('-prepared_at')
-
-    @classmethod
-    def _window_for_event(cls, event) -> tuple:
-        ends_at = event.starts_at + event.duration
-        return cls._snap_to_hour(event.starts_at), cls._snap_to_hour_ceiling(ends_at)
 
     @staticmethod
     def _snap_to_hour(value):

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -59,6 +59,12 @@ class ForecastService:
             **metrics,
         )
 
+    def get_current_forecast_for_event(self, event) -> Forecast | None:
+        if event.virtual:
+            return None
+        latitude, longitude = YOW_LOCATION
+        return self.get_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
+
     def get_forecasts_for_events(self, events) -> dict:
         latitude, longitude = YOW_LOCATION
         forecasts_by_window: dict = {}
@@ -67,11 +73,10 @@ class ForecastService:
         for event in events:
             if event.virtual:
                 continue
-            ends_at = event.starts_at + event.duration
-            window = (self._snap_to_hour(event.starts_at), self._snap_to_hour_ceiling(ends_at))
+            window = self._window_for_event(event)
             if window not in forecasts_by_window:
                 forecasts_by_window[window] = self.get_forecast(
-                    latitude, longitude, event.starts_at, ends_at
+                    latitude, longitude, event.starts_at, event.starts_at + event.duration
                 )
             if forecasts_by_window[window]:
                 forecasts_by_event_id[event.id] = forecasts_by_window[window]
@@ -83,14 +88,16 @@ class ForecastService:
             return Forecast.objects.none()
 
         latitude, longitude = YOW_LOCATION
-        ends_at = event.starts_at + event.duration
+        start_time, end_time = self._window_for_event(event)
 
         return Forecast.objects.filter(
-            latitude=latitude,
-            longitude=longitude,
-            start_time=self._snap_to_hour(event.starts_at),
-            end_time=self._snap_to_hour_ceiling(ends_at),
+            latitude=latitude, longitude=longitude, start_time=start_time, end_time=end_time
         ).order_by('-prepared_at')
+
+    @classmethod
+    def _window_for_event(cls, event) -> tuple:
+        ends_at = event.starts_at + event.duration
+        return cls._snap_to_hour(event.starts_at), cls._snap_to_hour_ceiling(ends_at)
 
     @staticmethod
     def _snap_to_hour(value):

--- a/backoffice/tests/services/test_event_service.py
+++ b/backoffice/tests/services/test_event_service.py
@@ -1,12 +1,14 @@
 import datetime
 from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.utils import timezone
 
-from backoffice.models import Event, Program, Registration, Ride, Route, SpeedRange
+from backoffice.models import Event, Forecast, Program, Registration, Ride, Route, SpeedRange
 from backoffice.services.event_service import EventService
+from backoffice.services.forecast_service import YOW_LOCATION
 
 
 class BaseEventServiceTest(TestCase):
@@ -690,3 +692,186 @@ class FetchEventsForMonthQueryFilterTests(TestCase):
 
         self.assertIn(self.road_event, result)
         self.assertIn(self.gravel_event, result)
+
+
+def _mock_response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _hour_range(start, end, hours_before=0):
+    hours = []
+    hour = start - timedelta(hours=hours_before)
+    while hour <= end:
+        hours.append(hour)
+        hour += timedelta(hours=1)
+    return hours
+
+
+def _mock_get(start, end):
+    weather_hours = _hour_range(start, end)
+    weather_payload = {
+        'utc_offset_seconds': 0,
+        'hourly': {
+            'time': [h.strftime('%Y-%m-%dT%H:%M') for h in weather_hours],
+            'weather_code': [0] * len(weather_hours),
+            'temperature_2m': [10.0] * len(weather_hours),
+        },
+    }
+    air_quality_hours = _hour_range(start, end, hours_before=2)
+    air_quality_payload = {
+        'utc_offset_seconds': 0,
+        'hourly': {
+            'time': [h.strftime('%Y-%m-%dT%H:%M') for h in air_quality_hours],
+            'pm2_5': [8.0] * len(air_quality_hours),
+            'nitrogen_dioxide': [15.0] * len(air_quality_hours),
+            'ozone': [60.0] * len(air_quality_hours),
+        },
+    }
+
+    def side_effect(url, **kwargs):
+        if 'air-quality' in url:
+            return _mock_response(air_quality_payload)
+        return _mock_response(weather_payload)
+
+    return side_effect
+
+
+class EventServiceForecastTestCase(TestCase):
+    def setUp(self):
+        self.program = Program.objects.create(name='Test Program')
+        self.service = EventService()
+        self.starts_at = (timezone.now() + timedelta(days=1)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        self.latitude, self.longitude = YOW_LOCATION
+
+    def _create_event(self, name='Test Event', starts_at=None, ends_at=None, virtual=False):
+        starts_at = starts_at or self.starts_at
+        return Event.objects.create(
+            program=self.program,
+            name=name,
+            description='Description',
+            starts_at=starts_at,
+            ends_at=ends_at,
+            registration_closes_at=starts_at - timedelta(hours=1),
+            virtual=virtual,
+        )
+
+    def _create_forecast(self, start_time=None, end_time=None):
+        start_time = start_time or self.starts_at
+        return Forecast.objects.create(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            start_time=start_time,
+            end_time=end_time or start_time + timedelta(hours=1),
+            conditions='sun',
+            temperature_min=5,
+            temperature_max=15,
+            aqhi_min=3,
+            aqhi_max=3,
+        )
+
+    def test_fetch_current_forecast_fetches_for_event_window(self):
+        # Arrange
+        event = self._create_event()
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            forecast = self.service.fetch_current_forecast(event)
+
+        # Assert
+        self.assertIsNotNone(forecast)
+        self.assertEqual(forecast.start_time, self.starts_at)
+
+    def test_fetch_current_forecast_returns_none_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecast = self.service.fetch_current_forecast(event)
+
+        # Assert
+        self.assertIsNone(forecast)
+        mock_get.assert_not_called()
+
+    def test_fetch_forecasts_groups_events_sharing_a_window(self):
+        # Arrange
+        first = self._create_event('First', self.starts_at + timedelta(minutes=1))
+        second = self._create_event('Second', self.starts_at + timedelta(minutes=55))
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            forecasts = self.service.fetch_forecasts([first, second])
+
+        # Assert
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(forecasts[first.id].pk, forecasts[second.id].pk)
+
+    def test_fetch_forecasts_skips_virtual_events(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecasts = self.service.fetch_forecasts([event])
+
+        # Assert
+        self.assertEqual(forecasts, {})
+        mock_get.assert_not_called()
+
+    def test_fetch_forecasts_excludes_events_beyond_forecast_window(self):
+        # Arrange
+        event = self._create_event(starts_at=timezone.now() + timedelta(days=9))
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecasts = self.service.fetch_forecasts([event])
+
+        # Assert
+        self.assertEqual(forecasts, {})
+        mock_get.assert_not_called()
+
+    def test_fetch_forecast_history_returns_forecasts_for_event_window_newest_first(self):
+        # Arrange
+        event = self._create_event()
+        older = self._create_forecast()
+        Forecast.objects.filter(pk=older.pk).update(
+            prepared_at=timezone.now() - timedelta(minutes=30)
+        )
+        newer = self._create_forecast()
+
+        # Act
+        forecasts = list(self.service.fetch_forecast_history(event))
+
+        # Assert
+        self.assertEqual(forecasts, [newer, older])
+
+    def test_fetch_forecast_history_returns_empty_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+        self._create_forecast()
+
+        # Act
+        forecasts = list(self.service.fetch_forecast_history(event))
+
+        # Assert
+        self.assertEqual(forecasts, [])
+
+    def test_fetch_forecast_history_uses_event_duration(self):
+        # Arrange
+        event = self._create_event(ends_at=self.starts_at + timedelta(hours=3))
+        self._create_forecast(end_time=self.starts_at + timedelta(hours=3))
+
+        # Act
+        forecasts = list(self.service.fetch_forecast_history(event))
+
+        # Assert
+        self.assertEqual(len(forecasts), 1)

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -5,7 +5,7 @@ import requests
 from django.test import TestCase
 from django.utils import timezone
 
-from backoffice.models import Event, Forecast, Program, Ride, Route
+from backoffice.models import Forecast
 from backoffice.services.forecast_service import (
     AIR_QUALITY_URL,
     ForecastService,
@@ -515,130 +515,69 @@ class AqhiComputationTestCase(TestCase):
         self.assertEqual(Forecast.objects.count(), 0)
 
 
-class ForecastServiceEventsTestCase(TestCase):
+class ForecastServiceWindowsTestCase(TestCase):
     def setUp(self):
         self.service = ForecastService()
-        self.program = Program.objects.create(name='Test Program')
-        self.route = Route.objects.create(name='Test Route')
         self.starts_at = (timezone.now() + timedelta(days=1)).replace(
             minute=0, second=0, microsecond=0
         )
 
-    def _create_event(self, name, starts_at, ends_at=None, with_ride=True, cancelled=False, virtual=False):
-        event = Event.objects.create(
-            program=self.program,
-            name=name,
-            description='Description',
-            starts_at=starts_at,
-            ends_at=ends_at,
-            registration_closes_at=starts_at - timedelta(hours=1),
-            virtual=virtual,
-        )
-        if with_ride:
-            Ride.objects.create(name=f'{name} ride', event=event, route=self.route)
-        if cancelled:
-            event.cancel()
-            event.save()
-        return event
-
-    def test_events_with_same_window_trigger_single_fetch(self):
+    def test_windows_sharing_an_hour_trigger_single_fetch(self):
         # Arrange
-        first = self._create_event('First', self.starts_at + timedelta(minutes=1))
-        second = self._create_event('Second', self.starts_at + timedelta(minutes=55))
+        first = (self.starts_at + timedelta(minutes=1), self.starts_at + timedelta(hours=1, minutes=1))
+        second = (self.starts_at + timedelta(minutes=55), self.starts_at + timedelta(hours=1, minutes=55))
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=2))
 
             # Act
-            forecasts = self.service.get_forecasts_for_events([first, second])
+            forecasts = self.service.get_forecasts_for_windows([first, second])
 
         # Assert
         self.assertEqual(mock_get.call_count, 2)
-        self.assertEqual(forecasts[first.id].pk, forecasts[second.id].pk)
+        self.assertEqual(forecasts[first].pk, forecasts[second].pk)
 
-    def test_events_with_different_durations_get_separate_forecasts(self):
+    def test_windows_with_different_durations_get_separate_forecasts(self):
         # Arrange
-        short = self._create_event('Short', self.starts_at, ends_at=self.starts_at + timedelta(hours=1))
-        long = self._create_event('Long', self.starts_at, ends_at=self.starts_at + timedelta(hours=4))
+        short = (self.starts_at, self.starts_at + timedelta(hours=1))
+        long = (self.starts_at, self.starts_at + timedelta(hours=4))
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=4))
 
             # Act
-            forecasts = self.service.get_forecasts_for_events([short, long])
+            forecasts = self.service.get_forecasts_for_windows([short, long])
 
         # Assert
-        self.assertNotEqual(forecasts[short.id].pk, forecasts[long.id].pk)
+        self.assertNotEqual(forecasts[short].pk, forecasts[long].pk)
 
-    def test_events_without_rides_included(self):
+    def test_window_outside_forecast_range_maps_to_none(self):
         # Arrange
-        event = self._create_event('No rides', self.starts_at, with_ride=False)
-
-        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
-
-            # Act
-            forecasts = self.service.get_forecasts_for_events([event])
-
-        # Assert
-        self.assertIn(event.id, forecasts)
-
-    def test_virtual_events_skipped(self):
-        # Arrange
-        event = self._create_event('Virtual', self.starts_at, virtual=True)
+        far_out = timezone.now() + timedelta(days=9)
+        window = (far_out, far_out + timedelta(hours=1))
 
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
             # Act
-            forecasts = self.service.get_forecasts_for_events([event])
+            forecasts = self.service.get_forecasts_for_windows([window])
+
+        # Assert
+        self.assertIsNone(forecasts[window])
+        mock_get.assert_not_called()
+
+    def test_empty_windows_returns_empty_dict(self):
+        # Act
+        forecasts = self.service.get_forecasts_for_windows([])
 
         # Assert
         self.assertEqual(forecasts, {})
-        mock_get.assert_not_called()
-
-    def test_cancelled_events_included(self):
-        # Arrange
-        event = self._create_event('Cancelled', self.starts_at, cancelled=True)
-
-        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
-
-            # Act
-            forecasts = self.service.get_forecasts_for_events([event])
-
-        # Assert
-        self.assertIn(event.id, forecasts)
-
-    def test_events_outside_window_excluded(self):
-        # Arrange
-        event = self._create_event('Far out', timezone.now() + timedelta(days=9))
-
-        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            # Act
-            forecasts = self.service.get_forecasts_for_events([event])
-
-        # Assert
-        self.assertEqual(forecasts, {})
-        mock_get.assert_not_called()
 
 
 class ForecastServiceHistoryTestCase(TestCase):
     def setUp(self):
         self.service = ForecastService()
-        self.program = Program.objects.create(name='Test Program')
         self.latitude, self.longitude = YOW_LOCATION
         self.starts_at = (timezone.now() + timedelta(days=1)).replace(
             minute=0, second=0, microsecond=0
-        )
-
-    def _create_event(self, starts_at=None, ends_at=None, virtual=False):
-        return Event.objects.create(
-            program=self.program,
-            name='Test Event',
-            description='Description',
-            starts_at=starts_at or self.starts_at,
-            ends_at=ends_at,
-            registration_closes_at=(starts_at or self.starts_at) - timedelta(hours=1),
-            virtual=virtual,
         )
 
     def _create_forecast(self, start_time=None, end_time=None):
@@ -655,9 +594,8 @@ class ForecastServiceHistoryTestCase(TestCase):
             aqhi_max=3,
         )
 
-    def test_returns_all_forecasts_for_event_window_newest_first(self):
+    def test_returns_all_forecasts_for_window_newest_first(self):
         # Arrange
-        event = self._create_event()
         older = self._create_forecast()
         Forecast.objects.filter(pk=older.pk).update(
             prepared_at=timezone.now() - timedelta(minutes=30)
@@ -665,29 +603,27 @@ class ForecastServiceHistoryTestCase(TestCase):
         newer = self._create_forecast()
 
         # Act
-        forecasts = list(self.service.get_forecasts_for_event(event))
+        forecasts = list(self.service.get_forecast_history(self.latitude, self.longitude, self.starts_at))
 
         # Assert
         self.assertEqual(forecasts, [newer, older])
 
     def test_excludes_forecasts_for_different_window(self):
         # Arrange
-        event = self._create_event()
         self._create_forecast(start_time=self.starts_at + timedelta(days=1))
 
         # Act
-        forecasts = list(self.service.get_forecasts_for_event(event))
+        forecasts = list(self.service.get_forecast_history(self.latitude, self.longitude, self.starts_at))
 
         # Assert
         self.assertEqual(forecasts, [])
 
-    def test_virtual_event_returns_no_forecasts(self):
+    def test_missing_end_defaults_to_one_hour_window(self):
         # Arrange
-        event = self._create_event(virtual=True)
-        self._create_forecast()
+        self._create_forecast(end_time=self.starts_at + timedelta(hours=1))
 
         # Act
-        forecasts = list(self.service.get_forecasts_for_event(event))
+        forecasts = list(self.service.get_forecast_history(self.latitude, self.longitude, self.starts_at))
 
         # Assert
-        self.assertEqual(forecasts, [])
+        self.assertEqual(len(forecasts), 1)

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -619,3 +619,75 @@ class ForecastServiceEventsTestCase(TestCase):
         # Assert
         self.assertEqual(forecasts, {})
         mock_get.assert_not_called()
+
+
+class ForecastServiceHistoryTestCase(TestCase):
+    def setUp(self):
+        self.service = ForecastService()
+        self.program = Program.objects.create(name='Test Program')
+        self.latitude, self.longitude = YOW_LOCATION
+        self.starts_at = (timezone.now() + timedelta(days=1)).replace(
+            minute=0, second=0, microsecond=0
+        )
+
+    def _create_event(self, starts_at=None, ends_at=None, virtual=False):
+        return Event.objects.create(
+            program=self.program,
+            name='Test Event',
+            description='Description',
+            starts_at=starts_at or self.starts_at,
+            ends_at=ends_at,
+            registration_closes_at=(starts_at or self.starts_at) - timedelta(hours=1),
+            virtual=virtual,
+        )
+
+    def _create_forecast(self, start_time=None, end_time=None):
+        start_time = start_time or self.starts_at
+        return Forecast.objects.create(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            start_time=start_time,
+            end_time=end_time or start_time + timedelta(hours=1),
+            conditions='sun',
+            temperature_min=5,
+            temperature_max=15,
+            aqhi_min=3,
+            aqhi_max=3,
+        )
+
+    def test_returns_all_forecasts_for_event_window_newest_first(self):
+        # Arrange
+        event = self._create_event()
+        older = self._create_forecast()
+        Forecast.objects.filter(pk=older.pk).update(
+            prepared_at=timezone.now() - timedelta(minutes=30)
+        )
+        newer = self._create_forecast()
+
+        # Act
+        forecasts = list(self.service.get_forecasts_for_event(event))
+
+        # Assert
+        self.assertEqual(forecasts, [newer, older])
+
+    def test_excludes_forecasts_for_different_window(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast(start_time=self.starts_at + timedelta(days=1))
+
+        # Act
+        forecasts = list(self.service.get_forecasts_for_event(event))
+
+        # Assert
+        self.assertEqual(forecasts, [])
+
+    def test_virtual_event_returns_no_forecasts(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+        self._create_forecast()
+
+        # Act
+        forecasts = list(self.service.get_forecasts_for_event(event))
+
+        # Assert
+        self.assertEqual(forecasts, [])

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -1,0 +1,143 @@
+import json
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from backoffice.models import Event, Forecast, Program
+from backoffice.services.forecast_service import YOW_LOCATION
+
+
+class EventForecastsViewTestCase(TestCase):
+    def setUp(self):
+        self.program = Program.objects.create(name='Test Program')
+        self.starts_at = (timezone.now() + timedelta(days=1)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        self.latitude, self.longitude = YOW_LOCATION
+
+    def _create_event(self, starts_at=None, ends_at=None, virtual=False):
+        starts_at = starts_at or self.starts_at
+        return Event.objects.create(
+            program=self.program,
+            name='Test Event',
+            description='Description',
+            starts_at=starts_at,
+            ends_at=ends_at,
+            registration_closes_at=starts_at - timedelta(hours=1),
+            virtual=virtual,
+        )
+
+    def _create_forecast(self, start_time=None, end_time=None, prepared_at=None, **overrides):
+        start_time = start_time or self.starts_at
+        end_time = end_time or (start_time + timedelta(hours=1))
+        fields = {
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'start_time': start_time,
+            'end_time': end_time,
+            'conditions': 'rain,cloud',
+            'temperature_min': 12,
+            'temperature_max': 15,
+            'aqhi_min': 5,
+            'aqhi_max': 5,
+            **overrides,
+        }
+        forecast = Forecast.objects.create(**fields)
+        if prepared_at:
+            Forecast.objects.filter(pk=forecast.pk).update(prepared_at=prepared_at)
+            forecast.refresh_from_db()
+        return forecast
+
+    def test_returns_forecast_for_event_window(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(len(data['forecasts']), 1)
+        forecast_data = data['forecasts'][0]
+        self.assertEqual(forecast_data['conditions'], ['rain', 'cloud'])
+        self.assertEqual(forecast_data['temperature_min'], 12)
+        self.assertEqual(forecast_data['temperature_max'], 15)
+        self.assertEqual(forecast_data['aqhi_min'], 5)
+        self.assertEqual(forecast_data['aqhi_max'], 5)
+
+    def test_returns_all_forecasts_prepared_for_window_newest_first(self):
+        # Arrange
+        event = self._create_event()
+        older = self._create_forecast(
+            conditions='sun', prepared_at=timezone.now() - timedelta(minutes=30)
+        )
+        newer = self._create_forecast(conditions='rain')
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        data = json.loads(response.content)
+        prepared_ats = [f['prepared_at'] for f in data['forecasts']]
+        self.assertEqual(len(data['forecasts']), 2)
+        self.assertEqual(data['forecasts'][0]['prepared_at'], newer.prepared_at.isoformat())
+        self.assertEqual(data['forecasts'][1]['prepared_at'], older.prepared_at.isoformat())
+        self.assertEqual(prepared_ats, sorted(prepared_ats, reverse=True))
+
+    def test_excludes_forecasts_for_other_windows(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast(start_time=self.starts_at + timedelta(days=1))
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        data = json.loads(response.content)
+        self.assertEqual(data['forecasts'], [])
+
+    def test_returns_empty_list_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        data = json.loads(response.content)
+        self.assertEqual(data['forecasts'], [])
+
+    def test_returns_empty_list_when_no_forecasts_prepared(self):
+        # Arrange
+        event = self._create_event()
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        data = json.loads(response.content)
+        self.assertEqual(data['forecasts'], [])
+
+    def test_uses_event_duration_to_determine_window(self):
+        # Arrange
+        event = self._create_event(ends_at=self.starts_at + timedelta(hours=3))
+        self._create_forecast(end_time=self.starts_at + timedelta(hours=3))
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        data = json.loads(response.content)
+        self.assertEqual(len(data['forecasts']), 1)
+
+    def test_returns_404_for_unknown_event(self):
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[999999]))
+
+        # Assert
+        self.assertEqual(response.status_code, 404)

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from web.views.events import event_detail, event_list, event_registrations, \
+from web.views.events import event_detail, event_forecasts, event_list, event_registrations, \
     event_emergency_contacts, event_emails, event_registrations_print, calendar_view, events_redirect
 from web.views.events_ical import EventFeed
 from web.views.helpers import changes_email_addresses
@@ -38,6 +38,7 @@ urlpatterns = [
     path('events/<int:event_id>/registrations/print', event_registrations_print, name='event_registrations_print'),
     path('events/<int:event_id>/registrations', event_registrations, name='riders_list'),
     path('events/<int:event_id>/registration', registration_create, name='registration_create'),
+    path('events/<int:event_id>/forecasts', event_forecasts, name='event_forecasts'),
     path('events/<int:event_id>', event_detail, name='event_detail'),
     path('events.ics', EventFeed(), name='event_feed'),
     path('registrations/<int:registration_id>/withdraw', registration_withdraw, name='registration_withdraw'),

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -17,7 +17,6 @@ from waffle import flag_is_active
 from audit.services import AuditService
 from backoffice.models import Event, Registration
 from backoffice.services.event_service import EventService
-from backoffice.services.forecast_service import ForecastService
 from backoffice.services.registration_service import RegistrationService
 from web.filters import PublicRegistrationFilter
 from web.tables import PublicRegistrationTable
@@ -184,7 +183,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
 
     forecast = None
     if flag_is_active(request, 'weather_forecast_badges'):
-        forecast = ForecastService().get_current_forecast_for_event(event)
+        forecast = EventService().fetch_current_forecast(event)
 
     context = {
         'event': event,
@@ -200,7 +199,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
 def event_forecasts(request: HttpRequest, event_id: int) -> JsonResponse:
     event = get_object_or_404(Event, id=event_id)
 
-    forecasts = ForecastService().get_forecasts_for_event(event)
+    forecasts = EventService().fetch_forecast_history(event)
 
     return JsonResponse({
         'forecasts': [
@@ -251,7 +250,7 @@ def event_list(request: HttpRequest) -> HttpResponse:
 
     forecasts = {}
     if flag_is_active(request, 'weather_forecast_badges'):
-        forecasts = ForecastService().get_forecasts_for_events(events)
+        forecasts = EventService().fetch_forecasts(events)
 
     context = {
         'forecasts': forecasts,

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -17,7 +17,7 @@ from waffle import flag_is_active
 from audit.services import AuditService
 from backoffice.models import Event, Registration
 from backoffice.services.event_service import EventService
-from backoffice.services.forecast_service import ForecastService, YOW_LOCATION
+from backoffice.services.forecast_service import ForecastService
 from backoffice.services.registration_service import RegistrationService
 from web.filters import PublicRegistrationFilter
 from web.tables import PublicRegistrationTable
@@ -183,11 +183,8 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
         ).exists()
 
     forecast = None
-    if flag_is_active(request, 'weather_forecast_badges') and not event.virtual:
-        latitude, longitude = YOW_LOCATION
-        forecast = ForecastService().get_forecast(
-            latitude, longitude, event.starts_at, event.starts_at + event.duration
-        )
+    if flag_is_active(request, 'weather_forecast_badges'):
+        forecast = ForecastService().get_current_forecast_for_event(event)
 
     context = {
         'event': event,

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse
 from django.utils import timezone
@@ -198,6 +198,28 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
     }
 
     return render(request, 'web/events/detail.html', context)
+
+
+def event_forecasts(request: HttpRequest, event_id: int) -> JsonResponse:
+    event = get_object_or_404(Event, id=event_id)
+
+    forecasts = ForecastService().get_forecasts_for_event(event)
+
+    return JsonResponse({
+        'forecasts': [
+            {
+                'prepared_at': forecast.prepared_at.isoformat(),
+                'start_time': forecast.start_time.isoformat(),
+                'end_time': forecast.end_time.isoformat(),
+                'conditions': forecast.conditions.split(','),
+                'temperature_min': forecast.temperature_min,
+                'temperature_max': forecast.temperature_max,
+                'aqhi_min': forecast.aqhi_min,
+                'aqhi_max': forecast.aqhi_max,
+            }
+            for forecast in forecasts
+        ],
+    })
 
 
 def _get_filter_params(request):


### PR DESCRIPTION
Returns JSON with every Forecast record prepared for the time window
an event spans, newest first, using the event's start/end snapped to
the hour the same way ForecastService already does for the badge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PYfj3YoqCS155F8FvdojdD