### PR TITLE
Manage your registration from the event page

### DIFF
--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -205,6 +205,12 @@ class RegistrationService:
 
         return registration, None
 
+    def has_active_registration(self, user: User, event: Event) -> bool:
+        return Registration.objects.filter(
+            user=user, event=event,
+            state__in=[Registration.STATE_SUBMITTED, Registration.STATE_CONFIRMED, Registration.STATE_UNVERIFIED],
+        ).exists()
+
     def register(self, user_detail: UserDetail, registration_detail: RegistrationDetail, event: Event,
                  request_detail: RequestDetail | None = None,
                  acting_user: User | None = None) -> RegistrationResult:
@@ -215,12 +221,7 @@ class RegistrationService:
         )
         user = self.user_service.find_by_email_or_create(user_detail, update_existing=update_existing)
 
-        active_registrations = Registration.objects.filter(
-            user=user, event=event,
-            state__in=[Registration.STATE_SUBMITTED, Registration.STATE_CONFIRMED, Registration.STATE_UNVERIFIED],
-        )
-
-        if active_registrations.exists():
+        if self.has_active_registration(user, event):
             logger.info(
                 f"User {user.email} (id={user.id}) attempted to register for event {event.name} (id={event.id}) but already has an active registration"
             )
@@ -535,6 +536,28 @@ class RegistrationService:
     def mark_editable(self, registrations: list[Registration]) -> list[Registration]:
         for registration in registrations:
             registration.editable = self.is_registration_editable(registration)[0]
+        return registrations
+
+    def is_registration_withdrawable(self, registration: Registration) -> tuple[bool, str | None]:
+        if registration.state != Registration.STATE_CONFIRMED:
+            return False, 'Only confirmed registrations can be withdrawn.'
+
+        event = registration.event
+
+        if event.cancelled:
+            return False, 'Event is cancelled.'
+
+        if event.archived:
+            return False, 'Event is archived.'
+
+        if timezone.now() >= event.starts_at:
+            return False, 'Event has already started.'
+
+        return True, None
+
+    def mark_withdrawable(self, registrations: list[Registration]) -> list[Registration]:
+        for registration in registrations:
+            registration.withdrawable = self.is_registration_withdrawable(registration)[0]
         return registrations
 
     def _editable_fields(self, event: Event, registration_detail: RegistrationDetail) -> dict:

--- a/backoffice/services/registration_service.py
+++ b/backoffice/services/registration_service.py
@@ -390,6 +390,25 @@ class RegistrationService:
 
         return errors
 
+    def withdraw_registration(self, registration: Registration, user: User) -> None:
+        allowed, reason = self.is_registration_withdrawable(registration)
+
+        if not allowed:
+            raise ValueError(reason)
+
+        registration.withdraw()
+        registration.save()
+
+        logger.info(
+            "User %s (id=%d) withdrew registration %d from event %s (id=%d)",
+            user.email, user.id, registration.id,
+            registration.event.name, registration.event.id,
+        )
+
+        self.audit_service.log(user, 'registration_withdrawn', target=registration)
+
+        self._send_withdrawal_email(registration, withdrawn_by_organizer=False)
+
     def staff_withdraw(self, registration: Registration, staff_user) -> None:
         if registration.state not in [Registration.STATE_CONFIRMED, Registration.STATE_UNVERIFIED]:
             raise ValueError(f"Cannot withdraw registration in state '{registration.state}'")
@@ -600,10 +619,12 @@ class RegistrationService:
 
         return changed_fields
 
-    def _send_withdrawal_email(self, registration: Registration) -> None:
+    def _send_withdrawal_email(self, registration: Registration,
+                               withdrawn_by_organizer: bool = True) -> None:
         context = {
             'base_url': f"https://{settings.WEB_HOST}",
             'registration': registration,
+            'withdrawn_by_organizer': withdrawn_by_organizer,
         }
 
         self.email_service.send_email(

--- a/backoffice/tests/services/test_registration_service.py
+++ b/backoffice/tests/services/test_registration_service.py
@@ -2817,6 +2817,93 @@ class AuditLoggingTestCase(TestCase):
         self.assertEqual(audit_event.action, 'staff_withdrew')
         self.assertEqual(audit_event.target, registration)
 
+    def test_withdraw_registration_creates_audit_event(self):
+        # Arrange
+        user = User.objects.create_user(username='selfwithdraw', email='selfwithdraw@example.com')
+        registration = Registration.objects.create(
+            user=user, event=self.event, name="Self Withdraw",
+            first_name="Self", last_name="Withdraw", email="selfwithdraw@example.com",
+            state=Registration.STATE_SUBMITTED,
+        )
+        registration.confirm()
+        registration.save()
+
+        # Act
+        self.service.withdraw_registration(registration, user)
+
+        # Assert
+        audit_event = AuditEvent.objects.get()
+        self.assertEqual(audit_event.actor, user)
+        self.assertEqual(audit_event.action, 'registration_withdrawn')
+        self.assertEqual(audit_event.target, registration)
+
+    def test_withdraw_registration_sends_email_without_blaming_organizer(self):
+        # Arrange
+        user = User.objects.create_user(username='mailwithdraw', email='mailwithdraw@example.com')
+        registration = Registration.objects.create(
+            user=user, event=self.event, name="Mail Withdraw",
+            first_name="Mail", last_name="Withdraw", email="mailwithdraw@example.com",
+            state=Registration.STATE_SUBMITTED,
+        )
+        registration.confirm()
+        registration.save()
+
+        # Act
+        self.service.withdraw_registration(registration, user)
+
+        # Assert
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertEqual(message.to, ['mailwithdraw@example.com'])
+        self.assertIn('Registration withdrawn for Test Event', message.subject)
+        self.assertIn('has been withdrawn', message.body)
+        self.assertNotIn('by the event organizer', message.body)
+
+    def test_staff_withdraw_email_still_names_the_organizer(self):
+        # Arrange
+        user = User.objects.create_user(username='staffmail', email='staffmail@example.com')
+        registration = Registration.objects.create(
+            user=user, event=self.event, name="Staff Mail",
+            first_name="Staff", last_name="Mail", email="staffmail@example.com",
+            state=Registration.STATE_SUBMITTED,
+        )
+        registration.confirm()
+        registration.save()
+
+        # Act
+        self.service.staff_withdraw(registration, self.staff_user)
+
+        # Assert
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('by the event organizer', mail.outbox[0].body)
+
+    def test_withdraw_registration_rejects_started_event(self):
+        # Arrange
+        started_event = Event.objects.create(
+            program=self.program,
+            name="Started Event",
+            starts_at=timezone.now() - timezone.timedelta(hours=1),
+            requires_emergency_contact=False,
+            ride_leaders_wanted=False,
+        )
+        user = User.objects.create_user(username='toolate', email='toolate@example.com')
+        registration = Registration.objects.create(
+            user=user, event=started_event, name="Too Late",
+            first_name="Too", last_name="Late", email="toolate@example.com",
+            state=Registration.STATE_SUBMITTED,
+        )
+        registration.confirm()
+        registration.save()
+
+        # Act / Assert
+        with self.assertRaises(ValueError):
+            self.service.withdraw_registration(registration, user)
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(
+            Registration.objects.get(id=registration.id).state, Registration.STATE_CONFIRMED
+        )
+
     def test_staff_update_registration_creates_audit_event(self):
         # Arrange
         user = User.objects.create_user(username='updateme', email='updateme@example.com')

--- a/web/templates/email/withdrawal.html
+++ b/web/templates/email/withdrawal.html
@@ -5,9 +5,15 @@
 {% block content %}
     <h1>Hello {{ registration.first_name }},</h1>
 
-    <p>Your registration for <strong>{{ registration.event.name }}</strong> on <strong>{{ registration.event.starts_at|date:"l, M j" }}</strong> has been withdrawn by the event organizer.</p>
+    {% if withdrawn_by_organizer %}
+        <p>Your registration for <strong>{{ registration.event.name }}</strong> on <strong>{{ registration.event.starts_at|date:"l, M j" }}</strong> has been withdrawn by the event organizer.</p>
 
-    <p>If you believe this was done in error or have questions, please contact the ride director.</p>
+        <p>If you believe this was done in error or have questions, please contact the ride director.</p>
+    {% else %}
+        <p>Your registration for <strong>{{ registration.event.name }}</strong> on <strong>{{ registration.event.starts_at|date:"l, M j" }}</strong> has been withdrawn.</p>
+
+        <p>If you did not make this change, or you have questions, please contact the ride director.</p>
+    {% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/web/templates/email/withdrawal.txt
+++ b/web/templates/email/withdrawal.txt
@@ -1,7 +1,9 @@
 Hello {{ registration.first_name }},
 
-Your registration for {{ registration.event.name }} on {{ registration.event.starts_at|date:"l, M j" }} has been withdrawn by the event organizer.
+{% if withdrawn_by_organizer %}Your registration for {{ registration.event.name }} on {{ registration.event.starts_at|date:"l, M j" }} has been withdrawn by the event organizer.
 
-If you believe this was done in error or have questions, please contact the ride director.
+If you believe this was done in error or have questions, please contact the ride director.{% else %}Your registration for {{ registration.event.name }} on {{ registration.event.starts_at|date:"l, M j" }} has been withdrawn.
+
+If you did not make this change, or you have questions, please contact the ride director.{% endif %}
 
 Ottawa Bicycle Club

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -57,12 +57,12 @@
             </div>
         </div>
 
-        {% if user_is_registered %}
+        {% if user_is_registered and not event.cancelled %}
         <div class="p-4 mb-4 bg-success bg-opacity-10 border border-success border-opacity-25 rounded">
             <p class="text-success fw-medium mb-0">
                 <i class="bi bi-check-circle-fill me-1"></i>You're registered for this event.
             </p>
-            {% if user_registration.editable or not event.cancelled %}
+            {% if user_registration.editable or user_registration.withdrawable %}
             <div class="d-flex flex-wrap gap-2 mt-3">
                 {% if user_registration.editable %}
                 <a href="{% url 'registration_edit' user_registration.id %}?next={{ request.path|urlencode }}"
@@ -70,7 +70,7 @@
                     Edit registration
                 </a>
                 {% endif %}
-                {% if not event.cancelled %}
+                {% if user_registration.withdrawable %}
                 <form method="post" action="{% url 'registration_withdraw' user_registration.id %}"
                       onsubmit="return confirm('Are you sure you want to withdraw your registration for this event?');">
                     {% csrf_token %}

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -57,6 +57,32 @@
             </div>
         </div>
 
+        {% if user_is_registered %}
+        <div class="p-4 mb-4 bg-success bg-opacity-10 border border-success border-opacity-25 rounded">
+            <p class="text-success fw-medium mb-0">
+                <i class="bi bi-check-circle-fill me-1"></i>You're registered for this event.
+            </p>
+            {% if user_registration.editable or not event.cancelled %}
+            <div class="d-flex flex-wrap gap-2 mt-3">
+                {% if user_registration.editable %}
+                <a href="{% url 'registration_edit' user_registration.id %}?next={{ request.path|urlencode }}"
+                   class="btn btn-outline-success btn-sm">
+                    Edit registration
+                </a>
+                {% endif %}
+                {% if not event.cancelled %}
+                <form method="post" action="{% url 'registration_withdraw' user_registration.id %}"
+                      onsubmit="return confirm('Are you sure you want to withdraw your registration for this event?');">
+                    {% csrf_token %}
+                    <input type="hidden" name="next" value="{{ request.path }}">
+                    <button type="submit" class="btn btn-outline-success btn-sm">Withdraw</button>
+                </form>
+                {% endif %}
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
+
         <h2 class="fs-5 fw-medium mb-3">About the event</h2>
         <div class="card shadow-sm mb-4">
             <div class="card-body p-4">
@@ -93,28 +119,16 @@
                 </div>
                 {% endif %}
 
-                {% if event.registration_enabled %}
+                {% if event.registration_enabled and not user_is_registered %}
                 {% if event.registration_open %}
                 <div class="mt-4">
-                    {% if event.has_capacity_available and not user_is_registered and event.registration_closes_at %}
+                    {% if event.has_capacity_available and event.registration_closes_at %}
                     <div class="d-flex align-items-center mb-4">
                         <div class="text-muted">Registration closes {{ event.registration_closes_at|date:"F j, g:i A" }}.</div>
                     </div>
                     {% endif %}
                     <div class="d-flex align-items-center">
-                        {% if user_is_registered %}
-                            <div class="p-4 bg-success bg-opacity-10 border border-success border-opacity-25 rounded">
-                                <p class="text-success mb-0">
-                                    You are registered for this event.{% if user_registration.editable %} You can change your details below and keep your spot.{% endif %} You can cancel your registration on your <a href="{% url 'profile' %}" class="text-primary text-decoration-underline">profile page</a>.
-                                </p>
-                                {% if user_registration.editable %}
-                                <a href="{% url 'registration_edit' user_registration.id %}?next={{ request.path|urlencode }}"
-                                   class="btn btn-outline-success btn-sm mt-3">
-                                    Edit registration
-                                </a>
-                                {% endif %}
-                            </div>
-                        {% elif event.external_registration_url %}
+                        {% if event.external_registration_url %}
                             <a href="{{ event.external_registration_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
                                 Register <i class="bi bi-box-arrow-up-right ms-1 small"></i>
                             </a>

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -60,7 +60,7 @@
         {% if user_is_registered and not event.cancelled %}
         <div class="p-4 mb-4 bg-success bg-opacity-10 border border-success border-opacity-25 rounded">
             <p class="text-success fw-medium mb-0">
-                <i class="bi bi-check-circle-fill me-1"></i>You're registered for this event.
+                <i class="bi bi-check-circle-fill me-1" aria-hidden="true"></i>You're registered for this event.
             </p>
             {% if user_registration.editable or user_registration.withdrawable %}
             <div class="d-flex flex-wrap gap-2 mt-3">

--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -155,7 +155,7 @@
                                         </a>
                                         {% endif %}
 
-                                        {% if registration.state == 'confirmed' and not registration.event.cancelled %}
+                                        {% if registration.withdrawable %}
                                         <form method="post" action="{% url 'registration_withdraw' registration.id %}" onsubmit="return confirm('Are you sure you want to withdraw your registration for this event?');">
                                             {% csrf_token %}
                                             <button type="submit" class="btn btn-primary btn-sm">
@@ -227,7 +227,7 @@
                                             </a>
                                             {% endif %}
 
-                                            {% if registration.state == 'confirmed' and not registration.event.cancelled %}
+                                            {% if registration.withdrawable %}
                                             <form method="post" action="{% url 'registration_withdraw' registration.id %}" onsubmit="return confirm('Are you sure you want to withdraw your registration for this event?');" class="d-inline">
                                                 {% csrf_token %}
                                                 <button type="submit" class="btn btn-outline-primary btn-sm">

--- a/web/templates/web/registrations/verification_sent.html
+++ b/web/templates/web/registrations/verification_sent.html
@@ -22,6 +22,12 @@
                     <p class="text-secondary small mb-0">
                         The link is valid for 24 hours. If you don't see the email, please check your spam folder.
                     </p>
+
+                    <div class="mt-4">
+                        <a href="{% url 'events' %}" class="btn btn-outline-secondary">
+                            Back to event list
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1061,7 +1061,58 @@ class EventDetailViewTests(BaseEventViewTestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user_is_registered'])
-        self.assertNotContains(response, 'You are registered for this event')
+        self.assertNotContains(response, "You're registered for this event")
+
+    def test_registered_user_does_not_see_registration_status_for_cancelled_event(self):
+        # Arrange
+        self.event.cancel()
+        self.event.save()
+        self.client.login(username='regular_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "You're registered for this event")
+        self.assertContains(response, 'Event Cancelled')
+
+    def test_registered_user_keeps_actions_after_registration_closes(self):
+        # Arrange
+        self.event.registration_closes_at = timezone.now() - timedelta(hours=1)
+        self.event.save()
+        self.client.login(username='regular_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You're registered for this event")
+        self.assertContains(response, 'Withdraw')
+        self.assertNotContains(response, 'Sorry, registration closed')
+
+    def test_unregistered_user_sees_registration_closed_message(self):
+        # Arrange
+        self.event.registration_closes_at = timezone.now() - timedelta(hours=1)
+        self.event.save()
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Sorry, registration closed')
+
+    def test_registered_user_is_redirected_from_registration_form_to_event(self):
+        # Arrange
+        self.client.login(username='regular_user', password='password123')
+
+        # Act
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertRedirects(response, reverse('event_detail', args=[self.event.id]))
 
     def test_event_detail_with_external_registration_url_and_no_registration_closes_at(self):
         now = timezone.now()

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1051,7 +1051,8 @@ class EventDetailViewTests(BaseEventViewTestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['user_is_registered'])
-        self.assertContains(response, 'You are registered for this event')
+        self.assertContains(response, "You're registered for this event")
+        self.assertContains(response, 'Withdraw')
 
     def test_unauthenticated_user_does_not_see_registration_status(self):
         # Act

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.core.signing import TimestampSigner
 from django.test import TestCase
 from django.contrib.auth.models import User
@@ -530,9 +532,19 @@ class RegistrationWithdrawAccessControlTests(TestCase):
         self.event = Event.objects.create(
             name="Test Event",
             program=program,
-            starts_at=now,
-            ends_at=now,
-            registration_closes_at=now,
+            starts_at=now + timedelta(days=7),
+            ends_at=now + timedelta(days=7, hours=3),
+            registration_closes_at=now + timedelta(days=6),
+            requires_emergency_contact=False,
+            ride_leaders_wanted=False,
+            requires_membership=False
+        )
+
+        self.started_event = Event.objects.create(
+            name="Started Event",
+            program=program,
+            starts_at=now - timedelta(hours=1),
+            ends_at=now + timedelta(hours=2),
             requires_emergency_contact=False,
             ride_leaders_wanted=False,
             requires_membership=False
@@ -578,6 +590,41 @@ class RegistrationWithdrawAccessControlTests(TestCase):
         self.assertEqual(response.status_code, 302)
         updated_registration = Registration.objects.get(id=self.registration_a.id)
         self.assertEqual(updated_registration.state, 'withdrawn')
+
+    def test_user_cannot_withdraw_after_event_has_started(self):
+        # Arrange
+        registration = Registration.objects.create(
+            event=self.started_event,
+            user=self.user_a,
+            state='confirmed'
+        )
+        self.client.force_login(self.user_a)
+
+        # Act
+        response = self.client.post(
+            reverse('registration_withdraw', kwargs={'registration_id': registration.id})
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        updated_registration = Registration.objects.get(id=registration.id)
+        self.assertEqual(updated_registration.state, 'confirmed')
+
+    def test_user_cannot_withdraw_from_cancelled_event(self):
+        # Arrange
+        self.event.cancel()
+        self.event.save()
+        self.client.force_login(self.user_a)
+
+        # Act
+        response = self.client.post(
+            reverse('registration_withdraw', kwargs={'registration_id': self.registration_a.id})
+        )
+
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        updated_registration = Registration.objects.get(id=self.registration_a.id)
+        self.assertEqual(updated_registration.state, 'confirmed')
 
     def test_withdraw_redirects_to_safe_next_target(self):
         self.client.force_login(self.user_a)

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -571,12 +571,20 @@ class RegistrationWithdrawAccessControlTests(TestCase):
         self.registration_a = Registration.objects.create(
             event=self.event,
             user=self.user_a,
+            name='User A',
+            first_name='User',
+            last_name='A',
+            email='user_a@example.com',
             state='confirmed'
         )
 
         self.registration_b = Registration.objects.create(
             event=self.event,
             user=self.user_b,
+            name='User B',
+            first_name='User',
+            last_name='B',
+            email='user_b@example.com',
             state='confirmed'
         )
 
@@ -590,6 +598,20 @@ class RegistrationWithdrawAccessControlTests(TestCase):
         self.assertEqual(response.status_code, 302)
         updated_registration = Registration.objects.get(id=self.registration_a.id)
         self.assertEqual(updated_registration.state, 'withdrawn')
+
+    def test_withdrawing_sends_confirmation_email_to_the_user(self):
+        # Arrange
+        self.client.force_login(self.user_a)
+        mail.outbox = []
+
+        # Act
+        self.client.post(
+            reverse('registration_withdraw', kwargs={'registration_id': self.registration_a.id})
+        )
+
+        # Assert
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [self.registration_a.email])
 
     def test_user_cannot_withdraw_after_event_has_started(self):
         # Arrange
@@ -1619,3 +1641,97 @@ class RegistrationSubmittedRedirectTests(TestCase):
 
         # Assert
         self.assertEqual(response.status_code, 404)
+
+
+class SignedInRegistrationRoundTripTests(TestCase):
+    def setUp(self):
+        # Arrange
+        now = timezone.now()
+        self.program = Program.objects.create(name="Test Program")
+        self.event = Event.objects.create(
+            name="Round Trip Event",
+            program=self.program,
+            starts_at=now + timedelta(days=7),
+            registration_closes_at=now + timedelta(days=6),
+            requires_emergency_contact=False,
+            ride_leaders_wanted=True,
+            requires_membership=False
+        )
+        self.user = User.objects.create_user(
+            username='rider',
+            email='rider@example.com',
+            password='password123',
+            first_name='Rider',
+            last_name='One'
+        )
+        self.user.profile.phone = '+16135550100'
+        self.user.profile.save()
+        self.event_url = reverse('event_detail', kwargs={'event_id': self.event.id})
+
+    def _register(self):
+        return self.client.post(reverse('registration_create', args=[self.event.id]), {
+            'first_name': 'Rider',
+            'last_name': 'One',
+            'email': 'rider@example.com',
+            'phone': '+16135550100',
+        })
+
+    def test_register_then_withdraw_returns_user_to_a_registerable_event_page(self):
+        # Arrange
+        self.client.force_login(self.user)
+
+        # Act - register
+        response = self._register()
+
+        # Assert - lands on the submitted page for this event
+        self.assertRedirects(
+            response, reverse('registration_submitted', args=[self.event.id])
+        )
+
+        # Act - follow through to the event page
+        response = self.client.get(self.event_url)
+
+        # Assert - registered notice with both actions
+        self.assertContains(response, "You're registered for this event")
+        self.assertContains(response, 'Edit registration')
+        self.assertContains(response, 'Withdraw')
+        self.assertNotContains(response, 'class="btn btn-primary">Register</a>')
+
+        # Act - returning to the form redirects back to the event
+        response = self.client.get(reverse('registration_create', args=[self.event.id]))
+
+        # Assert
+        self.assertRedirects(response, self.event_url)
+
+        # Act - withdraw from the event page
+        registration = Registration.objects.get(event=self.event, user=self.user)
+        mail.outbox = []
+        response = self.client.post(
+            reverse('registration_withdraw', kwargs={'registration_id': registration.id}),
+            {'next': self.event_url}
+        )
+
+        # Assert - back on the event page, notice gone, able to register again
+        self.assertRedirects(response, self.event_url)
+        self.assertEqual(
+            Registration.objects.get(id=registration.id).state, Registration.STATE_WITHDRAWN
+        )
+        self.assertEqual(len(mail.outbox), 1)
+
+        response = self.client.get(self.event_url)
+        self.assertNotContains(response, "You're registered for this event")
+        self.assertContains(response, 'Register')
+
+        # Act - re-registering after withdrawing works
+        response = self._register()
+
+        # Assert
+        self.assertRedirects(
+            response, reverse('registration_submitted', args=[self.event.id])
+        )
+        self.assertEqual(
+            Registration.objects.filter(
+                event=self.event, user=self.user, state=Registration.STATE_CONFIRMED
+            ).count(),
+            1,
+        )

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -658,6 +658,19 @@ class RegistrationWithdrawAccessControlTests(TestCase):
 
         self.assertRedirects(response, f'/events/{self.event.id}')
 
+    def test_withdraw_ignores_next_target_from_query_string(self):
+        # Arrange
+        self.client.force_login(self.user_a)
+
+        # Act
+        response = self.client.get(
+            reverse('registration_withdraw', kwargs={'registration_id': self.registration_a.id})
+            + f'?next=/events/{self.event.id}'
+        )
+
+        # Assert
+        self.assertRedirects(response, reverse('profile'))
+
     def test_withdraw_ignores_external_next_target(self):
         self.client.force_login(self.user_a)
 

--- a/web/tests/views/test_registration_views.py
+++ b/web/tests/views/test_registration_views.py
@@ -579,6 +579,26 @@ class RegistrationWithdrawAccessControlTests(TestCase):
         updated_registration = Registration.objects.get(id=self.registration_a.id)
         self.assertEqual(updated_registration.state, 'withdrawn')
 
+    def test_withdraw_redirects_to_safe_next_target(self):
+        self.client.force_login(self.user_a)
+
+        response = self.client.post(
+            reverse('registration_withdraw', kwargs={'registration_id': self.registration_a.id}),
+            {'next': f'/events/{self.event.id}'}
+        )
+
+        self.assertRedirects(response, f'/events/{self.event.id}')
+
+    def test_withdraw_ignores_external_next_target(self):
+        self.client.force_login(self.user_a)
+
+        response = self.client.post(
+            reverse('registration_withdraw', kwargs={'registration_id': self.registration_a.id}),
+            {'next': 'https://evil.example.com/'}
+        )
+
+        self.assertRedirects(response, reverse('profile'))
+
     def test_user_cannot_withdraw_other_user_registration(self):
         self.client.force_login(self.user_a)
 

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -186,7 +186,9 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
 
     if user_registration is not None:
         user_registration.event = event
-        RegistrationService().mark_editable([user_registration])
+        registration_service = RegistrationService()
+        registration_service.mark_editable([user_registration])
+        registration_service.mark_withdrawable([user_registration])
 
     context = {
         'event': event,

--- a/web/views/profile.py
+++ b/web/views/profile.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404, redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from waffle import flag_is_active
 
 from backoffice.models import Registration, UserProfile
@@ -45,6 +46,11 @@ def registration_withdraw(request: HttpRequest, registration_id: int) -> HttpRes
     if registration.state == 'confirmed' and request.method == 'POST':
         registration.withdraw()
         registration.save()
+
+    target = request.POST.get('next') or request.GET.get('next')
+    if target and url_has_allowed_host_and_scheme(
+            target, allowed_hosts={request.get_host()}, require_https=request.is_secure()):
+        return redirect(target)
 
     return redirect('profile')
 

--- a/web/views/profile.py
+++ b/web/views/profile.py
@@ -60,8 +60,7 @@ def registration_withdraw(request: HttpRequest, registration_id: int) -> HttpRes
                 extra={'registration': registration.id, 'reason': reason},
             )
         else:
-            registration.withdraw()
-            registration.save()
+            registration_service.withdraw_registration(registration, request.user)
 
     target = request.POST.get('next') or request.GET.get('next')
     if target and url_has_allowed_host_and_scheme(

--- a/web/views/profile.py
+++ b/web/views/profile.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -11,12 +13,16 @@ from backoffice.services.registration_service import RegistrationService, NAME_M
 from backoffice.services.user_service import UserService
 from web.forms import MembershipNumberForm, NameVisibilityForm
 
+logger = logging.getLogger(__name__)
+
 
 @login_required
 def profile(request: HttpRequest) -> HttpResponse:
     registration_service = RegistrationService()
-    registrations = registration_service.mark_editable(
-        list(registration_service.fetch_current_registrations(request.user))
+    registrations = registration_service.mark_withdrawable(
+        registration_service.mark_editable(
+            list(registration_service.fetch_current_registrations(request.user))
+        )
     )
     past_registrations = registration_service.fetch_past_registrations(request.user)
 
@@ -41,11 +47,21 @@ def profile(request: HttpRequest) -> HttpResponse:
 
 @login_required
 def registration_withdraw(request: HttpRequest, registration_id: int) -> HttpResponseRedirect:
-    registration = get_object_or_404(Registration, id=registration_id, user=request.user)
+    registration = get_object_or_404(
+        Registration.objects.select_related('event'), id=registration_id, user=request.user)
 
-    if registration.state == 'confirmed' and request.method == 'POST':
-        registration.withdraw()
-        registration.save()
+    registration_service = RegistrationService()
+    allowed, reason = registration_service.is_registration_withdrawable(registration)
+
+    if request.method == 'POST':
+        if not allowed:
+            logger.warning(
+                "Registration withdrawal not allowed",
+                extra={'registration': registration.id, 'reason': reason},
+            )
+        else:
+            registration.withdraw()
+            registration.save()
 
     target = request.POST.get('next') or request.GET.get('next')
     if target and url_has_allowed_host_and_scheme(

--- a/web/views/profile.py
+++ b/web/views/profile.py
@@ -62,7 +62,7 @@ def registration_withdraw(request: HttpRequest, registration_id: int) -> HttpRes
         else:
             registration_service.withdraw_registration(registration, request.user)
 
-    target = request.POST.get('next') or request.GET.get('next')
+    target = request.POST.get('next')
     if target and url_has_allowed_host_and_scheme(
             target, allowed_hosts={request.get_host()}, require_https=request.is_secure()):
         return redirect(target)

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.contrib.auth import login
+from django.contrib.auth import login, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.http import HttpResponse, HttpRequest, HttpResponseRedirect, HttpResponseBadRequest
@@ -132,6 +132,10 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
                 event=event,
                 request_detail=request_detail,
                 acting_user=request.user if request.user.is_authenticated else None)
+
+            if request.user.is_authenticated:
+                request.user.refresh_from_db()
+                update_session_auth_hash(request, request.user)
 
             if result == RegistrationResult.VERIFICATION_REQUIRED:
                 return redirect('registration_verification_sent')

--- a/web/views/registrations.py
+++ b/web/views/registrations.py
@@ -94,6 +94,11 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
     event = get_object_or_404(Event, id=event_id)
     registration_service = RegistrationService()
 
+    user = request.user if request.user.is_authenticated else None
+
+    if user and registration_service.has_active_registration(user, event):
+        return redirect('event_detail', event_id=event.id)
+
     allowed, reason = registration_service.is_registration_allowed(event)
     if not allowed:
         logger.warning("Registration not allowed", extra={'event': event, 'reason': reason})
@@ -101,7 +106,6 @@ def registration_create(request: HttpRequest, event_id: int) -> HttpResponseRedi
 
     # OK, proceed
     request_service = RequestService()
-    user = request.user if request.user.is_authenticated else None
 
     initial_data = {}
     if user:


### PR DESCRIPTION
Signed-in users who were already registered got a wordy notice buried in the About card, and had to go to the profile page to withdraw. This puts the notice and both actions where the user already is.

## The registered notice

Moved above the About card, directly under the event title. Copy went from three sentences to one:

> ✓ **You're registered for this event.**

with **Edit registration** and **Withdraw** beneath it. Withdrawing returns you to the event page via a `next` target validated with `url_has_allowed_host_and_scheme`.

## Flows

| State | Event page shows |
|---|---|
| Anonymous, not registered | Register button (or external link / capacity / closed notice) |
| Anonymous, registered-unverified | Register button — cannot be identified; re-submitting is caught as a duplicate |
| Signed in, not registered | Register button |
| Signed in, registered, registration open | Notice + Edit + Withdraw |
| Signed in, registered, registration closed | Notice + Edit + Withdraw (Edit until the event starts) |
| Signed in, registered, event started | Notice only |
| Signed in, registered, event cancelled | No notice — cancellation panel only |

## Bugs found while walking the flows

**Withdraw button the view would reject.** The profile page decided withdrawability inline (`state == 'confirmed' and not event.cancelled`) while `fetch_current_registrations` filters by *date*, so an event that started three hours ago still rendered the button. Added `RegistrationService.is_registration_withdrawable` (confirmed, not cancelled, not archived, not started) plus `mark_withdrawable`, enforced it in the view, and pointed both templates at the same flag.

**Duplicate registration reported as success.** A signed-in registered user opening the registration form directly got a blank form; submitting hit the `DUPLICATE` branch and landed on the success page, which claimed a registration that was never created. They are now redirected to the event page before the form renders, ahead of the `is_registration_allowed` check so they get the event page rather than a bare 400 once registration closes.

**Registered users saw "Sorry, registration closed."** With no way to reach their own registration. That branch is now skipped for registered users, who keep the notice and their actions.

**Self-withdrawal sent no email and left no audit trail.** It wrote the model directly, unlike `staff_withdraw`. Moved into `RegistrationService.withdraw_registration`, which enforces the rule, logs an audit event, and sends the withdrawal email. The email template claimed the registration was "withdrawn by the event organizer" — wrong for a self-withdrawal — so the HTML and text templates now branch on who withdrew it.

**Registering could sign you out.** Applying user details clears a usable password for non-staff users, which rotates the session auth hash and drops the session on the next request — an unintended sign-out path, against the goal in `docs/users-authentication.md`. The registration view now refreshes the session auth hash. This predates this branch and reproduces on `main`; a probe test on `main` confirmed it.

**Dead end on the verification page.** `verification_sent.html` had no links in its content at all. Added a way back to the event list.

## Tests

952 passing, zero failures, zero errors. New coverage for the withdrawable rule at both service and view level, the withdrawal email for self and staff withdrawal, the registered/unregistered split once registration closes, the cancelled-event case, the already-registered redirect, and a signed-in round trip covering register → event page → withdraw → re-register.

Two fixtures were corrected rather than worked around: the withdraw tests used an event starting at `now` (so "can withdraw" only passed because nothing checked the start time) and registrations with no email address (so no mail could be sent).

## Not included

The withdraw confirmation is still the native browser `confirm()` on both pages, as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa1Q6w8NoWYLpwekAk3Wm2)_