### PR TITLE
Eliminate flash of unstyled content on page load

### DIFF
--- a/web/templates/web/_base_bootstrap.html
+++ b/web/templates/web/_base_bootstrap.html
@@ -10,7 +10,20 @@
     <meta name="theme-color" content="rgb(0, 85, 150)">
     <title>{% block title %}RideHub{% endblock %}</title>
 
-    <!-- Early scripts -->
+    <!-- Preconnects -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+    <!-- Stylesheets -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=block" rel="stylesheet">
+    <link href="{% static 'web/styling.css' %}" rel="stylesheet">
+    <link href="{% static 'web/prose-styling.css' %}" rel="stylesheet">
+
+    <!-- Scripts -->
     <script async src="https://plausible.io/js/pa-XujvMCTT79u83iuv0Levp.js"></script>
     <script>
       window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
@@ -20,22 +33,9 @@
         }
       })
     </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script>
-
-    <!-- Include Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
-
-    <!-- Add Inter font -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
-
-    <!-- Custom CSS -->
-    <link href="{% static 'web/styling.css' %}" rel="stylesheet">
-    <link href="{% static 'web/prose-styling.css' %}" rel="stylesheet">
   </head>
   <body class="d-flex flex-column h-100">
     <nav class="navbar navbar-obc shadow-sm py-0 navbar-autohide">


### PR DESCRIPTION
Pages briefly "danced" on load: fonts swapped, colours snapped in, layout shifted page-wide. Two causes in the base template's head:

- Synchronous scripts (htmx, Bootstrap bundle) were interleaved with the stylesheets, stretching the render-blocking window and letting slow CDN responses produce a genuinely unstyled first paint (Chrome unblocks rendering on slow stylesheets).
- Inter loaded from Google Fonts with `display=swap`, which paints the fallback font immediately and reflows the entire page when the webfont arrives — Inter's metrics differ enough to shift headings, pills, and cards.

Changes, all in `_base_bootstrap.html`:

- Stylesheets now form one uninterrupted block at the top of the head: Bootstrap, Bootstrap Icons, fonts, then the site stylesheets.
- htmx and the Bootstrap bundle are now `defer` (joining Alpine), so no script execution interrupts the CSS critical path. Both are safe deferred: htmx initialises on DOMContentLoaded and the only inline `htmx.ajax` callers already run inside DOMContentLoaded handlers; Bootstrap's data API uses delegated events.
- `cdn.jsdelivr.net` gets preconnects (it previously had none, unlike the font origins).
- Inter now loads with `display=block`: the browser waits briefly for the font instead of swapping mid-paint, and subsequent navigations serve it from cache with no reflow. Fonts remain CDN-hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6kovPpHW8ekPFiSqjZRGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6kovPpHW8ekPFiSqjZRGz)_