### PR TITLE
Limit unconfirmed registration alerts to events starting within 48 hours

### DIFF
--- a/backoffice/services/registration_alert_service.py
+++ b/backoffice/services/registration_alert_service.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 UNCONFIRMED_ALERT_THRESHOLD = timedelta(hours=1)
 
+UNCONFIRMED_ALERT_EVENT_HORIZON = timedelta(hours=48)
+
 UNCONFIRMED_STATES = [Registration.STATE_SUBMITTED, Registration.STATE_UNVERIFIED]
 
 
@@ -34,6 +36,7 @@ class RegistrationAlertService:
                 'base_url': f"https://{settings.WEB_HOST}",
                 'registrations': stale,
                 'threshold_hours': int(UNCONFIRMED_ALERT_THRESHOLD.total_seconds() // 3600),
+                'horizon_hours': int(UNCONFIRMED_ALERT_EVENT_HORIZON.total_seconds() // 3600),
             },
             subject=f"{len(stale)} unconfirmed registration{'s' if len(stale) > 1 else ''}",
             recipient_list=recipients,
@@ -44,9 +47,12 @@ class RegistrationAlertService:
 
     @staticmethod
     def _stale_registrations():
-        cutoff = timezone.now() - UNCONFIRMED_ALERT_THRESHOLD
+        now = timezone.now()
+        cutoff = now - UNCONFIRMED_ALERT_THRESHOLD
 
         return Registration.objects.filter(
             state__in=UNCONFIRMED_STATES,
             submitted_at__lte=cutoff,
-        ).select_related('event').order_by('submitted_at')
+            event__starts_at__gte=now,
+            event__starts_at__lte=now + UNCONFIRMED_ALERT_EVENT_HORIZON,
+        ).select_related('event').order_by('event__starts_at', 'submitted_at')

--- a/backoffice/tests/services/test_registration_alert_service.py
+++ b/backoffice/tests/services/test_registration_alert_service.py
@@ -13,20 +13,22 @@ class RegistrationAlertServiceTests(TestCase):
 
     def setUp(self):
         self.program = Program.objects.create(name='Test Program')
-        starts_at = timezone.now() + timedelta(days=7)
-        self.event = Event.objects.create(
-            name='Test Event',
+        self.event = self._create_event('Test Event', timezone.now() + timedelta(hours=24))
+        self.service = RegistrationAlertService()
+
+    def _create_event(self, name, starts_at):
+        return Event.objects.create(
+            name=name,
             starts_at=starts_at,
             registration_closes_at=starts_at - timedelta(hours=1),
             program=self.program,
             location='Test Location',
             description='Test Description',
         )
-        self.service = RegistrationAlertService()
 
-    def _create_registration(self, state, submitted_ago, name='Stale Rider'):
+    def _create_registration(self, state, submitted_ago, name='Stale Rider', event=None):
         registration = Registration.objects.create(
-            event=self.event,
+            event=event or self.event,
             first_name=name.split()[0],
             last_name=name.split()[1],
             name=name,
@@ -135,6 +137,58 @@ class RegistrationAlertServiceTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('First Rider', mail.outbox[0].body)
         self.assertIn('Second Rider', mail.outbox[0].body)
+
+    def test_ignores_registrations_for_past_events(self):
+        # Arrange
+        past_event = self._create_event('Past Event', timezone.now() - timedelta(hours=1))
+        self._create_registration(Registration.STATE_UNVERIFIED, timedelta(hours=2), event=past_event)
+
+        # Act
+        alerted = self.service.alert_unconfirmed_registrations()
+
+        # Assert
+        self.assertEqual(alerted, 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_ignores_registrations_for_events_more_than_48_hours_away(self):
+        # Arrange
+        distant_event = self._create_event('Distant Event', timezone.now() + timedelta(hours=49))
+        self._create_registration(Registration.STATE_UNVERIFIED, timedelta(hours=2), event=distant_event)
+
+        # Act
+        alerted = self.service.alert_unconfirmed_registrations()
+
+        # Assert
+        self.assertEqual(alerted, 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_alerts_about_registrations_for_events_within_48_hours(self):
+        # Arrange
+        soon_event = self._create_event('Soon Event', timezone.now() + timedelta(hours=47))
+        self._create_registration(Registration.STATE_UNVERIFIED, timedelta(hours=2), event=soon_event)
+
+        # Act
+        alerted = self.service.alert_unconfirmed_registrations()
+
+        # Assert
+        self.assertEqual(alerted, 1)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_orders_registrations_by_event_start_time(self):
+        # Arrange
+        later_event = self._create_event('Later Event', timezone.now() + timedelta(hours=40))
+        earlier_event = self._create_event('Earlier Event', timezone.now() + timedelta(hours=4))
+        self._create_registration(Registration.STATE_UNVERIFIED, timedelta(hours=2), name='Later Rider',
+                                  event=later_event)
+        self._create_registration(Registration.STATE_UNVERIFIED, timedelta(hours=3), name='Earlier Rider',
+                                  event=earlier_event)
+
+        # Act
+        self.service.alert_unconfirmed_registrations()
+
+        # Assert
+        body = mail.outbox[0].body
+        self.assertLess(body.index('Earlier Rider'), body.index('Later Rider'))
 
     @override_settings(REGISTRATION_ALERT_EMAILS=[])
     def test_sends_nothing_when_no_recipients_configured(self):

--- a/web/templates/email/unconfirmed_registrations.html
+++ b/web/templates/email/unconfirmed_registrations.html
@@ -5,7 +5,7 @@
 {% block content %}
     <h1>Unconfirmed registrations</h1>
 
-    <p>The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed, and the event starts within {{ horizon_hours }} hours.</p>
+    <p>The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed, for events starting within the next {% with hours=horizon_hours|default:48 %}{{ hours }} hour{{ hours|pluralize }}{% endwith %}.</p>
 
     <ul>
         {% for registration in registrations %}

--- a/web/templates/email/unconfirmed_registrations.html
+++ b/web/templates/email/unconfirmed_registrations.html
@@ -5,7 +5,7 @@
 {% block content %}
     <h1>Unconfirmed registrations</h1>
 
-    <p>The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed.</p>
+    <p>The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed, and the event starts within {{ horizon_hours }} hours.</p>
 
     <ul>
         {% for registration in registrations %}

--- a/web/templates/email/unconfirmed_registrations.txt
+++ b/web/templates/email/unconfirmed_registrations.txt
@@ -1,6 +1,6 @@
 Unconfirmed registrations
 
-The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed, and the event starts within {{ horizon_hours }} hours.
+The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed, for events starting within the next {% with hours=horizon_hours|default:48 %}{{ hours }} hour{{ hours|pluralize }}{% endwith %}.
 
 {% for registration in registrations %}- {{ registration.name }} - {{ registration.event.name }} on {{ registration.event.starts_at|date:"l, M j" }} (submitted {{ registration.submitted_at|date:"M j, H:i" }}, {{ registration.get_state_display|lower }})
   {{ base_url }}{% url 'event_registrations_manage' registration.event_id %}

--- a/web/templates/email/unconfirmed_registrations.txt
+++ b/web/templates/email/unconfirmed_registrations.txt
@@ -1,6 +1,6 @@
 Unconfirmed registrations
 
-The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed.
+The following registration{{ registrations|length|pluralize }} ha{{ registrations|length|pluralize:"s,ve" }} been waiting more than {{ threshold_hours }} hour{{ threshold_hours|pluralize }} without being confirmed, and the event starts within {{ horizon_hours }} hours.
 
 {% for registration in registrations %}- {{ registration.name }} - {{ registration.event.name }} on {{ registration.event.starts_at|date:"l, M j" }} (submitted {{ registration.submitted_at|date:"M j, H:i" }}, {{ registration.get_state_display|lower }})
   {{ base_url }}{% url 'event_registrations_manage' registration.event_id %}


### PR DESCRIPTION
Skip registrations for events that have already started, only warn when
the event begins within 48 hours, and order the digest by event start
time with the soonest event first.