### PR TITLE
Add ride preselection to registration and per-ride buttons

### DIFF
--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -117,7 +117,6 @@
                                 Register <i class="bi bi-box-arrow-up-right ms-1 small"></i>
                             </a>
                         {% elif ride_registration_enabled %}
-                            <div class="text-muted">Choose a ride below to register.</div>
                         {% elif event.has_capacity_available %}
                             <a href="{% url 'registration_create' event.id %}" class="btn btn-primary">Register</a>
                         {% else %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -116,6 +116,8 @@
                             <a href="{{ event.external_registration_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
                                 Register <i class="bi bi-box-arrow-up-right ms-1 small"></i>
                             </a>
+                        {% elif ride_registration_enabled %}
+                            <div class="text-muted">Choose a ride below to register.</div>
                         {% elif event.has_capacity_available %}
                             <a href="{% url 'registration_create' event.id %}" class="btn btn-primary">Register</a>
                         {% else %}
@@ -166,6 +168,12 @@
                             {{ride.route.name}}<i class="bi bi-box-arrow-up-right ms-1 small"></i>
                         </a>
                     </div>
+
+                    {% if ride_registration_enabled %}
+                    <div class="mt-4">
+                        <a href="{% url 'registration_create' event.id %}?ride={{ ride.id }}" class="btn btn-primary">Register for this ride</a>
+                    </div>
+                    {% endif %}
 
                     {% if not registrations_available %}
                     <p class="text-muted small mt-4 mb-0">Registration details are no longer available for this event.</p>

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1610,3 +1610,54 @@ class UpcomingViewQueryCountTests(TestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '2 registered')
+
+
+class EventDetailRegistrationButtonTests(TestCase):
+    def setUp(self):
+        self.program = Program.objects.create(name='Test Program')
+        now = timezone.now()
+        self.event = Event.objects.create(
+            program=self.program,
+            name='Test Event',
+            description='Test Description',
+            starts_at=now + timedelta(days=7),
+            registration_closes_at=now + timedelta(days=1),
+        )
+        self.route = Route.objects.create(name='Test Route')
+
+    def test_event_without_rides_shows_register_button_in_about_card(self):
+        # Act
+        response = self.client.get(reverse('event_detail', args=[self.event.id]))
+
+        # Assert
+        self.assertFalse(response.context['ride_registration_enabled'])
+        self.assertContains(response, f'href="/events/{self.event.id}/registration"')
+        self.assertNotContains(response, 'Register for this ride')
+
+    def test_event_with_rides_shows_register_button_per_ride(self):
+        # Arrange
+        first_ride = Ride.objects.create(name='Short Ride', event=self.event, route=self.route)
+        second_ride = Ride.objects.create(name='Long Ride', event=self.event, route=self.route)
+
+        # Act
+        response = self.client.get(reverse('event_detail', args=[self.event.id]))
+
+        # Assert
+        self.assertTrue(response.context['ride_registration_enabled'])
+        self.assertNotContains(response, f'href="/events/{self.event.id}/registration"')
+        self.assertContains(response, f'/events/{self.event.id}/registration?ride={first_ride.id}')
+        self.assertContains(response, f'/events/{self.event.id}/registration?ride={second_ride.id}')
+        self.assertContains(response, 'Choose a ride below to register.')
+
+    def test_event_with_rides_hides_ride_buttons_when_registration_closed(self):
+        # Arrange
+        Ride.objects.create(name='Short Ride', event=self.event, route=self.route)
+        self.event.registration_closes_at = timezone.now() - timedelta(days=1)
+        self.event.save()
+
+        # Act
+        response = self.client.get(reverse('event_detail', args=[self.event.id]))
+
+        # Assert
+        self.assertFalse(response.context['ride_registration_enabled'])
+        self.assertNotContains(response, 'Register for this ride')

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1647,7 +1647,6 @@ class EventDetailRegistrationButtonTests(TestCase):
         self.assertNotContains(response, f'href="/events/{self.event.id}/registration"')
         self.assertContains(response, f'/events/{self.event.id}/registration?ride={first_ride.id}')
         self.assertContains(response, f'/events/{self.event.id}/registration?ride={second_ride.id}')
-        self.assertContains(response, 'Choose a ride below to register.')
 
     def test_event_with_rides_hides_ride_buttons_when_registration_closed(self):
         # Arrange

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1475,3 +1475,58 @@ class RegistrationEmailLockdownTests(TestCase):
         self.assertEqual(registration.state, Registration.STATE_UNVERIFIED)
         registered_user = User.objects.get(email='entered@example.com')
         self.assertFalse(registered_user.profile.email_verified)
+
+
+class RegistrationRidePreselectionTests(TestCase):
+    def setUp(self):
+        now = timezone.now()
+        self.program = Program.objects.create(name="Test Program")
+        self.event = Event.objects.create(
+            name="Test Event",
+            program=self.program,
+            starts_at=now + timezone.timedelta(days=3),
+            registration_closes_at=now + timezone.timedelta(days=2),
+        )
+        self.route = Route.objects.create(name="Test Route")
+        self.ride = Ride.objects.create(name="Short Ride", event=self.event, route=self.route)
+        self.other_ride = Ride.objects.create(name="Long Ride", event=self.event, route=self.route)
+        self.url = reverse('registration_create', args=[self.event.id])
+
+    def test_ride_query_parameter_preselects_ride(self):
+        # Act
+        response = self.client.get(self.url, {'ride': self.ride.id})
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['form'].initial['ride'], self.ride.id)
+
+    def test_without_ride_query_parameter_no_ride_is_preselected(self):
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertIsNone(response.context['form'].initial.get('ride'))
+
+    def test_ride_from_another_event_is_ignored(self):
+        # Arrange
+        other_event = Event.objects.create(
+            name="Other Event",
+            program=self.program,
+            starts_at=timezone.now() + timezone.timedelta(days=5),
+            registration_closes_at=timezone.now() + timezone.timedelta(days=4),
+        )
+        foreign_ride = Ride.objects.create(name="Foreign Ride", event=other_event, route=self.route)
+
+        # Act
+        response = self.client.get(self.url, {'ride': foreign_ride.id})
+
+        # Assert
+        self.assertIsNone(response.context['form'].initial.get('ride'))
+
+    def test_non_numeric_ride_query_parameter_is_ignored(self):
+        # Act
+        response = self.client.get(self.url, {'ride': 'abc'})
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['form'].initial.get('ride'))

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -192,6 +192,14 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
         'user_is_registered': user_is_registered,
         'registrations_available': _registrations_visible(event, request.user),
         'forecast_state': forecast_state,
+        'ride_registration_enabled': (
+            event.ride_set.exists()
+            and event.registration_enabled
+            and event.registration_open
+            and event.has_capacity_available
+            and not event.external_registration_url
+            and not user_is_registered
+        ),
     }
 
     return render(request, 'web/events/detail.html', context)

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -103,6 +103,12 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
             'emergency_contact_phone': user.profile.emergency_contact_phone,
         }
 
+    if request.method == 'GET':
+        requested_ride_id = request.GET.get('ride')
+        if requested_ride_id and requested_ride_id.isdigit():
+            if event.ride_set.filter(id=requested_ride_id).exists():
+                initial_data['ride'] = int(requested_ride_id)
+
     form = RegistrationForm(request.POST or None, event=event, user=user, initial=initial_data)
 
     if request.method == 'POST':


### PR DESCRIPTION
## Summary
Implement ride preselection during registration and add per-ride registration buttons on event detail pages when rides are available.

## Key Changes
- **Registration ride preselection**: Added support for a `ride` query parameter in the registration form that preselects a specific ride. The parameter is validated to ensure the ride belongs to the current event and is numeric.
- **Event detail context**: Added `ride_registration_enabled` context variable that determines when per-ride registration buttons should be displayed. This flag is true when the event has rides, registration is open, capacity is available, and the user is not already registered.
- **Per-ride registration buttons**: Added "Register for this ride" buttons on the event detail page that link to the registration form with the ride preselected via query parameter.
- **Registration button logic**: Updated the event detail template to show per-ride buttons when `ride_registration_enabled` is true, otherwise fall back to the standard registration button.
- **Comprehensive test coverage**: Added test suites for both registration ride preselection and event detail registration button behavior, including edge cases like invalid ride IDs and rides from other events.

## Implementation Details
- Ride preselection validates that the requested ride ID is numeric and belongs to the current event before setting it as initial form data
- The `ride_registration_enabled` flag checks multiple conditions: ride existence, registration status, capacity, external URL absence, and user registration status
- Template logic prioritizes per-ride buttons over the generic registration button when rides are available

https://claude.ai/code/session_01E9DDXmXfy2dn5dhLm6zG7c