### PR TITLE
Remove auto-redirect timer from registration submitted page

### DIFF
--- a/web/templates/web/registrations/submitted.html
+++ b/web/templates/web/registrations/submitted.html
@@ -4,28 +4,7 @@
     <div class="row justify-content-center py-5">
         <div class="col-12 col-sm-8 col-md-6 col-lg-5">
             <div class="card">
-                <div class="card-body p-4 text-center"
-                     {% if auto_redirect %}
-                     x-data="{
-                         remaining: {{ redirect_seconds }},
-                         timer: null,
-                         start() {
-                             this.timer = setInterval(() => {
-                                 this.remaining -= 1;
-                                 if (this.remaining <= 0) {
-                                     this.stop();
-                                     window.location.replace('{% url 'event_detail' event.id %}');
-                                 }
-                             }, 1000);
-                         },
-                         stop() {
-                             clearInterval(this.timer);
-                             this.remaining = null;
-                         }
-                     }"
-                     x-init="start()"
-                     @pageshow.window="if ($event.persisted) stop()"
-                     {% endif %}>
+                <div class="card-body p-4 text-center">
                     <div class="d-inline-flex align-items-center justify-content-center rounded-circle bg-success bg-opacity-10 mb-4" style="width: 64px; height: 64px;">
                         <i class="bi bi-check-lg text-success fs-2"></i>
                     </div>
@@ -35,13 +14,6 @@
                     <p class="text-secondary mb-3">
                         Your registration for {{ event.name }} has been submitted successfully! Please expect a confirmation email within a couple of minutes.
                     </p>
-
-                    {% if auto_redirect %}
-                        <p class="text-secondary small mb-3" x-show="remaining !== null" x-cloak>
-                            Taking you back to the event in <span x-text="remaining"></span> seconds.
-                            <button type="button" class="btn btn-link btn-sm p-0 align-baseline" @click="stop()">Stay here</button>
-                        </p>
-                    {% endif %}
 
                     <div class="mt-4 d-flex flex-column flex-sm-row gap-2 justify-content-center">
                         <a href="{% url 'event_detail' event.id %}" class="btn btn-primary">

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1527,18 +1527,6 @@ class RegistrationSubmittedRedirectTests(TestCase):
         self.assertEqual(response.context['event'], self.event)
         self.assertContains(response, reverse('event_detail', args=[self.event.id]))
 
-    def test_submitted_page_does_not_schedule_a_redirect(self):
-        # Arrange
-        self.client.force_login(self.user)
-
-        # Act
-        response = self.client.get(reverse('registration_submitted', args=[self.event.id]))
-
-        # Assert
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, 'setInterval')
-        self.assertNotContains(response, 'Taking you back to the event')
-
     def test_submitted_page_names_the_event(self):
         # Arrange
         self.client.force_login(self.user)

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1515,7 +1515,7 @@ class RegistrationSubmittedRedirectTests(TestCase):
         # Assert
         self.assertRedirects(response, reverse('registration_submitted', args=[self.event.id]))
 
-    def test_submitted_page_auto_redirects_for_signed_in_user(self):
+    def test_submitted_page_links_back_to_the_event(self):
         # Arrange
         self.client.force_login(self.user)
 
@@ -1524,17 +1524,20 @@ class RegistrationSubmittedRedirectTests(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.context['auto_redirect'])
         self.assertEqual(response.context['event'], self.event)
         self.assertContains(response, reverse('event_detail', args=[self.event.id]))
 
-    def test_submitted_page_does_not_auto_redirect_for_anonymous_user(self):
+    def test_submitted_page_does_not_schedule_a_redirect(self):
+        # Arrange
+        self.client.force_login(self.user)
+
         # Act
         response = self.client.get(reverse('registration_submitted', args=[self.event.id]))
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.context['auto_redirect'])
+        self.assertNotContains(response, 'setInterval')
+        self.assertNotContains(response, 'Taking you back to the event')
 
     def test_submitted_page_names_the_event(self):
         # Arrange

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -18,16 +18,11 @@ from web.forms import RegistrationForm, RegistrationEditForm, MembershipNumberFo
 logger = logging.getLogger(__name__)
 
 
-REGISTRATION_SUBMITTED_REDIRECT_SECONDS = 10
-
-
 def registration_submitted(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
     return render(request, 'web/registrations/submitted.html', {
         'event': event,
-        'auto_redirect': request.user.is_authenticated,
-        'redirect_seconds': REGISTRATION_SUBMITTED_REDIRECT_SECONDS,
     })
 
 


### PR DESCRIPTION
The submitted page counted down from ten seconds and then replaced the
location with the event page. Users now choose one of the three buttons
instead.

Drops the Alpine countdown, the "Taking you back to the event" wording
and its "Stay here" escape hatch, the auto_redirect/redirect_seconds
context, and REGISTRATION_SUBMITTED_REDIRECT_SECONDS.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A1Nhigy6WN8zLU5SqJhjFz