### PR TITLE
Load weather badges asynchronously via HTMX

### DIFF
--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -107,6 +107,9 @@ class EventService:
 
         return new_event
 
+    def forecast_possible(self, event: Event) -> bool:
+        return not event.virtual and ForecastService().is_within_window(event.starts_at)
+
     def fetch_current_forecast(self, event: Event) -> Forecast | None:
         if event.virtual:
             return None

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -74,6 +74,11 @@ class ForecastService:
 
         return forecasts_by_window
 
+    def is_within_window(self, starts_at) -> bool:
+        now = timezone.now()
+        time = self._snap_to_hour(starts_at)
+        return self._snap_to_hour(now) <= time <= now + FORECAST_WINDOW
+
     def get_forecast_history(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> QuerySet:
         time = self._snap_to_hour(starts_at)
         end_time = self._snap_to_hour_ceiling(ends_at) if ends_at else time + timedelta(hours=1)

--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -151,6 +151,16 @@ body {
   white-space: nowrap;
 }
 
+.wx-loading {
+  opacity: 0.6;
+}
+
+.wx-spinner {
+  width: 1.2em;
+  height: 1.2em;
+  border-width: 0.15em;
+}
+
 button.meta-pill {
   cursor: pointer;
   font-family: inherit;

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -13,7 +13,7 @@
 </button>
 {% include 'web/events/_forecast_hourly_modal.html' with forecast=forecast summary=summary %}
 {% else %}
-<span class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted"
+<span {% if oob %}id="forecast-badge-{{ event.id }}" hx-swap-oob="outerHTML" {% endif %}class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted"
       title="Weather forecast from Open-Meteo"
       role="img"
       aria-label="{{ summary.aria_label }}">

--- a/web/templates/web/events/_forecast_badge_loading.html
+++ b/web/templates/web/events/_forecast_badge_loading.html
@@ -1,0 +1,7 @@
+<span id="forecast-badge-{{ event.id }}"
+      class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted wx-loading"
+      role="status"
+      aria-label="Loading weather forecast"
+      {% if hx_get %}hx-get="{{ hx_get }}" hx-trigger="load" hx-swap="outerHTML"{% endif %}>
+    <span class="spinner-border wx-spinner" aria-hidden="true"></span>
+</span>

--- a/web/templates/web/events/_forecast_badges_oob.html
+++ b/web/templates/web/events/_forecast_badges_oob.html
@@ -1,0 +1,10 @@
+{% load dict_filters %}
+{% for event in events %}
+{% with forecast=forecasts|get_item:event.id %}
+{% if forecast %}
+{% include 'web/events/_forecast_badge.html' with forecast=forecast compact=True oob=True %}
+{% else %}
+<span id="forecast-badge-{{ event.id }}" hx-swap-oob="delete"></span>
+{% endif %}
+{% endwith %}
+{% endfor %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -47,7 +47,10 @@
                 {% elif event.location %}
                 <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
-                {% include 'web/events/_forecast_badge.html' with expandable=True show_history_link=True %}
+                {% if forecast_placeholder %}
+                {% url 'event_forecast_badge' event.id as forecast_badge_url %}
+                {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
+                {% endif %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                 <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
                     🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -54,7 +54,9 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
-                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
+                                {% if event.id in forecast_event_ids %}
+                                {% include 'web/events/_forecast_badge_loading.html' with compact=True %}
+                                {% endif %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
@@ -75,6 +77,11 @@
             {% endif %}
         </div>
         {% endfor %}
+        {% if forecast_event_ids %}
+        <div hx-get="{% url 'upcoming_forecast_badges' %}{% if active_query %}?q={{ active_query|urlencode }}{% endif %}"
+             hx-trigger="load"
+             hx-swap="none"></div>
+        {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -54,7 +54,9 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
-                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
+                                {% if event.id in forecast_event_ids %}
+                                {% include 'web/events/_forecast_badge_loading.html' with compact=True %}
+                                {% endif %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
@@ -95,6 +97,11 @@
             {% endif %}
         </div>
         {% endfor %}
+        {% if forecast_event_ids %}
+        <div hx-get="{% url 'upcoming_forecast_badges' %}{% if active_query %}?q={{ active_query|urlencode }}{% endif %}"
+             hx-trigger="load"
+             hx-swap="none"></div>
+        {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+import requests
+
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -10,7 +12,7 @@ from backoffice.models import Event, Forecast, Program, Ride, Route
 from backoffice.services.forecast_service import YOW_LOCATION
 
 
-class ForecastBadgeViewTestCase(TestCase):
+class ForecastBadgeTestCase(TestCase):
     def setUp(self):
         self.program = Program.objects.create(name='Test Program')
         self.route = Route.objects.create(name='Test Route')
@@ -47,24 +49,85 @@ class ForecastBadgeViewTestCase(TestCase):
             hourly=hourly,
         )
 
+
+class UpcomingPageForecastPlaceholderTests(ForecastBadgeTestCase):
     @override_flag('weather_forecast_badges', active=True)
-    def test_upcoming_shows_badge_for_event_with_ride(self):
+    def test_upcoming_shows_placeholder_without_fetching_forecast(self):
         # Arrange
-        self._create_event()
-        self._create_forecast()
+        event = self._create_event()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertContains(response, f'forecast-badge-{event.id}')
+        self.assertContains(response, reverse('upcoming_forecast_badges'))
+        self.assertContains(response, 'Loading weather forecast')
+        self.assertNotContains(response, 'AQHI')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=False)
+    def test_upcoming_hides_placeholder_when_flag_disabled(self):
+        # Arrange
+        event = self._create_event()
 
         # Act
         response = self.client.get(reverse('upcoming'))
 
         # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+        self.assertNotContains(response, reverse('upcoming_forecast_badges'))
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_hides_placeholder_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+
+        # Act
+        response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+        self.assertNotContains(response, reverse('upcoming_forecast_badges'))
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_hides_placeholder_for_event_beyond_window(self):
+        # Arrange
+        far_starts_at = (timezone.now() + timedelta(days=9)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        event = self._create_event(starts_at=far_starts_at)
+
+        # Act
+        response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+        self.assertNotContains(response, reverse('upcoming_forecast_badges'))
+
+
+class UpcomingForecastBadgesViewTests(ForecastBadgeTestCase):
+    @override_flag('weather_forecast_badges', active=True)
+    def test_badges_endpoint_returns_badge_for_event_with_ride(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('upcoming_forecast_badges'))
+
+        # Assert
+        self.assertContains(response, f'id="forecast-badge-{event.id}"')
+        self.assertContains(response, 'hx-swap-oob="outerHTML"')
         self.assertContains(response, 'AQHI&nbsp;moderate')
-        self.assertContains(response, '12\u201315&deg;')
+        self.assertContains(response, '12–15&deg;')
         self.assertNotContains(response, '(beta)')
         self.assertNotContains(response, '\U0001F327')
         self.assertContains(response, 'Open-Meteo')
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_upcoming_shows_single_temperature_when_within_two_degree_span(self):
+    def test_badges_endpoint_shows_single_temperature_when_within_two_degree_span(self):
         # Arrange
         self._create_event()
         self._create_forecast(hourly=[
@@ -73,114 +136,119 @@ class ForecastBadgeViewTestCase(TestCase):
         ])
 
         # Act
-        response = self.client.get(reverse('upcoming'))
+        response = self.client.get(reverse('upcoming_forecast_badges'))
 
         # Assert
         self.assertContains(response, '12&deg;')
-        self.assertNotContains(response, '12\u201312')
+        self.assertNotContains(response, '12–12')
 
     @override_flag('weather_forecast_badges', active=False)
-    def test_upcoming_hides_badge_when_flag_disabled(self):
+    def test_badges_endpoint_returns_nothing_when_flag_disabled(self):
         # Arrange
         self._create_event()
         self._create_forecast()
 
         # Act
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            response = self.client.get(reverse('upcoming'))
+            response = self.client.get(reverse('upcoming_forecast_badges'))
 
         # Assert
-        self.assertNotContains(response, 'AQHI')
+        self.assertEqual(response.content.strip(), b'')
         mock_get.assert_not_called()
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_upcoming_shows_badge_for_event_without_rides(self):
+    def test_badges_endpoint_returns_badge_for_event_without_rides(self):
         # Arrange
         self._create_event(with_ride=False)
         self._create_forecast()
 
         # Act
-        response = self.client.get(reverse('upcoming'))
+        response = self.client.get(reverse('upcoming_forecast_badges'))
 
         # Assert
         self.assertContains(response, 'AQHI&nbsp;moderate')
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_upcoming_hides_badge_for_virtual_event(self):
-        # Arrange
-        self._create_event(virtual=True)
-        self._create_forecast()
-
-        # Act
-        response = self.client.get(reverse('upcoming'))
-
-        # Assert
-        self.assertNotContains(response, 'AQHI')
-
-    @override_flag('weather_forecast_badges', active=True)
-    def test_detail_hides_badge_for_virtual_event(self):
+    def test_badges_endpoint_skips_virtual_event(self):
         # Arrange
         event = self._create_event(virtual=True)
         self._create_forecast()
 
         # Act
-        response = self.client.get(reverse('event_detail', args=[event.id]))
+        response = self.client.get(reverse('upcoming_forecast_badges'))
 
         # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
         self.assertNotContains(response, 'AQHI')
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_detail_shows_badge_for_event_with_ride(self):
+    def test_badges_endpoint_deletes_placeholder_when_forecast_unavailable(self):
         # Arrange
         event = self._create_event()
-        self._create_forecast()
 
         # Act
-        response = self.client.get(reverse('event_detail', args=[event.id]))
+        with patch('backoffice.services.forecast_service.requests.get', side_effect=requests.RequestException('down')):
+            response = self.client.get(reverse('upcoming_forecast_badges'))
 
         # Assert
-        self.assertContains(response, 'AQHI&nbsp;moderate')
-        self.assertContains(response, '(beta)')
+        self.assertContains(response, f'id="forecast-badge-{event.id}"')
+        self.assertContains(response, 'hx-swap-oob="delete"')
+        self.assertNotContains(response, 'AQHI')
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_detail_popup_links_to_forecast_history(self):
-        # Arrange
-        event = self._create_event()
-        self._create_forecast()
-
-        # Act
-        response = self.client.get(reverse('event_detail', args=[event.id]))
-
-        # Assert
-        self.assertContains(response, reverse('event_forecasts', args=[event.id]))
-        self.assertContains(response, 'View forecast history')
-
-    @override_flag('weather_forecast_badges', active=True)
-    def test_upcoming_popup_has_no_forecast_history_link(self):
+    def test_badges_endpoint_has_no_forecast_history_link(self):
         # Arrange
         self._create_event()
         self._create_forecast()
 
         # Act
-        response = self.client.get(reverse('upcoming'))
+        response = self.client.get(reverse('upcoming_forecast_badges'))
 
         # Assert
         self.assertNotContains(response, 'View forecast history')
 
-    @override_flag('weather_forecast_badges', active=False)
-    def test_detail_hides_badge_when_flag_disabled(self):
+
+class DetailPageForecastPlaceholderTests(ForecastBadgeTestCase):
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_shows_placeholder_without_fetching_forecast(self):
         # Arrange
         event = self._create_event()
-        self._create_forecast()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('event_detail', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, f'forecast-badge-{event.id}')
+        self.assertContains(response, reverse('event_forecast_badge', args=[event.id]))
+        self.assertContains(response, 'Loading weather forecast')
+        self.assertNotContains(response, 'AQHI')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=False)
+    def test_detail_hides_placeholder_when_flag_disabled(self):
+        # Arrange
+        event = self._create_event()
 
         # Act
         response = self.client.get(reverse('event_detail', args=[event.id]))
 
         # Assert
-        self.assertNotContains(response, 'AQHI')
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_detail_hides_badge_for_event_beyond_window(self):
+    def test_detail_hides_placeholder_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+
+        # Act
+        response = self.client.get(reverse('event_detail', args=[event.id]))
+
+        # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_hides_placeholder_for_event_beyond_window(self):
         # Arrange
         far_starts_at = (timezone.now() + timedelta(days=9)).replace(
             minute=0, second=0, microsecond=0
@@ -192,11 +260,95 @@ class ForecastBadgeViewTestCase(TestCase):
             response = self.client.get(reverse('event_detail', args=[event.id]))
 
         # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_shows_placeholder_for_cancelled_event(self):
+        # Arrange
+        event = self._create_event()
+        event.cancel()
+        event.save()
+
+        # Act
+        response = self.client.get(reverse('event_detail', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, f'forecast-badge-{event.id}')
+
+
+class EventForecastBadgeViewTests(ForecastBadgeTestCase):
+    @override_flag('weather_forecast_badges', active=True)
+    def test_badge_endpoint_returns_expandable_badge(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_forecast_badge', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, 'AQHI&nbsp;moderate')
+        self.assertContains(response, '(beta)')
+        self.assertContains(response, 'data-bs-toggle="modal"')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_badge_endpoint_includes_forecast_history_link(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_forecast_badge', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, reverse('event_forecasts', args=[event.id]))
+        self.assertContains(response, 'View forecast history')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_badge_endpoint_returns_nothing_for_virtual_event(self):
+        # Arrange
+        event = self._create_event(virtual=True)
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('event_forecast_badge', args=[event.id]))
+
+        # Assert
+        self.assertNotContains(response, 'AQHI')
+
+    @override_flag('weather_forecast_badges', active=False)
+    def test_badge_endpoint_returns_nothing_when_flag_disabled(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('event_forecast_badge', args=[event.id]))
+
+        # Assert
         self.assertNotContains(response, 'AQHI')
         mock_get.assert_not_called()
 
     @override_flag('weather_forecast_badges', active=True)
-    def test_detail_shows_badge_for_cancelled_event(self):
+    def test_badge_endpoint_returns_nothing_for_event_beyond_window(self):
+        # Arrange
+        far_starts_at = (timezone.now() + timedelta(days=9)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        event = self._create_event(starts_at=far_starts_at)
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('event_forecast_badge', args=[event.id]))
+
+        # Assert
+        self.assertNotContains(response, 'AQHI')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_badge_endpoint_returns_badge_for_cancelled_event(self):
         # Arrange
         event = self._create_event()
         self._create_forecast()
@@ -204,7 +356,7 @@ class ForecastBadgeViewTestCase(TestCase):
         event.save()
 
         # Act
-        response = self.client.get(reverse('event_detail', args=[event.id]))
+        response = self.client.get(reverse('event_forecast_badge', args=[event.id]))
 
         # Assert
         self.assertContains(response, 'AQHI&nbsp;moderate')

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from web.views.events import event_detail, event_forecasts, event_list, event_registrations, \
-    event_emergency_contacts, event_emails, event_registrations_print, calendar_view, events_redirect
+from web.views.events import event_detail, event_forecast_badge, event_forecasts, event_list, event_registrations, \
+    event_emergency_contacts, event_emails, event_registrations_print, calendar_view, events_redirect, \
+    upcoming_forecast_badges
 from web.views.events_ical import EventFeed
 from web.views.helpers import changes_email_addresses
 from web.views.login import LoginFormView, logout_view, CustomLoginView
@@ -28,6 +29,7 @@ urlpatterns = [
     path('calendar', calendar_view, name='calendar'),
     path('calendar/<int:year>/<int:month>', calendar_view, name='calendar_month'),
     path('upcoming', event_list, name='upcoming'),
+    path('upcoming/forecast-badges', upcoming_forecast_badges, name='upcoming_forecast_badges'),
     path('events', events_redirect, name='events'),
     path('events/<int:event_id>/registrations/manage', event_registrations_manage, name='event_registrations_manage'),
     path('events/<int:event_id>/registrations/add', staff_registration_add, name='staff_registration_add'),
@@ -38,6 +40,7 @@ urlpatterns = [
     path('events/<int:event_id>/registrations/print', event_registrations_print, name='event_registrations_print'),
     path('events/<int:event_id>/registrations', event_registrations, name='riders_list'),
     path('events/<int:event_id>/registration', registration_create, name='registration_create'),
+    path('events/<int:event_id>/forecast-badge', event_forecast_badge, name='event_forecast_badge'),
     path('events/<int:event_id>/forecasts', event_forecasts, name='event_forecasts'),
     path('events/<int:event_id>', event_detail, name='event_detail'),
     path('events.ics', EventFeed(), name='event_feed'),

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -181,19 +181,58 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
             state=Registration.STATE_CONFIRMED,
         ).exists()
 
-    forecast = None
-    if flag_is_active(request, 'weather_forecast_badges'):
-        forecast = EventService().fetch_current_forecast(event)
+    forecast_placeholder = (
+        flag_is_active(request, 'weather_forecast_badges')
+        and EventService().forecast_possible(event)
+    )
 
     context = {
         'event': event,
         'rides': rides,
         'user_is_registered': user_is_registered,
         'registrations_available': _registrations_visible(event, request.user),
-        'forecast': forecast,
+        'forecast_placeholder': forecast_placeholder,
     }
 
     return render(request, 'web/events/detail.html', context)
+
+
+def event_forecast_badge(request: HttpRequest, event_id: int) -> HttpResponse:
+    event = get_object_or_404(Event, id=event_id)
+
+    forecast = None
+    if flag_is_active(request, 'weather_forecast_badges'):
+        forecast = EventService().fetch_current_forecast(event)
+
+    context = {
+        'event': event,
+        'forecast': forecast,
+        'expandable': True,
+        'show_history_link': True,
+    }
+
+    return render(request, 'web/events/_forecast_badge.html', context)
+
+
+def upcoming_forecast_badges(request: HttpRequest) -> HttpResponse:
+    if not flag_is_active(request, 'weather_forecast_badges'):
+        return HttpResponse()
+
+    _, active_query, _ = _get_filter_params(request)
+
+    service = EventService()
+    events = [
+        event for event in service.fetch_upcoming_events(query=active_query)
+        if service.forecast_possible(event)
+    ]
+    forecasts = service.fetch_forecasts(events)
+
+    context = {
+        'events': events,
+        'forecasts': forecasts,
+    }
+
+    return render(request, 'web/events/_forecast_badges_oob.html', context)
 
 
 def event_forecasts(request: HttpRequest, event_id: int) -> HttpResponse:
@@ -239,12 +278,13 @@ def event_list(request: HttpRequest) -> HttpResponse:
     today = timezone.localdate()
     tomorrow = today + timedelta(days=1)
 
-    forecasts = {}
+    forecast_event_ids = set()
     if flag_is_active(request, 'weather_forecast_badges'):
-        forecasts = EventService().fetch_forecasts(events)
+        service = EventService()
+        forecast_event_ids = {e.id for e in events if service.forecast_possible(e)}
 
     context = {
-        'forecasts': forecasts,
+        'forecast_event_ids': forecast_event_ids,
         'events_by_date': events_by_date,
         'today': today,
         'tomorrow': tomorrow,


### PR DESCRIPTION
Fetching forecasts from Open-Meteo during page render blocked /upcoming
and event detail responses. Pages now render immediately with a subtle
loading pill, and badges arrive via HTMX: one batch request with
out-of-band swaps for the upcoming list, one request per event detail
page carrying the badge and its hourly modal together. Placeholders
only render for events that can have a forecast and are removed when
none is available.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U6kovPpHW8ekPFiSqjZRGz