### PR TITLE
Show unverified riders inline on the rider list for staff

### DIFF
--- a/web/tables.py
+++ b/web/tables.py
@@ -121,6 +121,13 @@ class PublicRegistrationTable(tables.Table):
                 '{} <span class="badge badge-ride-leader">Leader</span>', html
             )
 
+        if record.state == Registration.STATE_UNVERIFIED:
+            html = format_html(
+                '{} <span class="badge bg-warning text-dark" '
+                'title="This user has not verified their email address">Unverified</span>',
+                html,
+            )
+
         count = self.ride_counts.get(record.user_id)
         if count in self.RIDE_COUNT_LABELS:
             html = format_html(

--- a/web/templates/web/events/registrations.html
+++ b/web/templates/web/events/registrations.html
@@ -204,15 +204,6 @@
         <p class="text-muted">Registration details are no longer available for this event.</p>
     </div>
     {% else %}
-    {% if user.is_staff and unverified_riders %}
-    <div class="p-3 mb-4 bg-warning bg-opacity-10 border border-warning border-opacity-25 rounded d-print-none">
-        <p class="text-muted small mb-0">
-            <i class="bi bi-envelope-exclamation me-1" aria-hidden="true"></i>
-            Pending confirmation{{ unverified_riders|length|pluralize }} from {{ unverified_riders|length }} rider{{ unverified_riders|length|pluralize }}:
-            {% for registration in unverified_riders %}{{ registration.name }} &lt;{{ registration.email }}&gt;{% if not forloop.last %}, {% endif %}{% endfor %}
-        </p>
-    </div>
-    {% endif %}
     <div id="registrations-content">
         {% include 'web/events/_registrations_list.html' %}
     </div>

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -206,41 +206,20 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
             state=Registration.STATE_UNVERIFIED
         )
 
-    def test_staff_sees_unverified_registrations_notice(self):
+    def test_staff_sees_unverified_rider_with_badge(self):
         # Arrange
-        self._add_unverified_registration()
+        unverified = self._add_unverified_registration()
         self.client.login(username='staff_user', password='password123')
 
         # Act
         response = self.client.get(self.url)
 
         # Assert
-        self.assertContains(response, 'Pending confirmation from 1 rider:')
-        self.assertContains(response, 'Bob Bobson &lt;bob@bobson.com&gt;')
+        self.assertIn(unverified, response.context['filtered_riders'])
+        self.assertContains(response, 'Bob Bobson')
+        self.assertContains(response, '>Unverified</span>')
 
-    def test_staff_notice_lists_unverified_registration_without_user(self):
-        # Arrange
-        Registration.objects.create(
-            first_name='Alice',
-            last_name='Alison',
-            name='Alice Alison',
-            email='alice@alison.com',
-            event=self.event,
-            ride=self.ride,
-            speed_range_preference=self.speed_range,
-            ride_leader_preference=Registration.RideLeaderPreference.NO,
-            user=None,
-            state=Registration.STATE_UNVERIFIED
-        )
-        self.client.login(username='staff_user', password='password123')
-
-        # Act
-        response = self.client.get(self.url)
-
-        # Assert
-        self.assertContains(response, 'Alice Alison &lt;alice@alison.com&gt;')
-
-    def test_ride_leader_does_not_see_unverified_registrations_notice(self):
+    def test_ride_leader_does_not_see_unverified_rider(self):
         # Arrange
         self._add_unverified_registration()
         self.client.login(username='leader_user', password='password123')
@@ -249,19 +228,34 @@ class EventRegistrationsViewTests(BaseEventViewTestCase):
         response = self.client.get(self.url)
 
         # Assert
-        self.assertEqual(response.context['unverified_riders'], [])
-        self.assertNotContains(response, 'Pending confirmation')
-        self.assertNotContains(response, 'bob@bobson.com')
+        self.assertNotIn('Bob Bobson', response.content.decode())
+        self.assertNotContains(response, 'Unverified')
 
-    def test_staff_sees_no_notice_without_unverified_registrations(self):
+    def test_anonymous_does_not_see_unverified_rider(self):
         # Arrange
+        self._add_unverified_registration()
+
+        # Act
+        response = Client().get(self.url)
+
+        # Assert
+        self.assertNotIn('Bob Bobson', response.content.decode())
+        self.assertNotContains(response, 'Unverified')
+
+    def test_unverified_rider_does_not_enable_ride_leader_emails(self):
+        # Arrange
+        unverified = self._add_unverified_registration()
+        unverified.ride_leader_preference = Registration.RideLeaderPreference.YES
+        unverified.save()
+        self.leader_registration.ride_leader_preference = Registration.RideLeaderPreference.NO
+        self.leader_registration.save()
         self.client.login(username='staff_user', password='password123')
 
         # Act
         response = self.client.get(self.url)
 
         # Assert
-        self.assertNotContains(response, 'Pending confirmation')
+        self.assertFalse(response.context['has_ride_leaders'])
 
     def _add_confirmed_registration(self, user, days_offset):
         event = Event.objects.create(

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -304,9 +304,13 @@ def _build_registrations_context(request, event, contacts_revealed):
     can_access_rider_contacts = is_ride_leader or is_staff
     can_reveal_contacts = can_access_rider_contacts
 
+    visible_states = [Registration.STATE_CONFIRMED]
+    if is_staff:
+        visible_states.append(Registration.STATE_UNVERIFIED)
+
     all_riders = Registration.objects.filter(
         event_id=event.id,
-        state=Registration.STATE_CONFIRMED
+        state__in=visible_states
     ).select_related(
         'ride',
         'speed_range_preference',
@@ -318,13 +322,6 @@ def _build_registrations_context(request, event, contacts_revealed):
         'user__first_name',
         'user__last_name'
     )
-
-    unverified_riders = []
-    if is_staff:
-        unverified_riders = list(Registration.objects.filter(
-            event_id=event.id,
-            state=Registration.STATE_UNVERIFIED
-        ).order_by('first_name', 'last_name'))
 
     registration_filter = PublicRegistrationFilter(
         request.GET, queryset=all_riders, event=event
@@ -367,10 +364,10 @@ def _build_registrations_context(request, event, contacts_revealed):
         'contacts_revealed': contacts_revealed,
         'has_ride_leaders': any(
             rider.ride_leader_preference == Registration.RideLeaderPreference.YES
+            and rider.state == Registration.STATE_CONFIRMED
             for rider in all_riders
         ),
         'registrations_available': True,
-        'unverified_riders': unverified_riders,
     }
 
 


### PR DESCRIPTION
Follow-up to #334. Replaces the standalone notice card with the same treatment the manage-registrations page already uses: unverified riders appear inline in the rider list with an "Unverified" badge.

- Staff viewers get `confirmed + unverified` in the rider list query; everyone else still sees confirmed only.
- `PublicRegistrationTable.render_name` adds the `Unverified` badge, matching `RegistrationTable`.
- Unverified riders are not treated as confirmed: `has_ride_leaders` (and the ride-leader email copy) still counts confirmed riders only, and `event.registration_count` is untouched.
- The notice card added in #334 is removed.

Tests: staff sees the badged row, ride leaders and anonymous users don't, and an unverified ride-leader volunteer doesn't enable the leader email button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
