### PR TITLE
Tidy event detail notices and list spacing

### DIFF
--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -57,6 +57,22 @@
             </div>
         </div>
 
+        {% if event.cancelled %}
+        <div class="p-4 mb-4 bg-danger bg-opacity-10 border border-danger border-opacity-25 rounded">
+            <p class="text-danger fw-medium mb-0">
+                <i class="bi bi-x-circle-fill me-1" aria-hidden="true"></i>This event was cancelled on {{ event.cancelled_at|date:"F j, Y" }} at {{ event.cancelled_at|date:"g:i A" }}.
+            </p>
+            {% if event.cancellation_reason %}
+            <p class="text-danger mb-0 mt-3">Reason: {{ event.cancellation_reason }}</p>
+            {% endif %}
+            {% if event.organizer_email %}
+            <div class="d-flex flex-wrap gap-2 mt-3">
+                <a href="mailto:{{ event.organizer_email }}" class="btn btn-outline-danger btn-sm">Contact the organizer</a>
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
+
         {% if user_is_registered and not event.cancelled %}
         <div class="p-4 mb-4 bg-success bg-opacity-10 border border-success border-opacity-25 rounded">
             <p class="text-success fw-medium mb-0">
@@ -99,23 +115,6 @@
         <h2 class="fs-5 fw-medium mb-3">About the event</h2>
         <div class="card shadow-sm mb-4">
             <div class="card-body p-4">
-                {% if event.cancelled %}
-                <div class="mb-4 p-4 bg-danger bg-opacity-10 border border-danger border-opacity-25 rounded">
-                    <div>
-                        <h3 class="fs-5 fw-medium text-danger">Event Cancelled</h3>
-                        <p class="text-danger">
-                            This event was cancelled on {{ event.cancelled_at|date:"F j, Y" }} at {{ event.cancelled_at|date:"g:i A" }}.
-                        </p>
-                        {% if event.cancellation_reason %}
-                        <div class="mt-2 text-danger">
-                            <p class="fw-medium">Reason:</p>
-                            <p>{{ event.cancellation_reason }}</p>
-                        </div>
-                        {% endif %}
-                    </div>
-                </div>
-                {% endif %}
-
                 <div class="prose mb-0">
                     <p>{{ event.description|safe }}</p>
                 </div>

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -83,6 +83,19 @@
         </div>
         {% endif %}
 
+        {% if event.registration_enabled and not user_is_registered and not event.registration_open and not event.cancelled and event.state != "announced" %}
+        <div class="p-4 mb-4 bg-primary bg-opacity-10 border border-primary border-opacity-25 rounded">
+            <p class="text-primary fw-medium mb-0">
+                <i class="bi bi-info-circle-fill me-1" aria-hidden="true"></i>Registration for this event is closed.
+            </p>
+            {% if event.organizer_email %}
+            <div class="d-flex flex-wrap gap-2 mt-3">
+                <a href="mailto:{{ event.organizer_email }}" class="btn btn-outline-primary btn-sm">Contact the organizer</a>
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
+
         <h2 class="fs-5 fw-medium mb-3">About the event</h2>
         <div class="card shadow-sm mb-4">
             <div class="card-body p-4">
@@ -103,12 +116,16 @@
                 </div>
                 {% endif %}
 
-                <div class="prose{% if event.organizer_email or event.registration_open or not event.cancelled %} mb-4{% endif %}">
+                <div class="prose mb-0">
                     <p>{{ event.description|safe }}</p>
                 </div>
 
-                {% if event.organizer_email or event.registration_open or not event.cancelled %}
-                <hr>
+                {% if event.organizer_email %}
+                <hr class="mt-4">
+                {% elif event.registration_enabled and not user_is_registered %}
+                {% if event.registration_open or event.state == "announced" %}
+                <hr class="mt-4">
+                {% endif %}
                 {% endif %}
 
                 {% if event.organizer_email %}
@@ -122,12 +139,7 @@
                 {% if event.registration_enabled and not user_is_registered %}
                 {% if event.registration_open %}
                 <div class="mt-4">
-                    {% if event.has_capacity_available and event.registration_closes_at %}
-                    <div class="d-flex align-items-center mb-4">
-                        <div class="text-muted">Registration closes {{ event.registration_closes_at|date:"F j, g:i A" }}.</div>
-                    </div>
-                    {% endif %}
-                    <div class="d-flex align-items-center">
+                    <div class="d-flex flex-wrap gap-3 align-items-center">
                         {% if event.external_registration_url %}
                             <a href="{{ event.external_registration_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
                                 Register <i class="bi bi-box-arrow-up-right ms-1 small"></i>
@@ -139,15 +151,14 @@
                                 <p class="text-warning mb-0">Sorry, the event has reached maximum capacity.</p>
                             </div>
                         {% endif %}
+                        {% if event.has_capacity_available and event.registration_closes_at %}
+                        <div class="text-muted">Registration closes {{ event.registration_closes_at|date:"F j, g:i A" }}.</div>
+                        {% endif %}
                     </div>
                 </div>
                 {% elif event.state == "announced" %}
                 <div class="mt-4 p-4 bg-primary bg-opacity-10 border border-primary border-opacity-25 rounded">
                     <p class="text-primary mb-0">Registration is coming soon. Please check back later.</p>
-                </div>
-                {% elif not event.cancelled %}
-                <div class="mt-4 p-4 bg-danger bg-opacity-10 border border-danger border-opacity-25 rounded">
-                    <p class="text-danger mb-0">Sorry, registration closed.</p>
                 </div>
                 {% endif %}
                 {% endif %}

--- a/web/templates/web/events/list_dense.html
+++ b/web/templates/web/events/list_dense.html
@@ -44,7 +44,7 @@
                                   {{ event.starts_at|date:"g:i A" }}{% if event.ends_at %} - {{ event.ends_at|date:"g:i A" }}{% endif %}
                                 {% endif %}
                             </div>
-                            <div class="fs-6 fw-medium text-dark">
+                            <div class="fs-6 fw-medium text-dark mb-1">
                                 {% if event.cancelled %}<span class="text-decoration-line-through">{{event.name}}</span> (cancelled){% else %}{{event.name}}{% endif %}
                             </div>
                             <div class="d-flex flex-wrap gap-2 align-items-center">

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1075,7 +1075,7 @@ class EventDetailViewTests(BaseEventViewTestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "You're registered for this event")
-        self.assertContains(response, 'Event Cancelled')
+        self.assertContains(response, 'This event was cancelled on')
 
     def test_registered_user_keeps_actions_after_registration_closes(self):
         # Arrange

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1090,7 +1090,7 @@ class EventDetailViewTests(BaseEventViewTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "You're registered for this event")
         self.assertContains(response, 'Withdraw')
-        self.assertNotContains(response, 'Sorry, registration closed')
+        self.assertNotContains(response, 'Registration for this event is closed')
 
     def test_unregistered_user_sees_registration_closed_message(self):
         # Arrange
@@ -1102,7 +1102,7 @@ class EventDetailViewTests(BaseEventViewTestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Sorry, registration closed')
+        self.assertContains(response, 'Registration for this event is closed')
 
     def test_registered_user_is_redirected_from_registration_form_to_event(self):
         # Arrange


### PR DESCRIPTION
## Summary
Tidies up the event detail page so all status notices live in one place, at the top, in a consistent style.

- **Notice boxes unified.** The registration confirmation, the registration-closed notice, and the cancellation notice now all render directly above the "About the event" card, sharing one shape: coloured tint, matching border, an icon, a one-line message, and optional action buttons.
  - Registration closed: moved out of the card, switched from danger red to informational blue, gained an info icon and a "Contact the organizer" button.
  - Event cancelled: moved out of the card, kept danger red, restyled to match, gained a "Contact the organizer" button.
- **Stray horizontal rule removed.** The `<hr>` inside the "About the event" card rendered even when no content followed it — visible to signed-in, registered users. It now only appears when something actually follows.
- **Register row.** "Registration closes ..." now sits on the same line as the Register button, after it, and wraps on narrow screens.
- **Upcoming events list.** A little vertical spacing added between the event title and the badges below it.

## Testing
`uv run python manage.py test` — 952 tests, OK.

Two assertions updated to match the new copy ("Sorry, registration closed" → "Registration for this event is closed", "Event Cancelled" → "This event was cancelled on").

🤖 Generated with [Claude Code](https://claude.com/claude-code)