### PR TITLE
User profile admin: searchable, block direct delete

### DIFF
--- a/backoffice/admin.py
+++ b/backoffice/admin.py
@@ -199,7 +199,11 @@ class UserMembershipNumberAdmin(AuditedAdminMixin, admin.ModelAdmin):
 class UserProfileAdmin(AuditedAdminMixin, admin.ModelAdmin):
     list_display = ('user', 'user__first_name', 'user__last_name', 'email_verified', 'name_visibility', 'legacy')
     list_filter = ('email_verified', 'name_visibility', 'legacy')
+    search_fields = ('user__first_name', 'user__last_name', 'user__email')
     readonly_fields = ('updated_at',)
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 admin.site.register(Program, ProgramAdmin)

--- a/backoffice/tests/test_user_profile_admin.py
+++ b/backoffice/tests/test_user_profile_admin.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from backoffice.admin import UserProfileAdmin
+from backoffice.models import UserProfile
+
+
+class UserProfileAdminTestCase(TestCase):
+    def setUp(self):
+        # Arrange
+        self.user = User.objects.create_user(username='rider', email='rider@example.com')
+        self.admin = UserProfileAdmin(UserProfile, admin_site=None)
+
+    def test_delete_permission_denied_for_profile(self):
+        # Act
+        allowed = self.admin.has_delete_permission(request=None, obj=self.user.profile)
+
+        # Assert
+        self.assertFalse(allowed)
+
+    def test_deleting_user_still_cascades_to_profile(self):
+        # Act
+        self.user.delete()
+
+        # Assert
+        self.assertFalse(UserProfile.objects.filter(user_id=self.user.id).exists())


### PR DESCRIPTION
## Summary
- Add `search_fields` to `UserProfileAdmin` (first name, last name, email) via `user__` traversal
- Block deleting a `UserProfile` directly through the admin (`has_delete_permission` returns False); deleting the parent `User` still cascades normally

## Why
Deleting only the profile leaves the `User` alive without a profile until the next `User.save()` fires the `ensure_user_profile` signal — many callers access `user.profile` unguarded and would 500 in the meantime.

## Test plan
- [x] `uv run python manage.py test` — 832 passed
- [x] New tests: delete permission denied for direct profile delete, cascade delete still works when User is deleted