### PR TITLE
Shape weather badge loading state like the final badge

### DIFF
--- a/web/static/web/styling.css
+++ b/web/static/web/styling.css
@@ -155,10 +155,43 @@ body {
   opacity: 0.6;
 }
 
-.wx-spinner {
-  width: 1.2em;
+.wx-shimmer {
+  display: inline-block;
+  height: 1em;
+  border-radius: 0.25rem;
+  vertical-align: -0.15em;
+  background: linear-gradient(
+    90deg,
+    rgba(108, 117, 125, 0.15) 25%,
+    rgba(108, 117, 125, 0.35) 50%,
+    rgba(108, 117, 125, 0.15) 75%
+  );
+  background-size: 200% 100%;
+  animation: wx-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes wx-shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wx-shimmer {
+    animation: none;
+  }
+}
+
+.wx-shimmer-icon {
   height: 1.2em;
-  border-width: 0.15em;
+  border-radius: 50%;
+}
+
+.wx-shimmer-temp {
+  min-width: 1ch;
+}
+
+.wx-shimmer-aqhi {
+  min-width: 3ch;
 }
 
 button.meta-pill {

--- a/web/templates/web/events/_forecast_badge_loading.html
+++ b/web/templates/web/events/_forecast_badge_loading.html
@@ -3,5 +3,7 @@
       role="status"
       aria-label="Loading weather forecast"
       {% if hx_get %}hx-get="{{ hx_get }}" hx-trigger="load" hx-swap="outerHTML"{% endif %}>
-    <span class="spinner-border wx-spinner" aria-hidden="true"></span>
+    <span class="wx-icon wx-shimmer wx-shimmer-icon" aria-hidden="true"></span>
+    <span class="wx-temp" aria-hidden="true"><span class="wx-shimmer wx-shimmer-temp"></span>&deg;</span>
+    <span class="wx-aqhi" aria-hidden="true">AQHI&nbsp;<span class="wx-shimmer wx-shimmer-aqhi"></span></span>
 </span>

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -64,7 +64,8 @@ class UpcomingPageForecastPlaceholderTests(ForecastBadgeTestCase):
         self.assertContains(response, f'forecast-badge-{event.id}')
         self.assertContains(response, reverse('upcoming_forecast_badges'))
         self.assertContains(response, 'Loading weather forecast')
-        self.assertNotContains(response, 'AQHI')
+        self.assertContains(response, 'wx-shimmer')
+        self.assertNotContains(response, 'AQHI&nbsp;moderate')
         mock_get.assert_not_called()
 
     @override_flag('weather_forecast_badges', active=False)
@@ -222,7 +223,8 @@ class DetailPageForecastPlaceholderTests(ForecastBadgeTestCase):
         self.assertContains(response, f'forecast-badge-{event.id}')
         self.assertContains(response, reverse('event_forecast_badge', args=[event.id]))
         self.assertContains(response, 'Loading weather forecast')
-        self.assertNotContains(response, 'AQHI')
+        self.assertContains(response, 'wx-shimmer')
+        self.assertNotContains(response, 'AQHI&nbsp;moderate')
         mock_get.assert_not_called()
 
     @override_flag('weather_forecast_badges', active=False)


### PR DESCRIPTION
The spinner-only placeholder from #311 was much narrower than the loaded badge, so the page re-laid out noticeably when the forecast swapped in.

The placeholder now mirrors the badge's anatomy so its width is close to the final badge in the common case:

- a shimmering circle where the condition icon goes
- a shimmer with a minimum width of a single-digit temperature, followed by a real degree sign
- the literal `AQHI` label followed by a shimmer with the minimum width of a category word like "low"

The shimmer is a subtle animated gradient, disabled under `prefers-reduced-motion`. Placeholder tests updated to assert the shimmer skeleton instead of the absence of the `AQHI` label (which is now legitimately part of the loading state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6kovPpHW8ekPFiSqjZRGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6kovPpHW8ekPFiSqjZRGz)_