### PR TITLE
Fix 500 on forecast history page and link to it from weather popup

### DIFF
--- a/backoffice/migrations/0089_delete_forecasts_without_hourly.py
+++ b/backoffice/migrations/0089_delete_forecasts_without_hourly.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def delete_forecasts_without_hourly(apps, schema_editor):
+    Forecast = apps.get_model('backoffice', 'Forecast')
+    Forecast.objects.filter(hourly=[]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("backoffice", "0088_alter_forecast_hourly"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_forecasts_without_hourly, migrations.RunPython.noop),
+    ]

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -80,7 +80,7 @@ class ForecastService:
 
         return Forecast.objects.filter(
             latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
-        ).order_by('-prepared_at')
+        ).exclude(hourly=[]).order_by('-prepared_at')
 
     @staticmethod
     def _snap_to_hour(value):

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -630,6 +630,18 @@ class ForecastServiceHistoryTestCase(TestCase):
         # Assert
         self.assertEqual(forecasts, [])
 
+    def test_excludes_forecasts_without_hourly_readings(self):
+        # Arrange
+        with_readings = self._create_forecast()
+        empty = self._create_forecast()
+        Forecast.objects.filter(pk=empty.pk).update(hourly=[])
+
+        # Act
+        forecasts = list(self.service.get_forecast_history(self.latitude, self.longitude, self.starts_at))
+
+        # Assert
+        self.assertEqual(forecasts, [with_readings])
+
     def test_missing_end_defaults_to_one_hour_window(self):
         # Arrange
         self._create_forecast(end_time=self.starts_at + timedelta(hours=1))

--- a/web/templates/web/events/_forecast_hourly_modal.html
+++ b/web/templates/web/events/_forecast_hourly_modal.html
@@ -42,6 +42,13 @@
           </tbody>
         </table>
       </div>
+      {% if show_history_link %}
+      <div class="modal-footer justify-content-start">
+        <a href="{% url 'event_forecasts' event.id %}" class="small">
+          <i class="bi bi-clock-history me-1"></i>View forecast history
+        </a>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -47,7 +47,7 @@
                 {% elif event.location %}
                 <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
-                {% include 'web/events/_forecast_badge.html' with expandable=True %}
+                {% include 'web/events/_forecast_badge.html' with expandable=True show_history_link=True %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                 <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
                     🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -93,6 +93,19 @@ class EventForecastsViewTestCase(TestCase):
         # Assert
         self.assertContains(response, 'No forecasts have been prepared for this event yet.')
 
+    def test_ignores_forecasts_without_hourly_readings(self):
+        # Arrange
+        event = self._create_event()
+        forecast = self._create_forecast()
+        Forecast.objects.filter(pk=forecast.pk).update(hourly=[])
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'No forecasts have been prepared for this event yet.')
+
     def test_shows_empty_state_for_virtual_event(self):
         # Arrange
         event = self._create_event(virtual=True)

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -142,6 +142,31 @@ class ForecastBadgeViewTestCase(TestCase):
         self.assertContains(response, 'AQHI&nbsp;moderate')
         self.assertContains(response, '(beta)')
 
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_popup_links_to_forecast_history(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_detail', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, reverse('event_forecasts', args=[event.id]))
+        self.assertContains(response, 'View forecast history')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_popup_has_no_forecast_history_link(self):
+        # Arrange
+        self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertNotContains(response, 'View forecast history')
+
     @override_flag('weather_forecast_badges', active=False)
     def test_detail_hides_badge_when_flag_disabled(self):
         # Arrange


### PR DESCRIPTION
Forecasts created before migration 0087 were left with empty hourly
readings, crashing summarize() on the forecast history page (Sentry
OBC-RIDEHUB-4S). Exclude such forecasts from get_forecast_history and
delete the orphaned rows in a data migration. Also add a forecast
history link to the hourly weather popup on the event detail page.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TVwspVaxq7aHrpufvxHTe