### PR TITLE
Fix weather badge background, sizing, and pill styling consistency

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -107,8 +107,11 @@ body {
 }
 
 .wx-icon {
-  vertical-align: -3px;
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: -0.2em;
   margin-right: 0.25rem;
+  flex-shrink: 0;
 }
 
 .wx-arrow {

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -117,11 +117,6 @@ body {
   margin: 0 0.15rem;
 }
 
-.chip-sep {
-  margin: 0 0.35rem;
-  color: #adb5bd;
-}
-
 .wx-temp {
   white-space: nowrap;
 }
@@ -131,6 +126,10 @@ body {
   align-items: center;
   font-weight: 500;
   white-space: nowrap;
+}
+
+.meta-pill .wx-aqhi {
+  margin-left: 0.5rem;
 }
 
 .wx-aqhi-dot {
@@ -148,17 +147,8 @@ body {
 .wx-aqhi--very-high { color: #7f1d1d; }
 
 .wx-warning-sep {
-  color: #dc2626;
-  font-weight: 700;
-  margin: 0 0.15rem;
-}
-
-.wx-warning-icon {
-  display: inline-flex;
-  border-radius: 50%;
-  outline: 1.5px solid #dc2626;
-  outline-offset: 1px;
-  padding: 1px;
+  color: #adb5bd;
+  margin-right: 0.25rem;
 }
 
 .wx-aqhi-spike {

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -89,6 +89,10 @@ body {
   font-size: 0.75rem;
 }
 
+.meta-pill-neutral {
+  background-color: rgba(108, 117, 125, 0.1);
+}
+
 .meta-pill-link {
   background-color: rgba(108, 117, 125, 0.1);
   color: var(--bs-primary);
@@ -165,11 +169,12 @@ body {
 
 button.meta-pill {
   cursor: pointer;
-  font: inherit;
+  font-family: inherit;
+  border: 0;
 }
 
 button.meta-pill:hover, button.meta-pill:focus-visible {
-  background-color: rgba(108, 117, 125, 0.2) !important;
+  background-color: rgba(108, 117, 125, 0.2);
 }
 
 .btn-danger {

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -3,8 +3,7 @@
 {% with summary=forecast|forecast_summary %}
 {% if expandable %}
 <button type="button"
-        class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted border-0 bg-transparent"
-        style="background-color: #6c757d1A;"
+        class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted"
         title="Weather forecast from Open-Meteo. Tap for hourly detail."
         aria-label="{{ summary.aria_label }}. Tap for hourly detail."
         aria-haspopup="dialog"
@@ -14,8 +13,7 @@
 </button>
 {% include 'web/events/_forecast_hourly_modal.html' with forecast=forecast summary=summary %}
 {% else %}
-<span class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted"
-      style="background-color: #6c757d1A;"
+<span class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted"
       title="Weather forecast from Open-Meteo"
       role="img"
       aria-label="{{ summary.aria_label }}">

--- a/web/templates/web/events/_forecast_badge_content.html
+++ b/web/templates/web/events/_forecast_badge_content.html
@@ -1,7 +1,7 @@
 {% include 'web/events/_weather_icon.html' with condition=summary.condition_primary %}
 {% if summary.condition_warning %}
 <span class="wx-warning-sep" aria-hidden="true">+</span>
-<span class="wx-warning-icon" title="{{ summary.condition_warning_label|capfirst }} possible">
+<span class="wx-warning-icon">
     {% include 'web/events/_weather_icon.html' with condition=summary.condition_warning %}
 </span>
 {% endif %}
@@ -9,10 +9,10 @@
 <span class="wx-temp" aria-hidden="true">{{ summary.temperature_display }}&nbsp;&deg;C</span>
 {% if summary.aqhi_category %}
 <span class="chip-sep" aria-hidden="true">&middot;</span>
-<span class="wx-aqhi wx-aqhi--{{ summary.aqhi_category|slugify }}" title="Air Quality Health Index (beta)" aria-hidden="true">
+<span class="wx-aqhi wx-aqhi--{{ summary.aqhi_category|slugify }}" aria-hidden="true">
     <span class="wx-aqhi-dot"></span>AQHI&nbsp;{{ summary.aqhi_category }}
 </span>
 {% if summary.aqhi_warning_category %}
-<span class="wx-aqhi-spike wx-aqhi--{{ summary.aqhi_warning_category|slugify }}" title="Spike to AQHI {{ summary.aqhi_warning_category }} possible" aria-hidden="true">&uarr;{{ summary.aqhi_warning_category }}</span>
+<span class="wx-aqhi-spike wx-aqhi--{{ summary.aqhi_warning_category|slugify }}" aria-hidden="true">&uarr;{{ summary.aqhi_warning_category }}</span>
 {% endif %}
 {% endif %}

--- a/web/templates/web/events/_forecast_badge_content.html
+++ b/web/templates/web/events/_forecast_badge_content.html
@@ -1,14 +1,10 @@
 {% include 'web/events/_weather_icon.html' with condition=summary.condition_primary %}
 {% if summary.condition_warning %}
-<span class="wx-warning-sep" aria-hidden="true">+</span>
-<span class="wx-warning-icon">
-    {% include 'web/events/_weather_icon.html' with condition=summary.condition_warning %}
-</span>
+<span class="wx-warning-sep" aria-hidden="true">/</span>
+{% include 'web/events/_weather_icon.html' with condition=summary.condition_warning %}
 {% endif %}
-<span class="chip-sep" aria-hidden="true">&middot;</span>
 <span class="wx-temp" aria-hidden="true">{{ summary.temperature_display }}&nbsp;&deg;C</span>
 {% if summary.aqhi_category %}
-<span class="chip-sep" aria-hidden="true">&middot;</span>
 <span class="wx-aqhi wx-aqhi--{{ summary.aqhi_category|slugify }}" aria-hidden="true">
     <span class="wx-aqhi-dot"></span>AQHI&nbsp;{{ summary.aqhi_category }}
 </span>

--- a/web/templates/web/events/_weather_icon.html
+++ b/web/templates/web/events/_weather_icon.html
@@ -1,25 +1,25 @@
 {% if condition == 'sun' %}
-<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="4"/>
-    <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>
+<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M12 1.5v3M12 19.5v3M4.57 4.57l2.12 2.12M17.31 17.31l2.12 2.12M1.5 12h3M19.5 12h3M4.57 19.43l2.12-2.12M17.31 6.69l2.12-2.12" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="12" cy="12" r="5" fill="#fbbf24" stroke="#f59e0b" stroke-width="1"/>
 </svg>
 {% elif condition == 'cloud' %}
-<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M17.5 19H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z"/>
+<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M17.5 19H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z" fill="#cbd5e1" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round"/>
 </svg>
 {% elif condition == 'rain' %}
-<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M17.5 15H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z"/>
-    <path d="M8 19v2M12 18v3M16 19v2"/>
+<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M17.5 15H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z" fill="#cbd5e1" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M8 18v3M12 17.5v3M16 18v3" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
 </svg>
 {% elif condition == 'snow' %}
-<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M17.5 15H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z"/>
-    <path d="M8 19h.01M12 21h.01M16 19h.01M10 22h.01M14 18h.01"/>
+<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M17.5 15H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z" fill="#cbd5e1" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M8 18.5h.01M12 20.5h.01M16 18.5h.01M10 21.5h.01M14 17.5h.01" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round"/>
 </svg>
 {% elif condition == 'thunder' %}
-<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M19.5 14.5a4.5 4.5 0 0 0-2-8.5h-1.8A7 7 0 1 0 6 15.5"/>
-    <path d="M13 11l-3 5h4l-3 5" stroke="#f59e0b"/>
+<svg class="wx-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M17.5 14H9a7 7 0 1 1 6.7-9h1.8a4.5 4.5 0 1 1 0 9Z" fill="#cbd5e1" stroke="#94a3b8" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M13.4 9.5 8.6 16h3.2l-1.7 5.5 6.3-7.5h-3.3l2.7-4.5Z" fill="#fbbf24" stroke="#f59e0b" stroke-width="1" stroke-linejoin="round"/>
 </svg>
 {% endif %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -37,7 +37,7 @@
                 {% if event.cancelled %}<span class="text-decoration-line-through">{{ event.name }}</span> (cancelled){% else %}{{ event.name }}{% endif %}
             </h1>
             <div class="d-flex flex-wrap gap-2 align-items-center">
-                <span class="meta-pill text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+                <span class="meta-pill meta-pill-neutral text-muted"{% if event.program.color %} style="background-color: {{ event.program.color }}1A;"{% endif %}>{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
                 {% if event.location_url %}
                 <a href="{{ event.location_url }}"
                    class="meta-pill meta-pill-link"
@@ -45,7 +45,7 @@
                     🗺️ {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
                 </a>
                 {% elif event.location %}
-                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
+                <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
                 {% include 'web/events/_forecast_badge.html' with expandable=True %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -50,13 +50,13 @@
                                 {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
                             </h3>
                             <div class="d-flex flex-wrap gap-2 align-items-center">
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
+                                <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted"{% if event.program.color %} style="background-color: {{ event.program.color }}1A;"{% endif %}>{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
                                 {% if event.location %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
+                                <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
                                 {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
+                                <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -50,13 +50,13 @@
                                 {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
                             </div>
                             <div class="d-flex flex-wrap gap-2 align-items-center">
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
+                                <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted"{% if event.program.color %} style="background-color: {{ event.program.color }}1A;"{% endif %}>{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program.name }}</span>
                                 {% if event.location %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
+                                <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
                                 {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
-                                <span class="meta-pill meta-pill-sm text-muted" style="background-color: #6c757d1A;">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
+                                <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -27,7 +27,7 @@
                 {% if event.cancelled %}<span class="text-decoration-line-through">{{ event.name }}</span> (cancelled){% else %}{{ event.name }}{% endif %}
             </h1>
             <div class="d-flex flex-wrap gap-2 align-items-center">
-                <span class="meta-pill text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+                <span class="meta-pill meta-pill-neutral text-muted"{% if event.program.color %} style="background-color: {{ event.program.color }}1A;"{% endif %}>{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
                 {% if event.location_url %}
                 <a href="{{ event.location_url }}"
                    class="meta-pill meta-pill-link"
@@ -35,7 +35,7 @@
                     🗺️ {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
                 </a>
                 {% elif event.location %}
-                <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
+                <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
             </div>
         </div>

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -183,7 +183,7 @@
             {% if event.cancelled %}<span class="text-decoration-line-through">{{ event.name }}</span> (cancelled){% else %}{{ event.name }}{% endif %}
         </h1>
         <div class="d-flex flex-wrap gap-2 align-items-center">
-            <span class="meta-pill text-muted" style="background-color: {% if event.program.color %}{{ event.program.color }}1A{% else %}#6c757d1A{% endif %};">{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
+            <span class="meta-pill meta-pill-neutral text-muted"{% if event.program.color %} style="background-color: {{ event.program.color }}1A;"{% endif %}>{% if event.program.emoji %}{{ event.program.emoji }} {% endif %}{{ event.program }}</span>
             {% if event.location_url %}
             <a href="{{ event.location_url }}"
                class="meta-pill meta-pill-link"
@@ -191,7 +191,7 @@
                 🗺️ {% if event.location %}{{ event.location }}{% else %}See location{% endif %}&nbsp;↗
             </a>
             {% elif event.location %}
-            <span class="meta-pill text-muted" style="background-color: #6c757d1A;">🗺️ {{ event.location }}</span>
+            <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
             {% endif %}
         </div>
     </div>

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -59,7 +59,7 @@ class ForecastBadgeViewTestCase(TestCase):
         # Assert
         self.assertContains(response, 'AQHI&nbsp;moderate')
         self.assertContains(response, '12\u201315&nbsp;&deg;C')
-        self.assertContains(response, '(beta)')
+        self.assertNotContains(response, '(beta)')
         self.assertNotContains(response, '\U0001F327')
         self.assertContains(response, 'Open-Meteo')
 
@@ -140,6 +140,7 @@ class ForecastBadgeViewTestCase(TestCase):
 
         # Assert
         self.assertContains(response, 'AQHI&nbsp;moderate')
+        self.assertContains(response, '(beta)')
 
     @override_flag('weather_forecast_badges', active=False)
     def test_detail_hides_badge_when_flag_disabled(self):


### PR DESCRIPTION
The expandable weather badge rendered without a background because
Bootstrap's bg-transparent utility (!important) defeated the inline
background colour, and its text rendered larger than sibling pills
because the font shorthand in button.meta-pill reset the font-size
and line-height set by .meta-pill.

Introduce a meta-pill-neutral class for the shared grey pill
background and replace the inline #6c757d1A styles across event
templates, keeping inline styles only for dynamically coloured
program pills. Move the button border reset into the stylesheet and
drop the !important from the hover rule.

Remove the nested title tooltips inside the badge content since they
shadowed the badge-level tooltip and were unreachable on touch
devices; the hourly modal remains the canonical home for the raw
AQHI value and beta disclosure.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NpDrPzb15bVZxipABHmE6H