### PR TITLE
Show weather badge on registrations and registration views

### DIFF
--- a/web/forecast.py
+++ b/web/forecast.py
@@ -1,0 +1,12 @@
+from django.http import HttpRequest
+from waffle import flag_is_active
+
+from backoffice.models import Event
+from backoffice.services.event_service import EventService
+from backoffice.services.forecast_service import ForecastState
+
+
+def resolve_forecast_state(request: HttpRequest, event: Event) -> ForecastState:
+    if not flag_is_active(request, 'weather_forecast_badges'):
+        return ForecastState.unavailable()
+    return EventService().resolve_forecast(event)

--- a/web/templates/web/events/_forecast_badge_slot.html
+++ b/web/templates/web/events/_forecast_badge_slot.html
@@ -1,0 +1,6 @@
+{% if state.forecast %}
+{% include 'web/events/_forecast_badge.html' with forecast=state.forecast expandable=True show_history_link=True compact=compact %}
+{% elif state.pending %}
+{% url 'event_forecast_badge' event.id as forecast_badge_url %}
+{% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url compact=compact %}
+{% endif %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -2,6 +2,7 @@
 {% load form_filters %}
 {% load dict_filters %}
 {% load name_filters %}
+{% load forecast_filters %}
 {% block title %}{{ event.name }} - Event Details{% endblock %}
 {% block content %}
     <div class="mb-4">
@@ -47,12 +48,7 @@
                 {% elif event.location %}
                 <span class="meta-pill text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
-                {% if forecast_state.forecast %}
-                {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast expandable=True show_history_link=True %}
-                {% elif forecast_state.pending %}
-                {% url 'event_forecast_badge' event.id as forecast_badge_url %}
-                {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
-                {% endif %}
+                {% forecast_badge event %}
                 {% if not event.external_registration_url and event.state != "announced" and event.registration_count > 0 %}
                 <a href="{% url 'riders_list' event.id %}" class="meta-pill meta-pill-link">
                     🚴 {{ event.registration_count }}{% if event.registration_limit %}/{{ event.registration_limit }}{% endif %} registered&nbsp;›

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -1,6 +1,7 @@
 {% extends 'web/_base_bootstrap.html' %}
 {% load form_filters %}
 {% load phone_filters %}
+{% load forecast_filters %}
 {% block title %}Register for {{ event.name }}{% endblock %}
 {% block content %}
     <div class="mb-4">
@@ -37,12 +38,7 @@
                 {% elif event.location %}
                 <span class="meta-pill text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
-                {% if forecast_state.forecast %}
-                {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast expandable=True show_history_link=True %}
-                {% elif forecast_state.pending %}
-                {% url 'event_forecast_badge' event.id as forecast_badge_url %}
-                {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
-                {% endif %}
+                {% forecast_badge event %}
             </div>
         </div>
 

--- a/web/templates/web/events/registration.html
+++ b/web/templates/web/events/registration.html
@@ -37,6 +37,12 @@
                 {% elif event.location %}
                 <span class="meta-pill text-muted">🗺️ {{ event.location }}</span>
                 {% endif %}
+                {% if forecast_state.forecast %}
+                {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast expandable=True show_history_link=True %}
+                {% elif forecast_state.pending %}
+                {% url 'event_forecast_badge' event.id as forecast_badge_url %}
+                {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
+                {% endif %}
             </div>
         </div>
 

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -193,6 +193,12 @@
             {% elif event.location %}
             <span class="meta-pill text-muted">🗺️ {{ event.location }}</span>
             {% endif %}
+            {% if forecast_state.forecast %}
+            {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast expandable=True show_history_link=True %}
+            {% elif forecast_state.pending %}
+            {% url 'event_forecast_badge' event.id as forecast_badge_url %}
+            {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
+            {% endif %}
         </div>
     </div>
 

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -1,4 +1,5 @@
 {% extends 'web/_base_bootstrap.html' %}
+{% load forecast_filters %}
 {% block title %}Riders for {{ event.name }}{% endblock %}
 {% block content %}
 <style media="print">
@@ -193,12 +194,7 @@
             {% elif event.location %}
             <span class="meta-pill text-muted">🗺️ {{ event.location }}</span>
             {% endif %}
-            {% if forecast_state.forecast %}
-            {% include 'web/events/_forecast_badge.html' with forecast=forecast_state.forecast expandable=True show_history_link=True %}
-            {% elif forecast_state.pending %}
-            {% url 'event_forecast_badge' event.id as forecast_badge_url %}
-            {% include 'web/events/_forecast_badge_loading.html' with hx_get=forecast_badge_url %}
-            {% endif %}
+            {% forecast_badge event %}
         </div>
     </div>
 

--- a/web/templatetags/forecast_filters.py
+++ b/web/templatetags/forecast_filters.py
@@ -1,8 +1,18 @@
 from django import template
 
 from backoffice.services.forecast_summary import summarize
+from web.forecast import resolve_forecast_state
 
 register = template.Library()
+
+
+@register.inclusion_tag('web/events/_forecast_badge_slot.html', takes_context=True)
+def forecast_badge(context, event, compact=False):
+    return {
+        'event': event,
+        'state': resolve_forecast_state(context['request'], event),
+        'compact': compact,
+    }
 
 
 @register.filter

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -446,6 +446,90 @@ class DetailPageForecastPlaceholderTests(ForecastBadgeTestCase):
         self.assertContains(response, f'forecast-badge-{event.id}')
 
 
+class RegistrationPagesForecastBadgeTests(ForecastBadgeTestCase):
+    @override_flag('weather_forecast_badges', active=True)
+    def test_registrations_renders_badge_inline_when_fresh_forecast_cached(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('riders_list', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, 'AQHI&nbsp;moderate')
+        self.assertNotContains(response, 'Loading weather forecast')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_registrations_shows_placeholder_without_fetching_forecast(self):
+        # Arrange
+        event = self._create_event()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('riders_list', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, f'forecast-badge-{event.id}')
+        self.assertContains(response, reverse('event_forecast_badge', args=[event.id]))
+        self.assertContains(response, 'Loading weather forecast')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=False)
+    def test_registrations_hides_badge_when_flag_disabled(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('riders_list', args=[event.id]))
+
+        # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+        self.assertNotContains(response, 'AQHI')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_registration_form_renders_badge_inline_when_fresh_forecast_cached(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, 'AQHI&nbsp;moderate')
+        self.assertNotContains(response, 'Loading weather forecast')
+
+    @override_flag('weather_forecast_badges', active=True)
+    def test_registration_form_shows_placeholder_without_fetching_forecast(self):
+        # Arrange
+        event = self._create_event()
+
+        # Act
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            response = self.client.get(reverse('registration_create', args=[event.id]))
+
+        # Assert
+        self.assertContains(response, f'forecast-badge-{event.id}')
+        self.assertContains(response, reverse('event_forecast_badge', args=[event.id]))
+        self.assertContains(response, 'Loading weather forecast')
+        mock_get.assert_not_called()
+
+    @override_flag('weather_forecast_badges', active=False)
+    def test_registration_form_hides_badge_when_flag_disabled(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast()
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[event.id]))
+
+        # Assert
+        self.assertNotContains(response, f'forecast-badge-{event.id}')
+        self.assertNotContains(response, 'AQHI')
+
+
 class EventForecastBadgeViewTests(ForecastBadgeTestCase):
     @override_flag('weather_forecast_badges', active=True)
     def test_badge_endpoint_returns_expandable_badge(self):

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -182,7 +182,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
             state=Registration.STATE_CONFIRMED,
         ).exists()
 
-    forecast_state = _resolve_forecast_state(request, event)
+    forecast_state = resolve_forecast_state(request, event)
 
     context = {
         'event': event,
@@ -195,7 +195,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
     return render(request, 'web/events/detail.html', context)
 
 
-def _resolve_forecast_state(request: HttpRequest, event: Event) -> ForecastState:
+def resolve_forecast_state(request: HttpRequest, event: Event) -> ForecastState:
     if not flag_is_active(request, 'weather_forecast_badges'):
         return ForecastState.unavailable()
     return EventService().resolve_forecast(event)
@@ -369,7 +369,7 @@ def _build_registrations_context(request, event, contacts_revealed):
 def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
-    forecast_state = _resolve_forecast_state(request, event)
+    forecast_state = resolve_forecast_state(request, event)
 
     if not _registrations_visible(event, request.user):
         context = {

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -182,9 +182,7 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
             state=Registration.STATE_CONFIRMED,
         ).exists()
 
-    forecast_state = ForecastState.unavailable()
-    if flag_is_active(request, 'weather_forecast_badges'):
-        forecast_state = EventService().resolve_forecast(event)
+    forecast_state = _resolve_forecast_state(request, event)
 
     context = {
         'event': event,
@@ -195,6 +193,12 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
     }
 
     return render(request, 'web/events/detail.html', context)
+
+
+def _resolve_forecast_state(request: HttpRequest, event: Event) -> ForecastState:
+    if not flag_is_active(request, 'weather_forecast_badges'):
+        return ForecastState.unavailable()
+    return EventService().resolve_forecast(event)
 
 
 def event_forecast_badge(request: HttpRequest, event_id: int) -> HttpResponse:
@@ -365,9 +369,12 @@ def _build_registrations_context(request, event, contacts_revealed):
 def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
+    forecast_state = _resolve_forecast_state(request, event)
+
     if not _registrations_visible(event, request.user):
         context = {
             'event': event,
+            'forecast_state': forecast_state,
             'all_riders': Registration.objects.none(),
             'is_ride_leader': False,
             'can_access_rider_contacts': False,
@@ -379,6 +386,7 @@ def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
         return render(request, 'web/events/registrations.html', context=context)
 
     context = _build_registrations_context(request, event, contacts_revealed=False)
+    context['forecast_state'] = forecast_state
     return render(request, 'web/events/registrations.html', context=context)
 
 

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -17,7 +17,6 @@ from waffle import flag_is_active
 from audit.services import AuditService
 from backoffice.models import Event, Registration
 from backoffice.services.event_service import EventService
-from backoffice.services.forecast_service import ForecastState
 from backoffice.services.registration_service import RegistrationService
 from web.filters import PublicRegistrationFilter
 from web.tables import PublicRegistrationTable
@@ -182,23 +181,14 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
             state=Registration.STATE_CONFIRMED,
         ).exists()
 
-    forecast_state = resolve_forecast_state(request, event)
-
     context = {
         'event': event,
         'rides': rides,
         'user_is_registered': user_is_registered,
         'registrations_available': _registrations_visible(event, request.user),
-        'forecast_state': forecast_state,
     }
 
     return render(request, 'web/events/detail.html', context)
-
-
-def resolve_forecast_state(request: HttpRequest, event: Event) -> ForecastState:
-    if not flag_is_active(request, 'weather_forecast_badges'):
-        return ForecastState.unavailable()
-    return EventService().resolve_forecast(event)
 
 
 def event_forecast_badge(request: HttpRequest, event_id: int) -> HttpResponse:
@@ -369,12 +359,9 @@ def _build_registrations_context(request, event, contacts_revealed):
 def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
-    forecast_state = resolve_forecast_state(request, event)
-
     if not _registrations_visible(event, request.user):
         context = {
             'event': event,
-            'forecast_state': forecast_state,
             'all_riders': Registration.objects.none(),
             'is_ride_leader': False,
             'can_access_rider_contacts': False,
@@ -386,7 +373,6 @@ def event_registrations(request: HttpRequest, event_id: int) -> HttpResponse:
         return render(request, 'web/events/registrations.html', context=context)
 
     context = _build_registrations_context(request, event, contacts_revealed=False)
-    context['forecast_state'] = forecast_state
     return render(request, 'web/events/registrations.html', context=context)
 
 

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -12,6 +12,7 @@ from backoffice.services.registration_service import RegistrationService, Regist
 from backoffice.services.request_service import RequestService
 from backoffice.services.user_service import UserDetail, UserService
 from web.forms import RegistrationForm, MembershipNumberForm, bool_to_yes_no
+from web.views.events import _resolve_forecast_state
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,7 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
     return render(request, 'web/events/registration.html', {
         'event': event,
         'form': form,
+        'forecast_state': _resolve_forecast_state(request, event),
         'selected_ride_id': selected_ride_id,
         'contact_collapsed': _is_section_collapsed(form, CONTACT_FIELDS, initial_data),
         'emergency_collapsed': (

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -12,7 +12,7 @@ from backoffice.services.registration_service import RegistrationService, Regist
 from backoffice.services.request_service import RequestService
 from backoffice.services.user_service import UserDetail, UserService
 from web.forms import RegistrationForm, MembershipNumberForm, bool_to_yes_no
-from web.views.events import _resolve_forecast_state
+from web.views.events import resolve_forecast_state
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
     return render(request, 'web/events/registration.html', {
         'event': event,
         'form': form,
-        'forecast_state': _resolve_forecast_state(request, event),
+        'forecast_state': resolve_forecast_state(request, event),
         'selected_ride_id': selected_ride_id,
         'contact_collapsed': _is_section_collapsed(form, CONTACT_FIELDS, initial_data),
         'emergency_collapsed': (

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -12,7 +12,6 @@ from backoffice.services.registration_service import RegistrationService, Regist
 from backoffice.services.request_service import RequestService
 from backoffice.services.user_service import UserDetail, UserService
 from web.forms import RegistrationForm, MembershipNumberForm, bool_to_yes_no
-from web.views.events import resolve_forecast_state
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +150,6 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
     return render(request, 'web/events/registration.html', {
         'event': event,
         'form': form,
-        'forecast_state': resolve_forecast_state(request, event),
         'selected_ride_id': selected_ride_id,
         'contact_collapsed': _is_section_collapsed(form, CONTACT_FIELDS, initial_data),
         'emergency_collapsed': (


### PR DESCRIPTION
## Summary

The weather forecast badge was only rendered on the event detail page. It now also appears on `/events/<id>/registrations` (riders list) and `/events/<id>/registration` (registration form), in the same meta-pill row as the program and location pills.

Rendering the badge used to need two coordinated halves — a view putting `forecast_state` into the template context, and a six-line `{% if %}/{% elif %}` block in the template. Adding it to two more pages would have made that block a third and fourth copy, and any page that added the template half but forgot the view half would silently render nothing. So the badge is now a template tag.

## Changes

- `web/forecast.py` (new) — `resolve_forecast_state(request, event)`, the flag-gated lookup, in a module no view owns
- `web/templatetags/forecast_filters.py` — new `forecast_badge` inclusion tag; resolves state from `context['request']` and renders the slot partial
- `web/templates/web/events/_forecast_badge_slot.html` (new) — picks between the expandable badge, the HTMX loading pill, and nothing
- `detail.html`, `registrations.html`, `registration.html` — each call site is now `{% forecast_badge event %}`
- `web/views/events.py`, `web/views/registrations.py` — no longer resolve or pass `forecast_state`

The upcoming-events list is unchanged: it resolves forecasts in bulk for the whole page, so per-event resolution through the tag would turn one query into N.

Behaviour is unchanged when the `weather_forecast_badges` waffle flag is off.

## Testing

`uv run python manage.py test` — 830 tests, all passing. Six new tests in `web/tests/views/test_forecast_badge_views.py` cover both new pages: inline badge when a fresh forecast is cached, HTMX placeholder when not, and nothing at all when the flag is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
