### PR TITLE
Hide low AQHI from the weather badge

### DIFF
--- a/backoffice/services/forecast_summary.py
+++ b/backoffice/services/forecast_summary.py
@@ -38,6 +38,7 @@ class ForecastSummary:
     temperature_aria_label: str
     aqhi_category: str | None
     aqhi_warning_category: str | None
+    aqhi_visible: bool
     aria_label: str
     hourly: list[HourlyReading]
 
@@ -53,11 +54,12 @@ def summarize(forecast: Forecast) -> ForecastSummary:
 
     aqhi_category = _prevalent_aqhi_category(hourly)
     aqhi_warning_category = _aqhi_warning(hourly, aqhi_category)
+    aqhi_visible = _aqhi_visible(aqhi_category, aqhi_warning_category)
 
     aria_label = _aria_label(
         condition_primary, condition_warning_label,
         temperature_aria_label,
-        aqhi_category, aqhi_warning_category,
+        aqhi_category if aqhi_visible else None, aqhi_warning_category,
     )
 
     return ForecastSummary(
@@ -68,6 +70,7 @@ def summarize(forecast: Forecast) -> ForecastSummary:
         temperature_aria_label=temperature_aria_label,
         aqhi_category=aqhi_category,
         aqhi_warning_category=aqhi_warning_category,
+        aqhi_visible=aqhi_visible,
         aria_label=aria_label,
         hourly=hourly,
     )
@@ -126,6 +129,12 @@ def _aqhi_warning(hourly: list[HourlyReading], prevalent_category: str | None) -
     if AQHI_CATEGORY_ORDER.index(worst) > AQHI_CATEGORY_ORDER.index(prevalent_category):
         return worst
     return None
+
+
+def _aqhi_visible(category: str | None, warning_category: str | None) -> bool:
+    if category is None:
+        return False
+    return category != 'low' or warning_category is not None
 
 
 def _aria_label(

--- a/backoffice/tests/services/test_forecast_summary.py
+++ b/backoffice/tests/services/test_forecast_summary.py
@@ -189,7 +189,62 @@ class ForecastSummaryTestCase(TestCase):
         self.assertEqual(summary.aqhi_category, 'low')
         self.assertEqual(summary.aqhi_warning_category, 'high')
 
-    def test_aria_label_combines_all_segments_without_warnings(self):
+    def test_aqhi_hidden_when_low_throughout(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'sun', 20, 2),
+            self._hour(1, 'sun', 20, 3),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertEqual(summary.aqhi_category, 'low')
+        self.assertFalse(summary.aqhi_visible)
+
+    def test_aqhi_shown_when_low_spikes_out_of_low(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'sun', 20, 2),
+            self._hour(1, 'sun', 20, 2),
+            self._hour(2, 'sun', 20, 5),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertEqual(summary.aqhi_category, 'low')
+        self.assertTrue(summary.aqhi_visible)
+
+    def test_aqhi_shown_when_prevalent_category_is_moderate(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'sun', 20, 5),
+            self._hour(1, 'sun', 20, 5),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertEqual(summary.aqhi_category, 'moderate')
+        self.assertTrue(summary.aqhi_visible)
+
+    def test_aqhi_hidden_when_unavailable(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'sun', 20, None),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertFalse(summary.aqhi_visible)
+
+    def test_aria_label_omits_air_quality_when_low_throughout(self):
         # Arrange
         forecast = self._build_forecast([
             self._hour(0, 'cloud', 20, 2),
@@ -200,7 +255,35 @@ class ForecastSummaryTestCase(TestCase):
         summary = summarize(forecast)
 
         # Assert
-        self.assertEqual(summary.aria_label, 'Weather: cloudy, 21 degrees Celsius, air quality low')
+        self.assertEqual(summary.aria_label, 'Weather: cloudy, 21 degrees Celsius')
+
+    def test_hourly_readings_keep_low_aqhi(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'sun', 20, 2),
+            self._hour(1, 'sun', 20, 3),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertFalse(summary.aqhi_visible)
+        self.assertEqual([reading.aqhi_display for reading in summary.hourly], ['2', '3'])
+        self.assertEqual([reading.aqhi_category for reading in summary.hourly], ['low', 'low'])
+
+    def test_aria_label_combines_all_segments_without_warnings(self):
+        # Arrange
+        forecast = self._build_forecast([
+            self._hour(0, 'cloud', 20, 5),
+            self._hour(1, 'cloud', 21, 5),
+        ])
+
+        # Act
+        summary = summarize(forecast)
+
+        # Assert
+        self.assertEqual(summary.aria_label, 'Weather: cloudy, 21 degrees Celsius, air quality moderate')
 
     def test_aria_label_includes_warnings_when_present(self):
         # Arrange

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -10,22 +10,29 @@ All events except virtual ones that start today or within the next 7 days get a
 badge:
 
 ```
-☁️/☀️ · 12 – 15° · AQHI 3 – 5 (beta)
+☁️/⚡ · 12–15° · AQHI moderate →high
 ```
 
-- **Conditions**: every weather condition that occurs during the event
-  (thunder ⚡, snow ❄️, rain ☔, cloud ☁️, sun ☀️), slash-separated and
-  ordered by prevalence — the condition covering the most hours of the
-  window comes first. Conditions covering the same number of hours are
-  ordered worst first.
+The badge summarizes the event's hours; `backoffice/services/forecast_summary.py`
+reduces the stored hourly readings to the values below.
+
+- **Condition**: one icon for the prevalent condition — the one covering the
+  most hours of the window (thunder ⚡, snow ❄️, rain ☔, cloud ☁️, sun ☀️),
+  ties broken toward the worse condition. A second icon follows when a notable
+  condition (rain, snow, thunder) appears in some hour and is worse than the
+  prevalent one.
 - **Temperature**: minimum and maximum in °C across the event's duration,
-  collapsed to a single number when they are equal.
-- **AQHI**: minimum and maximum Canadian Air Quality Health Index across the
-  event's duration, collapsed to a single value when they are equal, and shown
-  as `10+` above 10. It is omitted from the badge when the prevalent category is
-  low and no hour rises above it, since a low reading is not actionable; a
-  moderate or worse prevalent category, or a spike out of low, is always shown.
-  The hourly forecast always lists AQHI, whatever the category.
+  collapsed to a single midpoint when they span two degrees or less.
+- **AQHI**: the prevalent Canadian Air Quality Health Index *category* (low,
+  moderate, high, very high) rather than a number, plus a spike category when
+  some hour lands in a worse category than the prevalent one. The badge omits
+  AQHI entirely when the prevalent category is low and no hour rises above it,
+  since a low reading is not actionable; a moderate or worse prevalent
+  category, or a spike out of low, is always shown.
+
+The hourly forecast modal is unaffected by that suppression: it lists each
+hour's numeric AQHI (shown as `10+` above 10) and its category, whatever the
+category is.
 
 The badge is gated behind the `weather_forecast_badges` waffle flag and
 credits its source: Open-Meteo.

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -22,7 +22,10 @@ badge:
   collapsed to a single number when they are equal.
 - **AQHI**: minimum and maximum Canadian Air Quality Health Index across the
   event's duration, collapsed to a single value when they are equal, and shown
-  as `10+` above 10.
+  as `10+` above 10. It is omitted from the badge when the prevalent category is
+  low and no hour rises above it, since a low reading is not actionable; a
+  moderate or worse prevalent category, or a spike out of low, is always shown.
+  The hourly forecast always lists AQHI, whatever the category.
 
 The badge is gated behind the `weather_forecast_badges` waffle flag and
 credits its source: Open-Meteo.

--- a/web/templates/web/events/_forecast_badge_content.html
+++ b/web/templates/web/events/_forecast_badge_content.html
@@ -4,7 +4,7 @@
 {% include 'web/events/_weather_icon.html' with condition=summary.condition_warning %}
 {% endif %}
 <span class="wx-temp" aria-hidden="true">{{ summary.temperature_display }}&deg;</span>
-{% if summary.aqhi_category %}
+{% if summary.aqhi_visible %}
 <span class="wx-aqhi wx-aqhi--{{ summary.aqhi_category|slugify }}" aria-hidden="true">AQHI&nbsp;{{ summary.aqhi_category }}</span>
 {% if summary.aqhi_warning_category %}
 <span class="wx-aqhi-spike wx-aqhi--{{ summary.aqhi_warning_category|slugify }}" aria-hidden="true">&rarr;{{ summary.aqhi_warning_category }}</span>


### PR DESCRIPTION
A low AQHI is not actionable, so the badge omits it entirely, including
from the aria label. It is shown whenever the prevalent category is
moderate or worse, or when an hour spikes out of low. The hourly forecast
modal still lists AQHI for every hour.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LhpbsmkKqbK8fxHYh4mLKC