### PR TITLE
Show emergency contact details on profile page

### DIFF
--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -58,6 +58,20 @@
                     </div>
                     {% endflag %}
 
+                    <div class="mb-2">
+                        <div class="d-flex align-items-center">
+                            <span class="fw-medium me-2">Emergency contact:</span>
+                            <span>{% if user.profile.emergency_contact_name %}{{ user.profile.emergency_contact_name }}{% else %}Not provided{% endif %}</span>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <div class="d-flex align-items-center">
+                            <span class="fw-medium me-2">Emergency contact phone:</span>
+                            <span>{% if user.profile.emergency_contact_phone %}{{ user.profile.emergency_contact_phone|national_phone }}{% else %}Not provided{% endif %}</span>
+                        </div>
+                    </div>
+
                     <div class="text-muted small">
                         <p class="mb-0">These details are automatically updated when you register for events and will be prefilled to save you time.</p>
                     </div>

--- a/web/tests/views/test_profile_views.py
+++ b/web/tests/views/test_profile_views.py
@@ -1,0 +1,43 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+
+class ProfileEmergencyContactTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='rider@example.com',
+            email='rider@example.com',
+            password='secret',
+            first_name='Rita',
+            last_name='Rider',
+        )
+        self.client.force_login(self.user)
+
+    def test_emergency_contact_details_are_shown(self):
+        # Arrange
+        self.user.profile.emergency_contact_name = 'Erin Emergency'
+        self.user.profile.emergency_contact_phone = '+16135551234'
+        self.user.profile.save()
+
+        # Act
+        response = self.client.get(reverse('profile'))
+
+        # Assert
+        self.assertContains(response, 'Emergency contact:')
+        self.assertContains(response, 'Erin Emergency')
+        self.assertContains(response, 'Emergency contact phone:')
+        self.assertContains(response, '(613) 555-1234')
+
+    def test_emergency_contact_details_are_not_provided(self):
+        # Arrange
+        self.user.profile.emergency_contact_name = ''
+        self.user.profile.emergency_contact_phone = ''
+        self.user.profile.save()
+
+        # Act
+        response = self.client.get(reverse('profile'))
+
+        # Assert
+        self.assertContains(response, 'Emergency contact:')
+        self.assertContains(response, 'Not provided', count=3)


### PR DESCRIPTION
Add emergency contact name and phone to the 'Details on file' card,
below the existing profile details, with tests covering both the
provided and not-provided cases.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0113kyDUZN6UhwBevgziYh2i