### PR TITLE
Warn on any AQHI spike above the prevalent category

### DIFF
--- a/backoffice/services/forecast_summary.py
+++ b/backoffice/services/forecast_summary.py
@@ -15,7 +15,6 @@ CONDITION_WARNING_LABELS = {
 }
 
 AQHI_CATEGORY_ORDER = ['low', 'moderate', 'high', 'very high']
-AQHI_WARNING_CATEGORIES = {'high', 'very high'}
 
 TEMPERATURE_COLLAPSE_SPAN = 2
 
@@ -124,7 +123,7 @@ def _aqhi_warning(hourly: list[HourlyReading], prevalent_category: str | None) -
         return None
     categories = [reading.aqhi_category for reading in hourly if reading.aqhi_category is not None]
     worst = max(categories, key=AQHI_CATEGORY_ORDER.index)
-    if worst in AQHI_WARNING_CATEGORIES and AQHI_CATEGORY_ORDER.index(worst) > AQHI_CATEGORY_ORDER.index(prevalent_category):
+    if AQHI_CATEGORY_ORDER.index(worst) > AQHI_CATEGORY_ORDER.index(prevalent_category):
         return worst
     return None
 

--- a/backoffice/tests/services/test_forecast_summary.py
+++ b/backoffice/tests/services/test_forecast_summary.py
@@ -143,9 +143,9 @@ class ForecastSummaryTestCase(TestCase):
 
         # Assert
         self.assertEqual(summary.aqhi_category, 'low')
-        self.assertIsNone(summary.aqhi_warning_category)
+        self.assertEqual(summary.aqhi_warning_category, 'moderate')
 
-    def test_mild_aqhi_bump_does_not_warn(self):
+    def test_aqhi_bump_to_moderate_warns(self):
         # Arrange
         forecast = self._build_forecast([
             self._hour(0, 'sun', 20, 2),
@@ -157,6 +157,21 @@ class ForecastSummaryTestCase(TestCase):
         summary = summarize(forecast)
 
         # Assert
+        self.assertEqual(summary.aqhi_warning_category, 'moderate')
+
+    def test_no_aqhi_warning_when_all_hours_share_category(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'sun', 20, 2),
+            self._hour(1, 'sun', 20, 3),
+            self._hour(2, 'sun', 20, 2),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertEqual(summary.aqhi_category, 'low')
         self.assertIsNone(summary.aqhi_warning_category)
 
     def test_aqhi_spike_to_high_warns(self):


### PR DESCRIPTION
## Summary

The badge's AQHI spike indicator only fired when some hour reached *high* or *very high*. A ride window that is mostly low with a couple of hours at moderate — e.g. a forecast of 2/2/2/3/3/**4**/**4** — displayed a plain "AQHI low" with no hint that air quality worsens mid-ride.

`_aqhi_warning` in `ForecastSummary` now shows the spike marker (`↑moderate`) whenever any hour's category is worse than the prevalent one, dropping the `AQHI_WARNING_CATEGORIES` gate. The composed aria-label picks the change up automatically ("air quality low, spike to moderate"). Windows whose hours all share one category still show no marker.

Tests: `test_mild_aqhi_bump_does_not_warn` encoded the old behaviour and is replaced by `test_aqhi_bump_to_moderate_warns`; a new `test_no_aqhi_warning_when_all_hours_share_category` pins the no-spike case, and the prevalence test now expects the moderate warning alongside the prevalent low.

## Test plan

- [x] `uv run python manage.py test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpDrPzb15bVZxipABHmE6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpDrPzb15bVZxipABHmE6H)_