### PR TITLE
Address Copilot feedback on UserProfile admin tests

### DIFF
--- a/backoffice/tests/test_user_profile_admin.py
+++ b/backoffice/tests/test_user_profile_admin.py
@@ -1,3 +1,4 @@
+from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -9,7 +10,7 @@ class UserProfileAdminTestCase(TestCase):
     def setUp(self):
         # Arrange
         self.user = User.objects.create_user(username='rider', email='rider@example.com')
-        self.admin = UserProfileAdmin(UserProfile, admin_site=None)
+        self.admin = UserProfileAdmin(UserProfile, AdminSite())
 
     def test_delete_permission_denied_for_profile(self):
         # Act
@@ -19,8 +20,11 @@ class UserProfileAdminTestCase(TestCase):
         self.assertFalse(allowed)
 
     def test_deleting_user_still_cascades_to_profile(self):
+        # Arrange
+        profile_id = self.user.profile.pk
+
         # Act
         self.user.delete()
 
         # Assert
-        self.assertFalse(UserProfile.objects.filter(user_id=self.user.id).exists())
+        self.assertFalse(UserProfile.objects.filter(pk=profile_id).exists())


### PR DESCRIPTION
Follow-up to #323. Addresses Copilot's automated review, consulted with an Opus subagent on each point.

## Addressed
- **`admin_site=None` in test**: use a real `AdminSite()` instead, matching `test_signals.py` and `test_actions.py` convention — avoids relying on `ModelAdmin` tolerating `None`.
- **Vacuous cascade-delete assertion**: `self.user.delete()` sets `self.user.id` to `None` in memory, so the old `filter(user_id=self.user.id)` was really `filter(user_id=None)` — it passed regardless of whether cascade delete worked. Now capture `profile_id` before deleting and assert against that.

## Dismissed (false positive)
- Copilot flagged `list_display = (..., 'user__first_name', 'user__last_name', ...)` as invalid, claiming Django's admin only supports `__` lookups in `search_fields`/`list_filter`/`ordering`. That's true for older Django, but this repo runs **Django 5.2.13**, which added native `__` lookup support to `list_display` in 5.0. Verified empirically: migrated a local DB, logged in as superuser via Django's test `Client`, and loaded `/admin/backoffice/userprofile/` — HTTP 200, columns rendered correctly with real related-user data, sortable. No change made; this line also predates the merged PR.

## Test plan
- [x] `uv run python manage.py test` — 832 passed