### PR TITLE
Render event forecast history as a page instead of JSON

### DIFF
--- a/web/templates/web/events/forecasts.html
+++ b/web/templates/web/events/forecasts.html
@@ -1,0 +1,34 @@
+{% extends 'web/_base_bootstrap.html' %}
+{% block title %}Forecast history for {{ event.name }}{% endblock %}
+{% block content %}
+    <div class="mb-4">
+        <div class="d-flex flex-wrap gap-2 align-items-center mb-4">
+            <a href="{% url 'event_detail' event.id %}" class="btn btn-outline-secondary btn-sm rounded-pill d-inline-flex align-items-center">
+                <i class="bi bi-arrow-left me-2"></i> Back to event
+            </a>
+        </div>
+
+        <div class="mb-4">
+            <div class="text-muted small mb-2">
+                {{ event.starts_at|date:"l, F j" }} · {{ event.starts_at|date:"g:i A" }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A" }}{% endif %}
+            </div>
+            <h1 class="fs-2 fw-bold mb-2">{{ event.name }}</h1>
+        </div>
+
+        <h2 class="fs-5 fw-medium mb-3">Forecast history</h2>
+        <div class="card shadow-sm mb-4">
+            <div class="card-body p-4">
+                <div class="list-group list-group-flush">
+                    {% for forecast in forecasts %}
+                    <div class="list-group-item d-flex flex-wrap align-items-center justify-content-between gap-2 px-0">
+                        <span class="text-muted small">{{ forecast.prepared_at|date:"M j, g:i A" }}</span>
+                        {% include 'web/events/_forecast_badge.html' %}
+                    </div>
+                    {% empty %}
+                    <p class="text-muted mb-0">No forecasts have been prepared for this event yet.</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -1,4 +1,3 @@
-import json
 from datetime import timedelta
 
 from django.test import TestCase
@@ -50,7 +49,7 @@ class EventForecastsViewTestCase(TestCase):
             forecast.refresh_from_db()
         return forecast
 
-    def test_returns_forecast_for_event_window(self):
+    def test_renders_forecast_for_event_window(self):
         # Arrange
         event = self._create_event()
         self._create_forecast()
@@ -60,33 +59,27 @@ class EventForecastsViewTestCase(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content)
-        self.assertEqual(len(data['forecasts']), 1)
-        forecast_data = data['forecasts'][0]
-        self.assertEqual(forecast_data['conditions'], ['rain', 'cloud'])
-        self.assertEqual(forecast_data['temperature_min'], 12)
-        self.assertEqual(forecast_data['temperature_max'], 15)
-        self.assertEqual(forecast_data['aqhi_min'], 5)
-        self.assertEqual(forecast_data['aqhi_max'], 5)
+        self.assertTemplateUsed(response, 'web/events/forecasts.html')
+        self.assertContains(response, 'AQHI&nbsp;5')
+        self.assertContains(response, '15°')
+        self.assertContains(response, '☔/☁️')
 
-    def test_returns_all_forecasts_prepared_for_window_newest_first(self):
+    def test_shows_all_forecasts_prepared_for_window_newest_first(self):
         # Arrange
         event = self._create_event()
-        older = self._create_forecast(
+        self._create_forecast(
             conditions='sun', prepared_at=timezone.now() - timedelta(minutes=30)
         )
-        newer = self._create_forecast(conditions='rain')
+        self._create_forecast(conditions='rain')
 
         # Act
         response = self.client.get(reverse('event_forecasts', args=[event.id]))
 
         # Assert
-        data = json.loads(response.content)
-        prepared_ats = [f['prepared_at'] for f in data['forecasts']]
-        self.assertEqual(len(data['forecasts']), 2)
-        self.assertEqual(data['forecasts'][0]['prepared_at'], newer.prepared_at.isoformat())
-        self.assertEqual(data['forecasts'][1]['prepared_at'], older.prepared_at.isoformat())
-        self.assertEqual(prepared_ats, sorted(prepared_ats, reverse=True))
+        content = response.content.decode()
+        self.assertContains(response, '☔')
+        self.assertContains(response, '☀️')
+        self.assertLess(content.index('☔'), content.index('☀️'))
 
     def test_excludes_forecasts_for_other_windows(self):
         # Arrange
@@ -97,10 +90,9 @@ class EventForecastsViewTestCase(TestCase):
         response = self.client.get(reverse('event_forecasts', args=[event.id]))
 
         # Assert
-        data = json.loads(response.content)
-        self.assertEqual(data['forecasts'], [])
+        self.assertContains(response, 'No forecasts have been prepared for this event yet.')
 
-    def test_returns_empty_list_for_virtual_event(self):
+    def test_shows_empty_state_for_virtual_event(self):
         # Arrange
         event = self._create_event(virtual=True)
         self._create_forecast()
@@ -109,10 +101,9 @@ class EventForecastsViewTestCase(TestCase):
         response = self.client.get(reverse('event_forecasts', args=[event.id]))
 
         # Assert
-        data = json.loads(response.content)
-        self.assertEqual(data['forecasts'], [])
+        self.assertContains(response, 'No forecasts have been prepared for this event yet.')
 
-    def test_returns_empty_list_when_no_forecasts_prepared(self):
+    def test_shows_empty_state_when_no_forecasts_prepared(self):
         # Arrange
         event = self._create_event()
 
@@ -120,8 +111,7 @@ class EventForecastsViewTestCase(TestCase):
         response = self.client.get(reverse('event_forecasts', args=[event.id]))
 
         # Assert
-        data = json.loads(response.content)
-        self.assertEqual(data['forecasts'], [])
+        self.assertContains(response, 'No forecasts have been prepared for this event yet.')
 
     def test_uses_event_duration_to_determine_window(self):
         # Arrange
@@ -132,8 +122,7 @@ class EventForecastsViewTestCase(TestCase):
         response = self.client.get(reverse('event_forecasts', args=[event.id]))
 
         # Assert
-        data = json.loads(response.content)
-        self.assertEqual(len(data['forecasts']), 1)
+        self.assertContains(response, 'AQHI&nbsp;5')
 
     def test_returns_404_for_unknown_event(self):
         # Act
@@ -141,3 +130,13 @@ class EventForecastsViewTestCase(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 404)
+
+    def test_back_link_points_to_event_detail(self):
+        # Arrange
+        event = self._create_event()
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, reverse('event_detail', args=[event.id]))

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse
 from django.utils import timezone
@@ -196,26 +196,17 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
     return render(request, 'web/events/detail.html', context)
 
 
-def event_forecasts(request: HttpRequest, event_id: int) -> JsonResponse:
+def event_forecasts(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
     forecasts = EventService().fetch_forecast_history(event)
 
-    return JsonResponse({
-        'forecasts': [
-            {
-                'prepared_at': forecast.prepared_at.isoformat(),
-                'start_time': forecast.start_time.isoformat(),
-                'end_time': forecast.end_time.isoformat(),
-                'conditions': forecast.conditions.split(','),
-                'temperature_min': forecast.temperature_min,
-                'temperature_max': forecast.temperature_max,
-                'aqhi_min': forecast.aqhi_min,
-                'aqhi_max': forecast.aqhi_max,
-            }
-            for forecast in forecasts
-        ],
-    })
+    context = {
+        'event': event,
+        'forecasts': forecasts,
+    }
+
+    return render(request, 'web/events/forecasts.html', context)
 
 
 def _get_filter_params(request):


### PR DESCRIPTION
## Summary
- `/events/<id>/forecasts` now renders an HTML page instead of returning JSON.
- The page follows the same layout as the event detail page (back link, date/title header) with a "Forecast history" card listing every prepared forecast for the event's window, newest first.
- Each entry reuses the existing `_forecast_badge.html` partial alongside its `prepared_at` timestamp.
- Empty state ("No forecasts have been prepared for this event yet.") covers virtual events and events with no forecasts yet, via `{% for %}...{% empty %}...{% endfor %}`.
- Public page, no feature-flag gating, consistent with the previous JSON endpoint.

## Test plan
- [x] `uv run python manage.py test` (771 tests, all passing)
- [x] Updated `web/tests/views/test_event_forecasts_views.py` to assert on rendered HTML instead of JSON

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PYfj3YoqCS155F8FvdojdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYfj3YoqCS155F8FvdojdD)_