### PR TITLE
fix(cache): stop routing waffle flags through Redis with a bad SSL flag

### DIFF
--- a/backoffice/services/event_service.py
+++ b/backoffice/services/event_service.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import date, datetime, timedelta
 
-from django.core.cache import cache
+from django.conf import settings
+from django.core.cache import caches
 from django.db.models import Count, Max, Min, Q, QuerySet
 from django.utils import timezone
 
@@ -150,14 +151,29 @@ class EventService:
 
             starts_at, ends_at = window
             key = self._forecast_request_key(window)
-            if not cache.add(key, True, FORECAST_REQUEST_LOCK_SECONDS):
-                continue
+
+            try:
+                if not self._cache().add(key, True, FORECAST_REQUEST_LOCK_SECONDS):
+                    continue
+            except Exception as e:
+                logger.warning('Forecast request cache unavailable: %s', e)
 
             try:
                 fetch_forecast.delay(str(latitude), str(longitude), starts_at.isoformat(), ends_at.isoformat())
             except Exception as e:
-                cache.delete(key)
+                self._release_forecast_request(key)
                 logger.warning('Could not queue forecast fetch for %s to %s: %s', starts_at, ends_at, e)
+
+    @staticmethod
+    def _cache():
+        return caches[settings.FORECAST_CACHE_ALIAS]
+
+    @classmethod
+    def _release_forecast_request(cls, key: str) -> None:
+        try:
+            cls._cache().delete(key)
+        except Exception:
+            pass
 
     @staticmethod
     def _forecast_request_key(window) -> str:

--- a/docs/celery-tasks.md
+++ b/docs/celery-tasks.md
@@ -37,12 +37,21 @@ Events with no possible forecast — virtual events, and events outside the
 seven-day horizon — render an empty badge instead of polling for a forecast that
 will never arrive.
 
-Enqueueing is deduplicated through the Django cache: a window that has been
-requested is locked for `FORECAST_REQUEST_LOCK_SECONDS` (60s), so repeated poll
-attempts and concurrent visitors do not pile up duplicate tasks for the same
-window. `CACHES` points at `REDIS_URL` when it is set, so the lock holds across
-dynos; local development without Redis falls back to in-memory caching, which
-only deduplicates within a single process.
+Enqueueing is deduplicated through a cache lock: a window that has been requested
+is locked for `FORECAST_REQUEST_LOCK_SECONDS` (60s), so repeated poll attempts
+and concurrent visitors do not pile up duplicate tasks for the same window.
+
+The lock uses its own cache alias (`forecast`), backed by Redis when `REDIS_URL`
+is set so it holds across dynos. The `default` cache stays in-process on purpose:
+waffle reads every flag through it, so putting it on Redis would make flag
+evaluation — and therefore most page renders — depend on Redis being reachable.
+A failing forecast cache is caught and logged; the page still renders.
+
+Note that the two Redis URLs are not interchangeable. Celery goes through kombu,
+which wants `ssl_cert_reqs=CERT_NONE`; the Django cache goes through redis-py,
+which only accepts `none`, `optional`, or `required` and raises on anything else.
+`ridehub/redis_url.py` exposes `celery_redis_url()` and `cache_redis_url()` for
+this reason.
 
 ## Behaviour without a worker
 

--- a/ridehub/celery.py
+++ b/ridehub/celery.py
@@ -2,13 +2,13 @@ import os
 
 from celery import Celery
 
-from ridehub.redis_url import redis_url
+from ridehub.redis_url import celery_redis_url
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ridehub.settings')
 
 app = Celery('ridehub')
 
-broker_url = redis_url()
+broker_url = celery_redis_url()
 app.conf.update(broker_url=broker_url, result_backend=broker_url)
 
 app.config_from_object('django.conf:settings', namespace='CELERY')

--- a/ridehub/redis_url.py
+++ b/ridehub/redis_url.py
@@ -3,8 +3,11 @@ from urllib.parse import urlparse, parse_qs, urlencode
 
 LOCAL_REDIS_URL = 'redis://localhost:6379/0'
 
+KOMBU_CERT_NONE = 'CERT_NONE'
+REDIS_PY_CERT_NONE = 'none'
 
-def redis_url() -> str:
+
+def redis_url(cert_reqs: str = KOMBU_CERT_NONE) -> str:
     url = os.environ.get('REDIS_URL')
 
     if not url:
@@ -21,6 +24,14 @@ def redis_url() -> str:
     if 'ssl_cert_reqs' in query_params:
         return url
 
-    query_params['ssl_cert_reqs'] = ['CERT_NONE']
+    query_params['ssl_cert_reqs'] = [cert_reqs]
     parsed_url = parsed_url._replace(query=urlencode(query_params, doseq=True))
     return parsed_url.geturl()
+
+
+def celery_redis_url() -> str:
+    return redis_url(KOMBU_CERT_NONE)
+
+
+def cache_redis_url() -> str:
+    return redis_url(REDIS_PY_CERT_NONE)

--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -6,7 +6,7 @@ import dj_database_url
 import sentry_sdk
 from celery.schedules import crontab
 
-from ridehub.redis_url import redis_url
+from ridehub.redis_url import cache_redis_url
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.celery import CeleryIntegration
 
@@ -254,18 +254,22 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
+FORECAST_CACHE_ALIAS = 'forecast'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+    FORECAST_CACHE_ALIAS: {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'forecast',
+    },
+}
+
 if os.environ.get('REDIS_URL'):
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
-            'LOCATION': redis_url(),
-        }
-    }
-else:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        }
+    CACHES[FORECAST_CACHE_ALIAS] = {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': cache_redis_url(),
     }
 
 REGISTRATION_ALERT_EMAILS = [

--- a/ridehub/tests/test_redis_url.py
+++ b/ridehub/tests/test_redis_url.py
@@ -1,0 +1,60 @@
+import os
+from unittest.mock import patch
+
+import redis
+from django.test import TestCase
+
+from ridehub.redis_url import LOCAL_REDIS_URL, cache_redis_url, celery_redis_url
+
+
+class RedisUrlTests(TestCase):
+
+    def test_falls_back_to_localhost_off_heroku(self):
+        # Act
+        with patch.dict(os.environ, {}, clear=True):
+            url = celery_redis_url()
+
+        # Assert
+        self.assertEqual(url, LOCAL_REDIS_URL)
+
+    def test_raises_on_a_dyno_without_redis(self):
+        # Act / Assert
+        with patch.dict(os.environ, {'DYNO': 'web.1'}, clear=True):
+            with self.assertRaises(RuntimeError):
+                celery_redis_url()
+
+    def test_plain_redis_url_is_left_alone(self):
+        # Act
+        with patch.dict(os.environ, {'REDIS_URL': 'redis://localhost:6379/0'}, clear=True):
+            url = celery_redis_url()
+
+        # Assert
+        self.assertEqual(url, 'redis://localhost:6379/0')
+
+    def test_celery_url_uses_the_flag_spelling_kombu_accepts(self):
+        # Act
+        with patch.dict(os.environ, {'REDIS_URL': 'rediss://h:pw@example.com:1234'}, clear=True):
+            url = celery_redis_url()
+
+        # Assert
+        self.assertIn('ssl_cert_reqs=CERT_NONE', url)
+
+    def test_cache_url_is_accepted_by_redis_py(self):
+        # Arrange
+        with patch.dict(os.environ, {'REDIS_URL': 'rediss://h:pw@example.com:1234'}, clear=True):
+            url = cache_redis_url()
+
+        # Act
+        pool = redis.ConnectionPool.from_url(url)
+        connection = pool.make_connection()
+
+        # Assert
+        self.assertIsNotNone(connection)
+
+    def test_an_explicit_flag_in_the_url_is_preserved(self):
+        # Act
+        with patch.dict(os.environ, {'REDIS_URL': 'rediss://h:pw@example.com:1234?ssl_cert_reqs=required'}, clear=True):
+            url = cache_redis_url()
+
+        # Assert
+        self.assertIn('ssl_cert_reqs=required', url)

--- a/web/tests/views/test_async_forecast_views.py
+++ b/web/tests/views/test_async_forecast_views.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.core.cache import cache
+from django.conf import settings
+from django.core.cache import caches
 from django.test import TestCase
 from django.urls import reverse
 from kombu.exceptions import OperationalError
+from redis.exceptions import RedisError
 from django.utils import timezone
 from waffle.testutils import override_flag
 
@@ -14,7 +16,7 @@ from backoffice.services.forecast_service import YOW_LOCATION
 
 class AsyncForecastTestCase(TestCase):
     def setUp(self):
-        cache.clear()
+        caches[settings.FORECAST_CACHE_ALIAS].clear()
         self.program = Program.objects.create(name='Test Program')
         self.route = Route.objects.create(name='Test Route')
         self.starts_at = (timezone.now() + timedelta(days=1)).replace(
@@ -177,6 +179,31 @@ class EventForecastBadgeAsyncTests(AsyncForecastTestCase):
         # Act
         with patch('backoffice.tasks.fetch_forecast.delay', side_effect=OperationalError('broker down')):
             response = self.client.get(url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+    @override_flag('async_forecast_fetch', active=True)
+    def test_still_renders_when_the_forecast_cache_is_unreachable(self):
+        # Arrange
+        url = reverse('event_forecast_badge', args=[self.event.id])
+        broken_cache = caches[settings.FORECAST_CACHE_ALIAS]
+
+        # Act
+        with patch.object(broken_cache, 'add', side_effect=RedisError('cache down')), \
+                patch('backoffice.tasks.fetch_forecast.delay'):
+            response = self.client.get(url)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+    def test_event_list_renders_when_the_forecast_cache_is_unreachable(self):
+        # Arrange
+        broken_cache = caches[settings.FORECAST_CACHE_ALIAS]
+
+        # Act
+        with patch.object(broken_cache, 'add', side_effect=RedisError('cache down')):
+            response = self.client.get(reverse('upcoming'))
 
         # Assert
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Fixes the 500s on release v273 that forced a rollback. Follow-up to #337, which is already merged.

Sentry: [OBC-RIDEHUB-4V](https://viendi.sentry.io/issues/OBC-RIDEHUB-4V) — 12 events, culprit `/upcoming`.

## What broke

```
RedisError: Invalid SSL Certificate Requirements Flag: CERT_NONE
  web/views/events.py:337, in event_list
    if flag_is_active(request, 'weather_forecast_badges'):
  waffle/models.py:52, in get     → cached = cache.get(cache_key)
  django/core/cache/backends/redis.py:100
  redis/connection.py:997         → raise RedisError(...)
```

Two mistakes compounding.

**The SSL flag spelling.** #337 pointed `CACHES` at the same Redis URL as the Celery broker. Celery goes through kombu, which accepts `ssl_cert_reqs=CERT_NONE`. The Django cache goes through redis-py, which accepts only `none`, `optional`, or `required` and raises on anything else:

```
CERT_NONE -> RedisError : Invalid SSL Certificate Requirements Flag: CERT_NONE
none      -> OK
```

**Putting the default cache on Redis at all.** django-waffle reads every flag through the `default` cache (`CACHE_NAME = 'default'`), so making that cache Redis-backed meant every `flag_is_active()` call depended on Redis being reachable at request time. That is why an unrelated forecast dedup lock took down `/upcoming`. It also explains why the `async_forecast_fetch` flag did not protect anything here — the `CACHES` change was global, not behind the flag.

## The fix

- `default` cache returns to `LocMemCache`, exactly as before #337, so flag evaluation never touches the network.
- The forecast request lock moves to its own `forecast` cache alias, Redis-backed only when `REDIS_URL` is set. That lock is the only thing that actually needs to be shared across dynos.
- `celery_redis_url()` and `cache_redis_url()` keep the two SSL spellings apart, since the same URL cannot serve both clients.
- Cache calls in `request_forecasts` are caught and logged, so a Redis outage degrades to a missing badge rather than a 500.

## Tests

1017 passing. `ridehub/tests/test_redis_url.py` builds a real redis-py connection from the cache URL — confirmed it raises against the old value, so it would have caught this before deploy. Two view tests assert `/upcoming` and the badge endpoint still return 200 with the forecast cache throwing.

## Deploying

No config changes. Worth deploying with `async_forecast_fetch` still off, confirming `/upcoming` is clean, and enabling the flag separately afterwards.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCC3jJQRzPZZcJLteu1MMH)_