### PR TITLE
Log audit event when staff view manage registrations page

### DIFF
--- a/web/tests/views/test_registration_manage_views.py
+++ b/web/tests/views/test_registration_manage_views.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from audit.models import AuditEvent
 from backoffice.models import Event, Program, Registration, Ride, Route, SpeedRange
 
 
@@ -207,6 +208,75 @@ class ManagePageAccessTests(BaseManageTestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Unverified')
+
+
+class ManagePageAuditTests(BaseManageTestCase):
+    def _manage_url(self):
+        return reverse('event_registrations_manage', args=[self.event.id])
+
+    def test_staff_visit_logs_audit_event(self):
+        # Arrange
+        self.client.login(username='staff@example.com', password='password123')
+
+        # Act
+        self.client.get(self._manage_url())
+
+        # Assert
+        self.assertEqual(AuditEvent.objects.count(), 1)
+        audit_event = AuditEvent.objects.get()
+        self.assertEqual(audit_event.action, 'registration_management_viewed')
+        self.assertEqual(audit_event.actor, self.staff_user)
+        self.assertEqual(audit_event.target, self.event)
+
+    def test_each_visit_logs_a_separate_audit_event(self):
+        # Arrange
+        self.client.login(username='staff@example.com', password='password123')
+
+        # Act
+        self.client.get(self._manage_url())
+        self.client.get(self._manage_url())
+
+        # Assert
+        self.assertEqual(AuditEvent.objects.count(), 2)
+
+    def test_non_staff_denied_logs_no_audit_event(self):
+        # Arrange
+        self.client.login(username='regular@example.com', password='password123')
+
+        # Act
+        self.client.get(self._manage_url())
+
+        # Assert
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_anonymous_visit_logs_no_audit_event(self):
+        # Act
+        self.client.get(self._manage_url())
+
+        # Assert
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_external_registration_redirect_logs_no_audit_event(self):
+        # Arrange
+        self.client.login(username='staff@example.com', password='password123')
+        self.event.external_registration_url = 'https://example.com/register'
+        self.event.save(update_fields=['external_registration_url'])
+
+        # Act
+        self.client.get(self._manage_url())
+
+        # Assert
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_response_is_not_cacheable(self):
+        # Arrange
+        self.client.login(username='staff@example.com', password='password123')
+
+        # Act
+        response = self.client.get(self._manage_url())
+
+        # Assert
+        self.assertIn('no-store', response['Cache-Control'])
 
 
 class ManagePageFilterAndSortRegressionTests(BaseManageTestCase):

--- a/web/views/registration_manage.py
+++ b/web/views/registration_manage.py
@@ -3,8 +3,10 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.views.decorators.cache import never_cache
 from django_tables2 import RequestConfig
 
+from audit.services import AuditService
 from backoffice.models import Event, Registration
 from backoffice.services.registration_service import RegistrationDetail, RegistrationService
 from backoffice.services.user_service import UserDetail
@@ -19,6 +21,7 @@ def _require_staff(user):
 
 
 @login_required
+@never_cache
 def event_registrations_manage(request: HttpRequest, event_id: int) -> HttpResponse:
     _require_staff(request.user)
 
@@ -26,6 +29,8 @@ def event_registrations_manage(request: HttpRequest, event_id: int) -> HttpRespo
 
     if event.external_registration_url:
         return redirect('event_detail', event_id=event.id)
+
+    AuditService().log(request.user, 'registration_management_viewed', target=event)
 
     registrations = Registration.objects.filter(
         event_id=event_id,


### PR DESCRIPTION
## Summary

The manage registrations page surfaces every registrant's contact details and emergency contacts in one view, so a staff visit is now recorded as an audit event.

- `event_registrations_manage` logs `registration_management_viewed` with the staff user as actor and the event as target.
- The event is logged after the external-registration redirect check, so a redirect away from the page does not log anything.
- The view is marked `@never_cache`, matching `event_emergency_contacts` and `event_registrations_print`, so a browser cache cannot serve the page without the visit being logged.

The action name follows the existing convention in `audit` (`emergency_contacts_revealed`, `printable_emergency_contacts_viewed`), so it groups naturally with the other sensitive-data views in the admin's action filter.

## Tests

New `ManagePageAuditTests` in `web/tests/views/test_registration_manage_views.py` covers:

- a staff visit logs one event with the right action, actor, and target
- repeat visits log separate events
- non-staff (403) and anonymous (redirect) visits log nothing
- the external-registration redirect logs nothing
- the response carries `no-store`

`uv run python manage.py test` — 838 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGvAg5C3uCdYJXSyBeLrqf)_