### PR TITLE
feat(observability): monitor beat tasks with Sentry Crons

### DIFF
--- a/docs/celery-tasks.md
+++ b/docs/celery-tasks.md
@@ -70,6 +70,24 @@ stale cached forecast when one exists. Publishing is configured to fail fast
 (`CELERY_TASK_PUBLISH_RETRY = False`, 2s socket timeouts) so a dead broker does
 not stall web requests behind connection retries.
 
+## Knowing whether the schedule is running
+
+`CeleryIntegration(monitor_beat_tasks=True)` registers a Sentry Cron monitor per
+`CELERY_BEAT_SCHEDULE` entry and checks in on every run, so Sentry alerts on a
+run that never happened rather than only on one that raised. Monitors appear
+under Crons in Sentry after the first run of each task; their schedules come from
+`CELERY_BEAT_SCHEDULE` and need no setup in Sentry.
+
+This matters because a successful run is otherwise silent. `check_registrations`
+logs only when it finds a stuck registration, and `alert_unconfirmed_registrations`
+emails only when something is past the threshold, so an idle worker and a dead
+worker look identical from the outside.
+
+The other signals, in decreasing usefulness: `last_run_at` and `total_run_count`
+at `/admin/django_celery_beat/periodictask/`; `Scheduler: Sending due task` lines
+in the worker log; and `/debug/trigger-task` to prove the queue is being consumed
+right now.
+
 ## Heroku setup
 
 ```

--- a/ridehub/settings.py
+++ b/ridehub/settings.py
@@ -213,12 +213,16 @@ def _scrub_sentry_event(event, hint):
     return event
 
 
+def _sentry_integrations():
+    return [DjangoIntegration(), CeleryIntegration(monitor_beat_tasks=True)]
+
+
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=os.environ.get('SENTRY_DSN', SENTRY_DSN),
         send_default_pii=False,
         traces_sample_rate=_sentry_traces_sample_rate(),
-        integrations=[DjangoIntegration(), CeleryIntegration()],
+        integrations=_sentry_integrations(),
         release=os.environ.get('HEROKU_RELEASE_VERSION', 'unknown'),
         before_send=_scrub_sentry_event,
         before_send_transaction=_scrub_sentry_event,

--- a/ridehub/tests/test_sentry_configuration.py
+++ b/ridehub/tests/test_sentry_configuration.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from sentry_sdk.integrations.celery import CeleryIntegration
+
+from ridehub.settings import _sentry_integrations
+
+
+class SentryIntegrationTests(TestCase):
+
+    def _celery_integration(self):
+        return next(i for i in _sentry_integrations() if isinstance(i, CeleryIntegration))
+
+    def test_celery_integration_is_configured(self):
+        # Act
+        integration = self._celery_integration()
+
+        # Assert
+        self.assertIsNotNone(integration)
+
+    def test_beat_tasks_are_monitored(self):
+        # Act
+        integration = self._celery_integration()
+
+        # Assert
+        self.assertTrue(integration.monitor_beat_tasks)
+
+    def test_no_beat_tasks_are_excluded_from_monitoring(self):
+        # Act
+        integration = self._celery_integration()
+
+        # Assert
+        self.assertIsNone(integration.exclude_beat_tasks)


### PR DESCRIPTION
Makes a periodic task that *never ran* alertable, not just one that raised.

## Why

A successful periodic run is silent. `check_registrations` logs only when it finds a registration stuck in `submitted`; `alert_unconfirmed_registrations` emails only when something is past the threshold. So an idle worker and a dead worker produce identical output — nothing.

`CeleryIntegration()` already reported task *exceptions*, but nothing reported absence. That is the failure mode that matters here: an empty inbox means either "no unconfirmed registrations" or "beat has been dead for a week", and today you cannot tell which.

## Change

```python
integrations=_sentry_integrations()   # [DjangoIntegration(), CeleryIntegration(monitor_beat_tasks=True)]
```

Each `CELERY_BEAT_SCHEDULE` entry registers a Sentry Cron monitor and checks in on every run. Sentry alerts when an expected check-in does not arrive.

The integration list moved into `_sentry_integrations()` so the configuration is assertable — `sentry_sdk.init()` runs only when `SENTRY_DSN` is set, which makes the inline list untestable.

## Setup

None in Sentry. Monitors appear under Crons after each task's first run, with schedules taken from `CELERY_BEAT_SCHEDULE`. Alert rules on those monitors are worth configuring once they show up.

## Tests

1020 passing. Three tests assert the Celery integration is present, that `monitor_beat_tasks` is on, and that no tasks are excluded from monitoring.

## Ordering

Independent of #340, but #340 fixes the 500s that forced the rollback and should go in first — `main` still carries that bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCC3jJQRzPZZcJLteu1MMH)_