### PR TITLE
Render weather badge inline when a fresh forecast is cached

### DIFF
--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -116,13 +116,26 @@ class EventService:
         latitude, longitude = YOW_LOCATION
         return ForecastService().get_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
 
+    def fetch_cached_forecast(self, event: Event) -> Forecast | None:
+        if event.virtual:
+            return None
+        latitude, longitude = YOW_LOCATION
+        return ForecastService().get_cached_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
+
     def fetch_forecasts(self, events) -> dict:
+        return self._forecasts_by_event_id(events, ForecastService().get_forecasts_for_windows)
+
+    def fetch_cached_forecasts(self, events) -> dict:
+        return self._forecasts_by_event_id(events, ForecastService().get_cached_forecasts_for_windows)
+
+    @staticmethod
+    def _forecasts_by_event_id(events, lookup) -> dict:
         windows_by_event_id = {
             event.id: (event.starts_at, event.starts_at + event.duration)
             for event in events
             if not event.virtual
         }
-        forecasts_by_window = ForecastService().get_forecasts_for_windows(windows_by_event_id.values())
+        forecasts_by_window = lookup(windows_by_event_id.values())
 
         return {
             event_id: forecasts_by_window[window]

--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -4,7 +4,7 @@ from django.db.models import Count, Max, Min, Q, QuerySet
 from django.utils import timezone
 
 from backoffice.models import Event, Forecast, Registration, Ride
-from backoffice.services.forecast_service import ForecastService, YOW_LOCATION
+from backoffice.services.forecast_service import ForecastService, ForecastState, YOW_LOCATION
 
 
 class EventService:
@@ -107,8 +107,19 @@ class EventService:
 
         return new_event
 
-    def forecast_possible(self, event: Event) -> bool:
-        return not event.virtual and ForecastService().is_within_window(event.starts_at)
+    def resolve_forecast(self, event: Event) -> ForecastState:
+        return self.resolve_forecasts([event])[event.id]
+
+    def resolve_forecasts(self, events) -> dict:
+        windows_by_event_id = self._windows_by_event_id(events)
+        states_by_window = ForecastService().resolve_for_windows(windows_by_event_id.values())
+
+        return {
+            event.id: states_by_window[windows_by_event_id[event.id]]
+            if event.id in windows_by_event_id
+            else ForecastState.unavailable()
+            for event in events
+        }
 
     def fetch_current_forecast(self, event: Event) -> Forecast | None:
         if event.virtual:
@@ -116,31 +127,22 @@ class EventService:
         latitude, longitude = YOW_LOCATION
         return ForecastService().get_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
 
-    def fetch_cached_forecast(self, event: Event) -> Forecast | None:
-        if event.virtual:
-            return None
-        latitude, longitude = YOW_LOCATION
-        return ForecastService().get_cached_forecast(latitude, longitude, event.starts_at, event.starts_at + event.duration)
-
     def fetch_forecasts(self, events) -> dict:
-        return self._forecasts_by_event_id(events, ForecastService().get_forecasts_for_windows)
-
-    def fetch_cached_forecasts(self, events) -> dict:
-        return self._forecasts_by_event_id(events, ForecastService().get_cached_forecasts_for_windows)
-
-    @staticmethod
-    def _forecasts_by_event_id(events, lookup) -> dict:
-        windows_by_event_id = {
-            event.id: (event.starts_at, event.starts_at + event.duration)
-            for event in events
-            if not event.virtual
-        }
-        forecasts_by_window = lookup(windows_by_event_id.values())
+        windows_by_event_id = self._windows_by_event_id(events)
+        forecasts_by_window = ForecastService().get_forecasts_for_windows(windows_by_event_id.values())
 
         return {
             event_id: forecasts_by_window[window]
             for event_id, window in windows_by_event_id.items()
             if forecasts_by_window[window]
+        }
+
+    @staticmethod
+    def _windows_by_event_id(events) -> dict:
+        return {
+            event.id: (event.starts_at, event.starts_at + event.duration)
+            for event in events
+            if not event.virtual
         }
 
     def fetch_forecast_history(self, event: Event) -> QuerySet:

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -23,21 +23,13 @@ AIR_QUALITY_URL = 'https://air-quality-api.open-meteo.com/v1/air-quality'
 
 class ForecastService:
     def get_forecast(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> Forecast | None:
-        time = self._snap_to_hour(starts_at)
-        end_time = self._snap_to_hour_ceiling(ends_at) if ends_at else time + timedelta(hours=1)
         now = timezone.now()
-
-        horizon = self._snap_to_hour_ceiling(now + FORECAST_WINDOW)
-        end_time = min(end_time, horizon)
-        if end_time < time:
-            end_time = time
-
-        if time < self._snap_to_hour(now) or time > now + FORECAST_WINDOW:
+        window = self._resolve_window(starts_at, ends_at, now)
+        if window is None:
             return None
+        time, end_time = window
 
-        latest = Forecast.objects.filter(
-            latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
-        ).order_by('-prepared_at').first()
+        latest = self._latest_forecast(latitude, longitude, time, end_time)
         if latest and latest.prepared_at >= now - FORECAST_MAX_AGE:
             return latest
 
@@ -58,7 +50,25 @@ class ForecastService:
             **metrics,
         )
 
+    def get_cached_forecast(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> Forecast | None:
+        now = timezone.now()
+        window = self._resolve_window(starts_at, ends_at, now)
+        if window is None:
+            return None
+        time, end_time = window
+
+        latest = self._latest_forecast(latitude, longitude, time, end_time)
+        if latest and latest.prepared_at >= now - FORECAST_MAX_AGE:
+            return latest
+        return None
+
     def get_forecasts_for_windows(self, windows) -> dict:
+        return self._forecasts_for_windows(windows, self.get_forecast)
+
+    def get_cached_forecasts_for_windows(self, windows) -> dict:
+        return self._forecasts_for_windows(windows, self.get_cached_forecast)
+
+    def _forecasts_for_windows(self, windows, lookup) -> dict:
         latitude, longitude = YOW_LOCATION
         forecasts_by_snapped_window: dict = {}
         forecasts_by_window: dict = {}
@@ -67,12 +77,33 @@ class ForecastService:
             starts_at, ends_at = window
             snapped_window = (self._snap_to_hour(starts_at), self._snap_to_hour_ceiling(ends_at))
             if snapped_window not in forecasts_by_snapped_window:
-                forecasts_by_snapped_window[snapped_window] = self.get_forecast(
+                forecasts_by_snapped_window[snapped_window] = lookup(
                     latitude, longitude, starts_at, ends_at
                 )
             forecasts_by_window[window] = forecasts_by_snapped_window[snapped_window]
 
         return forecasts_by_window
+
+    @classmethod
+    def _resolve_window(cls, starts_at, ends_at, now) -> tuple | None:
+        time = cls._snap_to_hour(starts_at)
+        end_time = cls._snap_to_hour_ceiling(ends_at) if ends_at else time + timedelta(hours=1)
+
+        horizon = cls._snap_to_hour_ceiling(now + FORECAST_WINDOW)
+        end_time = min(end_time, horizon)
+        if end_time < time:
+            end_time = time
+
+        if time < cls._snap_to_hour(now) or time > now + FORECAST_WINDOW:
+            return None
+
+        return time, end_time
+
+    @staticmethod
+    def _latest_forecast(latitude: Decimal, longitude: Decimal, time, end_time) -> Forecast | None:
+        return Forecast.objects.filter(
+            latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
+        ).order_by('-prepared_at').first()
 
     def is_within_window(self, starts_at) -> bool:
         now = timezone.now()

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from dataclasses import dataclass
 from datetime import timedelta, timezone as datetime_timezone
 from decimal import Decimal
 
@@ -21,6 +22,28 @@ WEATHER_URL = 'https://api.open-meteo.com/v1/forecast'
 AIR_QUALITY_URL = 'https://air-quality-api.open-meteo.com/v1/air-quality'
 
 
+@dataclass(frozen=True)
+class ForecastState:
+    forecast: Forecast | None = None
+    pending: bool = False
+
+    @classmethod
+    def ready(cls, forecast: Forecast) -> 'ForecastState':
+        return cls(forecast=forecast)
+
+    @classmethod
+    def pending_fetch(cls) -> 'ForecastState':
+        return cls(pending=True)
+
+    @classmethod
+    def unavailable(cls) -> 'ForecastState':
+        return cls()
+
+    @property
+    def possible(self) -> bool:
+        return self.forecast is not None or self.pending
+
+
 class ForecastService:
     def get_forecast(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> Forecast | None:
         now = timezone.now()
@@ -30,7 +53,7 @@ class ForecastService:
         time, end_time = window
 
         latest = self._latest_forecast(latitude, longitude, time, end_time)
-        if latest and latest.prepared_at >= now - FORECAST_MAX_AGE:
+        if latest and self._is_fresh(latest, now):
             return latest
 
         try:
@@ -50,25 +73,25 @@ class ForecastService:
             **metrics,
         )
 
-    def get_cached_forecast(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> Forecast | None:
+    def resolve(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> ForecastState:
         now = timezone.now()
         window = self._resolve_window(starts_at, ends_at, now)
         if window is None:
-            return None
+            return ForecastState.unavailable()
         time, end_time = window
 
         latest = self._latest_forecast(latitude, longitude, time, end_time)
-        if latest and latest.prepared_at >= now - FORECAST_MAX_AGE:
-            return latest
-        return None
+        if latest and self._is_fresh(latest, now):
+            return ForecastState.ready(latest)
+        return ForecastState.pending_fetch()
 
     def get_forecasts_for_windows(self, windows) -> dict:
-        return self._forecasts_for_windows(windows, self.get_forecast)
+        return self._lookup_by_window(windows, self.get_forecast)
 
-    def get_cached_forecasts_for_windows(self, windows) -> dict:
-        return self._forecasts_for_windows(windows, self.get_cached_forecast)
+    def resolve_for_windows(self, windows) -> dict:
+        return self._lookup_by_window(windows, self.resolve)
 
-    def _forecasts_for_windows(self, windows, lookup) -> dict:
+    def _lookup_by_window(self, windows, lookup) -> dict:
         latitude, longitude = YOW_LOCATION
         forecasts_by_snapped_window: dict = {}
         forecasts_by_window: dict = {}
@@ -105,10 +128,9 @@ class ForecastService:
             latitude=latitude, longitude=longitude, start_time=time, end_time=end_time
         ).order_by('-prepared_at').first()
 
-    def is_within_window(self, starts_at) -> bool:
-        now = timezone.now()
-        time = self._snap_to_hour(starts_at)
-        return self._snap_to_hour(now) <= time <= now + FORECAST_WINDOW
+    @staticmethod
+    def _is_fresh(forecast: Forecast, now) -> bool:
+        return forecast.prepared_at >= now - FORECAST_MAX_AGE
 
     def get_forecast_history(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> QuerySet:
         time = self._snap_to_hour(starts_at)

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -115,6 +115,67 @@ class ForecastServiceTestCase(TestCase):
         self.assertEqual([entry['aqhi'] for entry in forecast.hourly], [3, 3, 3, 3])
         self.assertEqual(Forecast.objects.count(), 1)
 
+    def test_cached_forecast_returns_fresh_forecast_without_fetching(self):
+        # Arrange
+        window_end = self.starts_at + timedelta(hours=1)
+        forecast = Forecast.objects.create(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            start_time=self.starts_at,
+            end_time=window_end,
+            hourly=_hourly_entry(self.starts_at),
+        )
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            cached = self.service.get_cached_forecast(
+                self.latitude, self.longitude, self.starts_at, window_end
+            )
+
+        # Assert
+        self.assertEqual(cached, forecast)
+        mock_get.assert_not_called()
+
+    def test_cached_forecast_returns_none_when_forecast_stale(self):
+        # Arrange
+        window_end = self.starts_at + timedelta(hours=1)
+        forecast = Forecast.objects.create(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            start_time=self.starts_at,
+            end_time=window_end,
+            hourly=_hourly_entry(self.starts_at),
+        )
+        Forecast.objects.filter(pk=forecast.pk).update(
+            prepared_at=timezone.now() - timedelta(hours=2)
+        )
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            cached = self.service.get_cached_forecast(
+                self.latitude, self.longitude, self.starts_at, window_end
+            )
+
+        # Assert
+        self.assertIsNone(cached)
+        mock_get.assert_not_called()
+
+    def test_cached_forecast_returns_none_beyond_window(self):
+        # Arrange
+        far_starts_at = (timezone.now() + timedelta(days=9)).replace(
+            minute=0, second=0, microsecond=0
+        )
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            cached = self.service.get_cached_forecast(
+                self.latitude, self.longitude, far_starts_at
+            )
+
+        # Assert
+        self.assertIsNone(cached)
+        mock_get.assert_not_called()
+
     def test_air_quality_entirely_unavailable_still_produces_forecast(self):
         # Arrange
         window_end = self.starts_at + timedelta(hours=1)

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -115,7 +115,7 @@ class ForecastServiceTestCase(TestCase):
         self.assertEqual([entry['aqhi'] for entry in forecast.hourly], [3, 3, 3, 3])
         self.assertEqual(Forecast.objects.count(), 1)
 
-    def test_cached_forecast_returns_fresh_forecast_without_fetching(self):
+    def test_resolve_returns_ready_state_without_fetching_when_forecast_fresh(self):
         # Arrange
         window_end = self.starts_at + timedelta(hours=1)
         forecast = Forecast.objects.create(
@@ -128,15 +128,17 @@ class ForecastServiceTestCase(TestCase):
 
         # Act
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            cached = self.service.get_cached_forecast(
+            state = self.service.resolve(
                 self.latitude, self.longitude, self.starts_at, window_end
             )
 
         # Assert
-        self.assertEqual(cached, forecast)
+        self.assertEqual(state.forecast, forecast)
+        self.assertFalse(state.pending)
+        self.assertTrue(state.possible)
         mock_get.assert_not_called()
 
-    def test_cached_forecast_returns_none_when_forecast_stale(self):
+    def test_resolve_returns_pending_state_when_forecast_stale(self):
         # Arrange
         window_end = self.starts_at + timedelta(hours=1)
         forecast = Forecast.objects.create(
@@ -152,15 +154,27 @@ class ForecastServiceTestCase(TestCase):
 
         # Act
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            cached = self.service.get_cached_forecast(
+            state = self.service.resolve(
                 self.latitude, self.longitude, self.starts_at, window_end
             )
 
         # Assert
-        self.assertIsNone(cached)
+        self.assertIsNone(state.forecast)
+        self.assertTrue(state.pending)
+        self.assertTrue(state.possible)
         mock_get.assert_not_called()
 
-    def test_cached_forecast_returns_none_beyond_window(self):
+    def test_resolve_returns_pending_state_when_no_forecast_stored(self):
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            state = self.service.resolve(self.latitude, self.longitude, self.starts_at)
+
+        # Assert
+        self.assertIsNone(state.forecast)
+        self.assertTrue(state.pending)
+        mock_get.assert_not_called()
+
+    def test_resolve_returns_unavailable_state_beyond_window(self):
         # Arrange
         far_starts_at = (timezone.now() + timedelta(days=9)).replace(
             minute=0, second=0, microsecond=0
@@ -168,12 +182,12 @@ class ForecastServiceTestCase(TestCase):
 
         # Act
         with patch('backoffice.services.forecast_service.requests.get') as mock_get:
-            cached = self.service.get_cached_forecast(
-                self.latitude, self.longitude, far_starts_at
-            )
+            state = self.service.resolve(self.latitude, self.longitude, far_starts_at)
 
         # Assert
-        self.assertIsNone(cached)
+        self.assertIsNone(state.forecast)
+        self.assertFalse(state.pending)
+        self.assertFalse(state.possible)
         mock_get.assert_not_called()
 
     def test_air_quality_entirely_unavailable_still_produces_forecast(self):

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -13,7 +13,8 @@
 </button>
 {% include 'web/events/_forecast_hourly_modal.html' with forecast=forecast summary=summary %}
 {% else %}
-<span {% if oob %}id="forecast-badge-{{ event.id }}" hx-swap-oob="outerHTML" {% endif %}class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted"
+<span id="forecast-badge-{{ event.id }}"{% if oob %} hx-swap-oob="outerHTML"{% endif %}
+      class="meta-pill{% if compact %} meta-pill-sm{% endif %} meta-pill-neutral text-muted"
       title="Weather forecast from Open-Meteo"
       role="img"
       aria-label="{{ summary.aria_label }}">

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -47,9 +47,9 @@
                 {% elif event.location %}
                 <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
-                {% if forecast %}
-                {% include 'web/events/_forecast_badge.html' with expandable=True show_history_link=True %}
-                {% elif forecast_placeholder %}
+                {% if forecast_state.forecast %}
+                {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast expandable=True show_history_link=True %}
+                {% elif forecast_state.pending %}
                 {% url 'event_forecast_badge' event.id as forecast_badge_url %}
                 {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
                 {% endif %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -47,7 +47,9 @@
                 {% elif event.location %}
                 <span class="meta-pill meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
-                {% if forecast_placeholder %}
+                {% if forecast %}
+                {% include 'web/events/_forecast_badge.html' with expandable=True show_history_link=True %}
+                {% elif forecast_placeholder %}
                 {% url 'event_forecast_badge' event.id as forecast_badge_url %}
                 {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
                 {% endif %}

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -54,11 +54,13 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
-                                {% if event.id in forecasts %}
-                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
-                                {% elif event.id in forecast_pending_ids %}
+                                {% with forecast_state=forecast_states|get_item:event.id %}
+                                {% if forecast_state.forecast %}
+                                {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast compact=True %}
+                                {% elif forecast_state.pending %}
                                 {% include 'web/events/_forecast_badge_loading.html' with compact=True %}
                                 {% endif %}
+                                {% endwith %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
@@ -79,7 +81,7 @@
             {% endif %}
         </div>
         {% endfor %}
-        {% if forecast_pending_ids %}
+        {% if forecasts_pending %}
         <div hx-get="{% url 'upcoming_forecast_badges' %}{% if active_query %}?q={{ active_query|urlencode }}{% endif %}"
              hx-trigger="load"
              hx-swap="none"></div>

--- a/web/templates/web/events/list.html
+++ b/web/templates/web/events/list.html
@@ -54,7 +54,9 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
-                                {% if event.id in forecast_event_ids %}
+                                {% if event.id in forecasts %}
+                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
+                                {% elif event.id in forecast_pending_ids %}
                                 {% include 'web/events/_forecast_badge_loading.html' with compact=True %}
                                 {% endif %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
@@ -77,7 +79,7 @@
             {% endif %}
         </div>
         {% endfor %}
-        {% if forecast_event_ids %}
+        {% if forecast_pending_ids %}
         <div hx-get="{% url 'upcoming_forecast_badges' %}{% if active_query %}?q={{ active_query|urlencode }}{% endif %}"
              hx-trigger="load"
              hx-swap="none"></div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -54,11 +54,13 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
-                                {% if event.id in forecasts %}
-                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
-                                {% elif event.id in forecast_pending_ids %}
+                                {% with forecast_state=forecast_states|get_item:event.id %}
+                                {% if forecast_state.forecast %}
+                                {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast compact=True %}
+                                {% elif forecast_state.pending %}
                                 {% include 'web/events/_forecast_badge_loading.html' with compact=True %}
                                 {% endif %}
+                                {% endwith %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered</span>
                                 {% endif %}
@@ -99,7 +101,7 @@
             {% endif %}
         </div>
         {% endfor %}
-        {% if forecast_pending_ids %}
+        {% if forecasts_pending %}
         <div hx-get="{% url 'upcoming_forecast_badges' %}{% if active_query %}?q={{ active_query|urlencode }}{% endif %}"
              hx-trigger="load"
              hx-swap="none"></div>

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -54,7 +54,9 @@
                                 {% if event.location %}
                                 <span class="meta-pill meta-pill-sm meta-pill-neutral text-muted">🗺️ {{ event.location }}</span>
                                 {% endif %}
-                                {% if event.id in forecast_event_ids %}
+                                {% if event.id in forecasts %}
+                                {% include 'web/events/_forecast_badge.html' with forecast=forecasts|get_item:event.id compact=True %}
+                                {% elif event.id in forecast_pending_ids %}
                                 {% include 'web/events/_forecast_badge_loading.html' with compact=True %}
                                 {% endif %}
                                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
@@ -97,7 +99,7 @@
             {% endif %}
         </div>
         {% endfor %}
-        {% if forecast_event_ids %}
+        {% if forecast_pending_ids %}
         <div hx-get="{% url 'upcoming_forecast_badges' %}{% if active_query %}?q={{ active_query|urlencode }}{% endif %}"
              hx-trigger="load"
              hx-swap="none"></div>

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -49,6 +49,11 @@ class ForecastBadgeTestCase(TestCase):
             hourly=hourly,
         )
 
+    def _make_stale(self, forecast):
+        Forecast.objects.filter(pk=forecast.pk).update(
+            prepared_at=timezone.now() - timedelta(hours=2)
+        )
+
 
 class UpcomingPageForecastPlaceholderTests(ForecastBadgeTestCase):
     @override_flag('weather_forecast_badges', active=True)
@@ -65,6 +70,39 @@ class UpcomingPageForecastPlaceholderTests(ForecastBadgeTestCase):
         self.assertContains(response, reverse('upcoming_forecast_badges'))
         self.assertContains(response, 'Loading weather forecast')
         self.assertContains(response, 'wx-shimmer')
+        self.assertNotContains(response, 'AQHI&nbsp;moderate')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_renders_badge_inline_when_fresh_forecast_cached(self):
+        # Arrange
+        self._create_event()
+        self._create_forecast()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertContains(response, 'AQHI&nbsp;moderate')
+        self.assertContains(response, '12–15&deg;')
+        self.assertNotContains(response, 'Loading weather forecast')
+        self.assertNotContains(response, reverse('upcoming_forecast_badges'))
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_upcoming_shows_placeholder_when_cached_forecast_stale(self):
+        # Arrange
+        event = self._create_event()
+        self._make_stale(self._create_forecast())
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('upcoming'))
+
+        # Assert
+        self.assertContains(response, f'forecast-badge-{event.id}')
+        self.assertContains(response, reverse('upcoming_forecast_badges'))
         self.assertNotContains(response, 'AQHI&nbsp;moderate')
         mock_get.assert_not_called()
 
@@ -224,6 +262,39 @@ class DetailPageForecastPlaceholderTests(ForecastBadgeTestCase):
         self.assertContains(response, reverse('event_forecast_badge', args=[event.id]))
         self.assertContains(response, 'Loading weather forecast')
         self.assertContains(response, 'wx-shimmer')
+        self.assertNotContains(response, 'AQHI&nbsp;moderate')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_renders_badge_inline_when_fresh_forecast_cached(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('event_detail', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, 'AQHI&nbsp;moderate')
+        self.assertContains(response, '(beta)')
+        self.assertContains(response, 'View forecast history')
+        self.assertNotContains(response, 'Loading weather forecast')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_detail_shows_placeholder_when_cached_forecast_stale(self):
+        # Arrange
+        event = self._create_event()
+        self._make_stale(self._create_forecast())
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('event_detail', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, 'Loading weather forecast')
+        self.assertContains(response, reverse('event_forecast_badge', args=[event.id]))
         self.assertNotContains(response, 'AQHI&nbsp;moderate')
         mock_get.assert_not_called()
 

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -76,7 +76,7 @@ class UpcomingPageForecastPlaceholderTests(ForecastBadgeTestCase):
     @override_flag('weather_forecast_badges', active=True)
     def test_upcoming_renders_badge_inline_when_fresh_forecast_cached(self):
         # Arrange
-        self._create_event()
+        event = self._create_event()
         self._create_forecast()
 
         # Act
@@ -86,6 +86,7 @@ class UpcomingPageForecastPlaceholderTests(ForecastBadgeTestCase):
         # Assert
         self.assertContains(response, 'AQHI&nbsp;moderate')
         self.assertContains(response, '12–15&deg;')
+        self.assertContains(response, f'id="forecast-badge-{event.id}"')
         self.assertNotContains(response, 'Loading weather forecast')
         self.assertNotContains(response, reverse('upcoming_forecast_badges'))
         mock_get.assert_not_called()

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -17,6 +17,7 @@ from waffle import flag_is_active
 from audit.services import AuditService
 from backoffice.models import Event, Registration
 from backoffice.services.event_service import EventService
+from backoffice.services.forecast_service import ForecastState
 from backoffice.services.registration_service import RegistrationService
 from web.filters import PublicRegistrationFilter
 from web.tables import PublicRegistrationTable
@@ -181,20 +182,16 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
             state=Registration.STATE_CONFIRMED,
         ).exists()
 
-    forecast = None
-    forecast_placeholder = False
-    service = EventService()
-    if flag_is_active(request, 'weather_forecast_badges') and service.forecast_possible(event):
-        forecast = service.fetch_cached_forecast(event)
-        forecast_placeholder = forecast is None
+    forecast_state = ForecastState.unavailable()
+    if flag_is_active(request, 'weather_forecast_badges'):
+        forecast_state = EventService().resolve_forecast(event)
 
     context = {
         'event': event,
         'rides': rides,
         'user_is_registered': user_is_registered,
         'registrations_available': _registrations_visible(event, request.user),
-        'forecast': forecast,
-        'forecast_placeholder': forecast_placeholder,
+        'forecast_state': forecast_state,
     }
 
     return render(request, 'web/events/detail.html', context)
@@ -224,10 +221,9 @@ def upcoming_forecast_badges(request: HttpRequest) -> HttpResponse:
     _, active_query, _ = _get_filter_params(request)
 
     service = EventService()
-    events = [
-        event for event in service.fetch_upcoming_events(query=active_query)
-        if service.forecast_possible(event)
-    ]
+    events = list(service.fetch_upcoming_events(query=active_query))
+    states = service.resolve_forecasts(events)
+    events = [event for event in events if states[event.id].possible]
     forecasts = service.fetch_forecasts(events)
 
     context = {
@@ -281,17 +277,15 @@ def event_list(request: HttpRequest) -> HttpResponse:
     today = timezone.localdate()
     tomorrow = today + timedelta(days=1)
 
-    forecasts = {}
-    forecast_pending_ids = set()
+    forecast_states = {}
+    forecasts_pending = False
     if flag_is_active(request, 'weather_forecast_badges'):
-        service = EventService()
-        eligible = [e for e in events if service.forecast_possible(e)]
-        forecasts = service.fetch_cached_forecasts(eligible)
-        forecast_pending_ids = {e.id for e in eligible if e.id not in forecasts}
+        forecast_states = EventService().resolve_forecasts(events)
+        forecasts_pending = any(state.pending for state in forecast_states.values())
 
     context = {
-        'forecasts': forecasts,
-        'forecast_pending_ids': forecast_pending_ids,
+        'forecast_states': forecast_states,
+        'forecasts_pending': forecasts_pending,
         'events_by_date': events_by_date,
         'today': today,
         'tomorrow': tomorrow,

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -181,16 +181,19 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
             state=Registration.STATE_CONFIRMED,
         ).exists()
 
-    forecast_placeholder = (
-        flag_is_active(request, 'weather_forecast_badges')
-        and EventService().forecast_possible(event)
-    )
+    forecast = None
+    forecast_placeholder = False
+    service = EventService()
+    if flag_is_active(request, 'weather_forecast_badges') and service.forecast_possible(event):
+        forecast = service.fetch_cached_forecast(event)
+        forecast_placeholder = forecast is None
 
     context = {
         'event': event,
         'rides': rides,
         'user_is_registered': user_is_registered,
         'registrations_available': _registrations_visible(event, request.user),
+        'forecast': forecast,
         'forecast_placeholder': forecast_placeholder,
     }
 
@@ -278,13 +281,17 @@ def event_list(request: HttpRequest) -> HttpResponse:
     today = timezone.localdate()
     tomorrow = today + timedelta(days=1)
 
-    forecast_event_ids = set()
+    forecasts = {}
+    forecast_pending_ids = set()
     if flag_is_active(request, 'weather_forecast_badges'):
         service = EventService()
-        forecast_event_ids = {e.id for e in events if service.forecast_possible(e)}
+        eligible = [e for e in events if service.forecast_possible(e)]
+        forecasts = service.fetch_cached_forecasts(eligible)
+        forecast_pending_ids = {e.id for e in eligible if e.id not in forecasts}
 
     context = {
-        'forecast_event_ids': forecast_event_ids,
+        'forecasts': forecasts,
+        'forecast_pending_ids': forecast_pending_ids,
         'events_by_date': events_by_date,
         'today': today,
         'tomorrow': tomorrow,


### PR DESCRIPTION
Follow-up to #311/#312. Async loading only makes sense when rendering the badge would block on Open-Meteo. When a fresh forecast (under the 1-hour max age) is already in the database, the badge is now rendered inline during page render — no extra round trip, no swap-in re-layout.

The lookup is modelled as a single resolve call returning a state, rather than parallel cached/fetching method pairs:

- `ForecastState`: a frozen value object that is either ready with a forecast, pending a fetch, or unavailable (virtual event or outside the 7-day window), with a `possible` property covering the first two.
- `EventService.resolve_forecasts(events)` is total — it returns a state for every event — so views make one call and templates branch on `state.forecast` / `state.pending`. `resolve_forecast(event)` is the single-event form used by the detail page.
- `ForecastService.resolve` shares the window-resolution and freshness rules with `get_forecast` via extracted pure helpers (`_resolve_window`, `_latest_forecast`, `_is_fresh`) but never touches the network; fetching from Open-Meteo stays isolated to the async badge endpoints.
- `/upcoming` and event detail resolve during render: ready → inline badge; pending → shimmer placeholder plus the HTMX request as before. The list's batch request is skipped entirely when nothing is pending.
- Tests cover the inline path (badge present, no placeholder, no HTMX trigger, no external request during render), the stale/pending path, and the resolve states at service level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6kovPpHW8ekPFiSqjZRGz