### PR TITLE
Tighten weather badge formatting

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -135,15 +135,6 @@ body {
   margin-left: 0.5rem;
 }
 
-.wx-aqhi-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin-right: 0.3rem;
-  background-color: currentColor;
-}
-
 .wx-aqhi--low { color: #0891b2; }
 .wx-aqhi--moderate { color: #d97706; }
 .wx-aqhi--high { color: #dc2626; }
@@ -155,9 +146,8 @@ body {
 }
 
 .wx-aqhi-spike {
-  margin-left: 0.3rem;
-  font-size: 0.85em;
-  font-weight: 600;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 button.meta-pill {

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -122,6 +122,7 @@ body {
 
 .wx-temp {
   white-space: nowrap;
+  margin-left: 0.25rem;
 }
 
 .wx-aqhi {

--- a/web/templates/web/events/_forecast_badge_content.html
+++ b/web/templates/web/events/_forecast_badge_content.html
@@ -3,12 +3,10 @@
 <span class="wx-warning-sep" aria-hidden="true">/</span>
 {% include 'web/events/_weather_icon.html' with condition=summary.condition_warning %}
 {% endif %}
-<span class="wx-temp" aria-hidden="true">{{ summary.temperature_display }}&nbsp;&deg;C</span>
+<span class="wx-temp" aria-hidden="true">{{ summary.temperature_display }}&deg;</span>
 {% if summary.aqhi_category %}
-<span class="wx-aqhi wx-aqhi--{{ summary.aqhi_category|slugify }}" aria-hidden="true">
-    <span class="wx-aqhi-dot"></span>AQHI&nbsp;{{ summary.aqhi_category }}
-</span>
+<span class="wx-aqhi wx-aqhi--{{ summary.aqhi_category|slugify }}" aria-hidden="true">AQHI&nbsp;{{ summary.aqhi_category }}</span>
 {% if summary.aqhi_warning_category %}
-<span class="wx-aqhi-spike wx-aqhi--{{ summary.aqhi_warning_category|slugify }}" aria-hidden="true">&uarr;{{ summary.aqhi_warning_category }}</span>
+<span class="wx-aqhi-spike wx-aqhi--{{ summary.aqhi_warning_category|slugify }}" aria-hidden="true">&rarr;{{ summary.aqhi_warning_category }}</span>
 {% endif %}
 {% endif %}

--- a/web/templates/web/events/_forecast_hourly_modal.html
+++ b/web/templates/web/events/_forecast_hourly_modal.html
@@ -27,12 +27,10 @@
                 {% include 'web/events/_weather_icon.html' with condition=hour.condition %}
                 <span class="visually-hidden">{{ hour.condition.label }}</span>
               </td>
-              <td>{{ hour.temperature }}&nbsp;&deg;C</td>
+              <td>{{ hour.temperature }}&deg;</td>
               <td>
                 {% if hour.aqhi_category %}
-                <span class="wx-aqhi wx-aqhi--{{ hour.aqhi_category|slugify }}">
-                    <span class="wx-aqhi-dot"></span>{{ hour.aqhi_display }}&nbsp;&middot;&nbsp;{{ hour.aqhi_category }}
-                </span>
+                <span class="wx-aqhi wx-aqhi--{{ hour.aqhi_category|slugify }}">{{ hour.aqhi_display }}&nbsp;&middot;&nbsp;{{ hour.aqhi_category }}</span>
                 {% else %}
                 <span class="text-muted">&ndash;</span>
                 {% endif %}

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -59,7 +59,7 @@ class EventForecastsViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'web/events/forecasts.html')
         self.assertContains(response, 'AQHI&nbsp;moderate')
-        self.assertContains(response, '12\u201315&nbsp;&deg;C')
+        self.assertContains(response, '12\u201315&deg;')
         self.assertContains(response, 'rainy')
 
     def test_shows_all_forecasts_prepared_for_window_newest_first(self):

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -58,7 +58,7 @@ class ForecastBadgeViewTestCase(TestCase):
 
         # Assert
         self.assertContains(response, 'AQHI&nbsp;moderate')
-        self.assertContains(response, '12\u201315&nbsp;&deg;C')
+        self.assertContains(response, '12\u201315&deg;')
         self.assertNotContains(response, '(beta)')
         self.assertNotContains(response, '\U0001F327')
         self.assertContains(response, 'Open-Meteo')
@@ -76,7 +76,7 @@ class ForecastBadgeViewTestCase(TestCase):
         response = self.client.get(reverse('upcoming'))
 
         # Assert
-        self.assertContains(response, '12&nbsp;&deg;C')
+        self.assertContains(response, '12&deg;')
         self.assertNotContains(response, '12\u201312')
 
     @override_flag('weather_forecast_badges', active=False)


### PR DESCRIPTION
## Summary

Three small presentation tweaks to the weather badge and hourly modal:

- **Temperature**: `12–15°` instead of `12–15 °C` — no space before the degree sign, no unit letter. Applied to both the badge and the modal's hourly rows; the aria-label keeps saying "degrees Celsius" so nothing is lost for screen readers.
- **AQHI spike**: rendered as an arrow chain, e.g. blue `AQHI low` followed immediately by orange `→moderate` — the base category keeps its own colour, the arrow and target category take the warning category's colour. The arrow changed from `↑` to `→` and the spike text now matches the base segment's size and weight so it reads as one phrase.
- **AQHI dot removed** from both the badge and the modal, since the coloured category text carries the signal on its own; the now-unused `.wx-aqhi-dot` rule is deleted.

## Test plan

- [x] `uv run python manage.py test` — full suite passes
- [x] Rendered the badge variants (single temp, range, spike, compact) in headless Chromium and verified the new formatting and colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpDrPzb15bVZxipABHmE6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpDrPzb15bVZxipABHmE6H)_