### PR TITLE
Scale forecast refresh interval with event lead time

### DIFF
--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -13,9 +13,14 @@ logger = logging.getLogger(__name__)
 
 YOW_LOCATION = (Decimal('45.32250'), Decimal('-75.66920'))
 
-FORECAST_STALE_AFTER = timedelta(hours=6)
 FORECAST_WINDOW = timedelta(days=7)
 REQUEST_TIMEOUT_SECONDS = 3
+
+REFRESH_INTERVAL_MIN_HOURS = 1
+REFRESH_INTERVAL_MAX_HOURS = 12
+REFRESH_LEAD_MIN_HOURS = 24
+REFRESH_LEAD_MAX_HOURS = 168
+STALE_AFTER_INTERVALS = 2
 
 WEATHER_URL = 'https://api.open-meteo.com/v1/forecast'
 AIR_QUALITY_URL = 'https://air-quality-api.open-meteo.com/v1/air-quality'
@@ -53,23 +58,31 @@ class ForecastService:
     def refresh_forecasts_for_windows(self, windows) -> dict:
         latitude, longitude = YOW_LOCATION
         now = timezone.now()
+        windows = list(windows)
+
+        fresh_by_window = self.get_forecasts_for_windows(windows)
 
         forecasts_by_snapped_window: dict = {}
         forecasts_by_window: dict = {}
+        skipped = 0
 
         for window in windows:
             starts_at, ends_at = window
             snapped_window = self._window(starts_at, ends_at, now)
             if snapped_window not in forecasts_by_snapped_window:
-                forecasts_by_snapped_window[snapped_window] = self.refresh_forecast(
+                fresh = fresh_by_window.get(window)
+                if fresh:
+                    skipped += 1
+                forecasts_by_snapped_window[snapped_window] = fresh or self.refresh_forecast(
                     latitude, longitude, starts_at, ends_at
                 )
             forecasts_by_window[window] = forecasts_by_snapped_window[snapped_window]
 
         logger.info(
-            'Refreshed %s of %s distinct forecast windows',
-            len([f for f in forecasts_by_snapped_window.values() if f]),
+            'Refreshed %s of %s distinct forecast windows, %s already fresh',
+            len([f for f in forecasts_by_snapped_window.values() if f]) - skipped,
             len(forecasts_by_snapped_window),
+            skipped,
         )
 
         return forecasts_by_window
@@ -121,9 +134,21 @@ class ForecastService:
             return None
         return forecast
 
+    @classmethod
+    def _usable_from(cls, time, now):
+        return min(now, time) - STALE_AFTER_INTERVALS * cls.refresh_interval(time, now)
+
     @staticmethod
-    def _usable_from(time, now):
-        return min(now, time) - FORECAST_STALE_AFTER
+    def refresh_interval(time, now) -> timedelta:
+        lead_hours = (time - now).total_seconds() / 3600
+        slope = (
+            (REFRESH_INTERVAL_MAX_HOURS - REFRESH_INTERVAL_MIN_HOURS)
+            / (REFRESH_LEAD_MAX_HOURS - REFRESH_LEAD_MIN_HOURS)
+        )
+        hours = REFRESH_INTERVAL_MIN_HOURS + (lead_hours - REFRESH_LEAD_MIN_HOURS) * slope
+        return timedelta(hours=min(
+            REFRESH_INTERVAL_MAX_HOURS, max(REFRESH_INTERVAL_MIN_HOURS, round(hours))
+        ))
 
     @classmethod
     def _window(cls, starts_at, ends_at, now) -> tuple:

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -27,8 +27,8 @@ AIR_QUALITY_URL = 'https://air-quality-api.open-meteo.com/v1/air-quality'
 
 
 class ForecastService:
-    def refresh_forecast(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None) -> Forecast | None:
-        now = timezone.now()
+    def refresh_forecast(self, latitude: Decimal, longitude: Decimal, starts_at, ends_at=None, now=None) -> Forecast | None:
+        now = now or timezone.now()
         if starts_at <= now or starts_at > now + FORECAST_WINDOW:
             return None
         time, end_time = self._window(starts_at, ends_at, now)
@@ -60,7 +60,7 @@ class ForecastService:
         now = timezone.now()
         windows = list(windows)
 
-        fresh_by_window = self.get_forecasts_for_windows(windows)
+        fresh_by_window = self.get_forecasts_for_windows(windows, now)
 
         forecasts_by_snapped_window: dict = {}
         forecasts_by_window: dict = {}
@@ -74,7 +74,7 @@ class ForecastService:
                 if fresh:
                     skipped += 1
                 forecasts_by_snapped_window[snapped_window] = fresh or self.refresh_forecast(
-                    latitude, longitude, starts_at, ends_at
+                    latitude, longitude, starts_at, ends_at, now
                 )
             forecasts_by_window[window] = forecasts_by_snapped_window[snapped_window]
 
@@ -91,8 +91,8 @@ class ForecastService:
         window = (starts_at, ends_at or starts_at + timedelta(hours=1))
         return self.get_forecasts_for_windows([window])[window]
 
-    def get_forecasts_for_windows(self, windows) -> dict:
-        now = timezone.now()
+    def get_forecasts_for_windows(self, windows, now=None) -> dict:
+        now = now or timezone.now()
         latitude, longitude = YOW_LOCATION
 
         snapped_windows = {

--- a/backoffice/tasks.py
+++ b/backoffice/tasks.py
@@ -34,6 +34,6 @@ def refresh_forecasts() -> int:
 
     refreshed = service.refresh_forecasts(events)
     logger.info(
-        'Forecast refresh finished: %s windows stored for %s events', refreshed, len(events)
+        'Forecast refresh finished: %s windows covered for %s events', refreshed, len(events)
     )
     return refreshed

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -141,7 +141,7 @@ class ForecastServiceTestCase(TestCase):
         self.assertEqual(fresh, forecast)
         mock_get.assert_not_called()
 
-    def test_forecast_older_than_six_hours_is_not_fresh(self):
+    def test_forecast_older_than_two_refresh_intervals_is_not_fresh(self):
         # Arrange
         window_end = self.starts_at + timedelta(hours=1)
         forecast = Forecast.objects.create(
@@ -152,7 +152,7 @@ class ForecastServiceTestCase(TestCase):
             hourly=_hourly_entry(self.starts_at),
         )
         Forecast.objects.filter(pk=forecast.pk).update(
-            prepared_at=timezone.now() - timedelta(hours=6, minutes=1)
+            prepared_at=timezone.now() - timedelta(hours=2, minutes=1)
         )
 
         # Act
@@ -163,7 +163,7 @@ class ForecastServiceTestCase(TestCase):
         self.assertIsNone(fresh)
         mock_get.assert_not_called()
 
-    def test_forecast_just_under_six_hours_old_is_still_fresh(self):
+    def test_forecast_just_under_two_refresh_intervals_old_is_still_fresh(self):
         # Arrange
         window_end = self.starts_at + timedelta(hours=1)
         forecast = Forecast.objects.create(
@@ -174,7 +174,7 @@ class ForecastServiceTestCase(TestCase):
             hourly=_hourly_entry(self.starts_at),
         )
         Forecast.objects.filter(pk=forecast.pk).update(
-            prepared_at=timezone.now() - timedelta(hours=5, minutes=59)
+            prepared_at=timezone.now() - timedelta(hours=1, minutes=59)
         )
 
         # Act
@@ -182,6 +182,52 @@ class ForecastServiceTestCase(TestCase):
 
         # Assert
         self.assertEqual(fresh, forecast)
+
+    def test_distant_event_keeps_a_forecast_far_older_than_a_nearby_event_would(self):
+        # Arrange
+        starts_at = (timezone.now() + timedelta(days=7)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        window_end = starts_at + timedelta(hours=1)
+        forecast = Forecast.objects.create(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            start_time=starts_at,
+            end_time=window_end,
+            hourly=_hourly_entry(starts_at),
+        )
+        Forecast.objects.filter(pk=forecast.pk).update(
+            prepared_at=timezone.now() - timedelta(hours=23)
+        )
+
+        # Act
+        displayed = self.service.get_forecast(starts_at, window_end)
+
+        # Assert
+        self.assertEqual(displayed, forecast)
+
+    def test_distant_event_drops_a_forecast_older_than_two_twelve_hour_intervals(self):
+        # Arrange
+        starts_at = (timezone.now() + timedelta(days=7)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        window_end = starts_at + timedelta(hours=1)
+        forecast = Forecast.objects.create(
+            latitude=self.latitude,
+            longitude=self.longitude,
+            start_time=starts_at,
+            end_time=window_end,
+            hourly=_hourly_entry(starts_at),
+        )
+        Forecast.objects.filter(pk=forecast.pk).update(
+            prepared_at=timezone.now() - timedelta(hours=25)
+        )
+
+        # Act
+        displayed = self.service.get_forecast(starts_at, window_end)
+
+        # Assert
+        self.assertIsNone(displayed)
 
     def test_past_event_keeps_a_forecast_prepared_shortly_before_it_started(self):
         # Arrange
@@ -195,7 +241,7 @@ class ForecastServiceTestCase(TestCase):
             hourly=_hourly_entry(starts_at),
         )
         Forecast.objects.filter(pk=forecast.pk).update(
-            prepared_at=starts_at - timedelta(hours=5)
+            prepared_at=starts_at - timedelta(hours=1)
         )
 
         # Act
@@ -216,7 +262,7 @@ class ForecastServiceTestCase(TestCase):
             hourly=_hourly_entry(starts_at),
         )
         Forecast.objects.filter(pk=forecast.pk).update(
-            prepared_at=starts_at - timedelta(hours=7)
+            prepared_at=starts_at - timedelta(hours=3)
         )
 
         # Act
@@ -237,7 +283,7 @@ class ForecastServiceTestCase(TestCase):
         }
         earlier = Forecast.objects.create(hourly=_hourly_entry(starts_at, condition='rain'), **common)
         Forecast.objects.filter(pk=earlier.pk).update(
-            prepared_at=starts_at - timedelta(hours=5)
+            prepared_at=starts_at - timedelta(hours=1, minutes=50)
         )
         latest = Forecast.objects.create(hourly=_hourly_entry(starts_at, condition='sun'), **common)
         Forecast.objects.filter(pk=latest.pk).update(
@@ -897,6 +943,94 @@ class ForecastServiceWindowsTestCase(TestCase):
 
         # Assert
         self.assertEqual(forecasts, {})
+
+    def test_fresh_forecast_is_reused_without_fetching(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertEqual(forecasts[window], existing)
+        mock_get.assert_not_called()
+        self.assertEqual(Forecast.objects.count(), 1)
+
+    def test_repeated_runs_fetch_only_once_while_the_forecast_stays_fresh(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            first = self.service.refresh_forecasts_for_windows([window])
+            call_count_after_first = mock_get.call_count
+            second = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertEqual(second[window], first[window])
+        self.assertEqual(mock_get.call_count, call_count_after_first)
+        self.assertEqual(Forecast.objects.count(), 1)
+
+    def test_stale_forecast_is_refetched(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=timezone.now() - timedelta(hours=2, minutes=1)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertNotEqual(forecasts[window].pk, existing.pk)
+        self.assertEqual(Forecast.objects.count(), 2)
+
+
+class ForecastRefreshIntervalTestCase(TestCase):
+    def test_interval_scales_with_how_far_out_the_event_is(self):
+        # Arrange
+        now = timezone.now()
+        expected_hours_by_lead_hours = {
+            0: 1,
+            12: 1,
+            23: 1,
+            24: 1,
+            48: 3,
+            72: 5,
+            96: 6,
+            120: 8,
+            144: 10,
+            168: 12,
+        }
+
+        for lead_hours, expected_hours in expected_hours_by_lead_hours.items():
+            # Act
+            interval = ForecastService.refresh_interval(now + timedelta(hours=lead_hours), now)
+
+            # Assert
+            self.assertEqual(
+                interval, timedelta(hours=expected_hours), f'{lead_hours} hours out'
+            )
+
+    def test_interval_is_clamped_beyond_the_anchor_points(self):
+        # Arrange
+        now = timezone.now()
+
+        # Act
+        started = ForecastService.refresh_interval(now - timedelta(hours=5), now)
+        far_out = ForecastService.refresh_interval(now + timedelta(days=30), now)
+
+        # Assert
+        self.assertEqual(started, timedelta(hours=1))
+        self.assertEqual(far_out, timedelta(hours=12))
 
 
 class ForecastServiceHistoryTestCase(TestCase):

--- a/backoffice/tests/test_tasks.py
+++ b/backoffice/tests/test_tasks.py
@@ -58,7 +58,7 @@ class RefreshForecastsTaskTests(TestCase):
                 refresh_forecasts()
 
         # Assert
-        self.assertIn('2 windows stored for 1 events', logs.output[0])
+        self.assertIn('2 windows covered for 1 events', logs.output[0])
 
     def test_logs_and_stops_when_no_events_are_within_the_horizon(self):
         # Arrange

--- a/docs/celery-tasks.md
+++ b/docs/celery-tasks.md
@@ -36,17 +36,24 @@ coordinates — cost one fetch, not one per event.
 The task is the only thing that calls Open-Meteo. Nothing in the request path
 fetches: pages read stored `Forecast` rows and nothing else.
 
-A forecast is displayable for six hours, measured from the event start or from
-now, whichever comes first. For an upcoming event that means the usual freshness
-rule: nothing older than six hours. For an event that has already started it means
-the last forecast prepared in the six hours before it began, which keeps showing
-indefinitely — an old event's badge is a record of what was predicted, and it
-never goes stale. In steady state an upcoming event's data is at most one hour
-old, so its badge only goes dark after roughly six consecutive failed runs.
+How often a window is actually refetched depends on how far out the event is:
+one hour when it starts within a day, twelve hours when it is seven days out,
+interpolated linearly and rounded to the closest hour in between (48h out → 3h,
+96h out → 6h, 144h out → 10h). A forecast is stale once it is older than twice
+that interval, measured from the event start or from now, whichever comes first.
+See `docs/weather-forecast-algorithm.md` for the formula.
 
-Each run always writes new rows rather than skipping windows that already have
-recent data; history is append-only, and `/events/<id>/forecasts` shows every
-revision regardless of age.
+Each run checks freshness first and fetches only the windows whose latest row is
+stale. Running the task several times in a row — a beat run landing near a manual
+`/debug/tasks-refresh-forecasts` trigger, say — costs one set of requests, not
+one per run. Rows are still append-only: a refetch adds a revision rather than
+replacing one, and `/events/<id>/forecasts` shows every revision regardless of
+age.
+
+For an event that has already started, the stale rule anchors on its start, where
+the interval is one hour: it keeps the last forecast prepared in the two hours
+before it began, and that keeps showing indefinitely — an old event's badge is a
+record of what was predicted, and it never goes stale.
 
 A fetch or parse failure against Open-Meteo is caught per window, logged, and
 leaves the previous row untouched; the run continues with the remaining windows
@@ -58,7 +65,8 @@ failure, say — and retries those with backoff up to three times.
 
 Nothing in the request path depends on a worker being up. Pages render from
 whatever forecast rows exist; with no worker those rows stop being refreshed and
-badges disappear six hours later. Beat tasks simply do not run, so no alert
+badges disappear once they go stale — two hours later for an event starting
+within a day, up to a day later for one a week out. Beat tasks simply do not run, so no alert
 emails are sent either.
 
 ## Knowing whether the schedule is running
@@ -78,7 +86,8 @@ look identical from the outside.
 `refresh_forecasts` also logs its own progress at INFO: how many events it is
 about to cover and how many are skipped as virtual, one line per stored row
 (`Stored forecast <id> for <start> to <end> with <n> hourly readings`), how many
-of the distinct windows were refreshed, and a closing summary. A run that fetched
+of the distinct windows were refreshed and how many were already fresh, and a
+closing summary. A run that fetched
 nothing says so explicitly rather than logging nothing at all, so an empty
 horizon is distinguishable from a task that never ran. Failures stay at WARNING
 with the window and the underlying error.

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -111,7 +111,7 @@ For each hour in the window:
   the closest hour and clamped outside that range:
 
   ```
-  interval_hours = clamp(1, 12, round(1 + (lead_hours − 24) × 11 / 144))
+  interval_hours = clamp(1, 12, round(1 + (lead_hours - 24) * 11 / 144))
   ```
 
   | Lead | <24h | 24h | 48h | 72h | 96h | 120h | 144h | 168h |

--- a/docs/weather-forecast-algorithm.md
+++ b/docs/weather-forecast-algorithm.md
@@ -101,16 +101,35 @@ For each hour in the window:
 - Lookups key on `(latitude, longitude, start_time, end_time)` and use the row
   with the latest `prepared_at`; events sharing the same snapped window share
   rows and fetches.
-- Rows are written only by the `refresh_forecasts` beat task, which runs
-  hourly over the events starting in the next seven days and always fetches,
-  with a 3-second timeout per request. Nothing is fetched on page load, and an
-  event that has already started is never fetched again.
-- A row is displayable for 6 hours, measured from the event start or from now,
-  whichever is earlier. An upcoming event therefore needs a row prepared within
-  the last 6 hours, and once the latest row is older than that no badge is
-  rendered — no forecast is better than a wrong one. A past event keeps the last
-  row prepared in the 6 hours before it started, indefinitely. The forecast
-  history page is subject to neither rule and shows every stored row.
+- Rows are written only by the `refresh_forecasts` beat task, which runs hourly
+  over the events starting in the next seven days, with a 3-second timeout per
+  request. Nothing is fetched on page load, and an event that has already
+  started is never fetched again.
+- **Refresh interval** scales with how far out the event is, so a distant event
+  is not re-fetched as often as an imminent one. It is linear between the two
+  anchor points — 1 hour at 24 hours out, 12 hours at 7 days out — rounded to
+  the closest hour and clamped outside that range:
+
+  ```
+  interval_hours = clamp(1, 12, round(1 + (lead_hours − 24) × 11 / 144))
+  ```
+
+  | Lead | <24h | 24h | 48h | 72h | 96h | 120h | 144h | 168h |
+  |------|------|-----|-----|-----|-----|------|------|------|
+  | Interval | 1h | 1h | 3h | 5h | 6h | 8h | 10h | 12h |
+
+- A row is **stale**, and therefore neither displayable nor reusable, once it is
+  older than twice the interval for its window, measured from the event start or
+  from now, whichever is earlier. An event 7 days out keeps a row for 24 hours;
+  one starting within a day keeps it for 2. Once the latest row is stale no
+  badge is rendered — no forecast is better than a wrong one. A past event is
+  anchored at its start, where the lead is zero, so it keeps the last row
+  prepared in the 2 hours before it started, indefinitely. The forecast history
+  page is subject to neither rule and shows every stored row.
+- Every run checks freshness before fetching: a window that already has a fresh
+  row is skipped and the existing row is reused. Running the task repeatedly —
+  including through the superuser debug trigger — therefore issues no further
+  requests until the row goes stale.
 - On any fetch or parse error the previous row is left alone and no new row is
   written. A failure never breaks the page and a partial or
   invalid value is never stored: model validation enforces top-of-hour times,

--- a/web/templates/web/debug/forecasts.html
+++ b/web/templates/web/debug/forecasts.html
@@ -4,7 +4,8 @@
 <p><a href="{% url 'debug_index' %}">Debug</a></p>
 
 <p>Queues <code>backoffice.tasks.refresh_forecasts</code> on the worker and lists the most
-    recently prepared forecast records.</p>
+    recently prepared forecast records. Windows that already have a fresh forecast are
+    skipped, so triggering this repeatedly does not fetch again.</p>
 
 {% if result %}
 <p>Queued task <code>{{ result.task_id }}</code>.</p>


### PR DESCRIPTION
## What

Refresh frequency now varies with how far out an event is, and a run skips windows that already have a fresh forecast.

**Interval** — linear between the two anchor points, rounded to the closest hour, clamped outside the range:

```
interval_hours = clamp(1, 12, round(1 + (lead_hours - 24) * 11 / 144))
```

| Lead | <24h | 24h | 48h | 72h | 96h | 120h | 144h | 168h |
|------|------|-----|-----|-----|-----|------|------|------|
| Interval | 1h | 1h | 3h | 5h | 6h | 8h | 10h | 12h |

**Staleness** — a row is stale once older than `2 x interval`. This replaces the fixed `FORECAST_STALE_AFTER = 6h`, and governs display as well as fetching, so the badge never shows a row the refresh logic considers expired. The existing `min(now, event_start)` anchor is kept: a past event sits at lead 0, so it keeps the last row prepared in the 2 hours before it started, indefinitely.

**Skip when fresh** — `refresh_forecasts_for_windows` runs the existing `get_forecasts_for_windows` lookup first and fetches only stale windows. Repeated runs, including via the superuser debug trigger, issue no further requests until rows go stale. No force override was added; the debug button behaves exactly like the beat run.

## Notes

- `EventService.refresh_forecasts` now returns windows *covered* (fetched + reused) rather than windows *stored*. The task log wording changed to match.
- The beat schedule is unchanged (hourly at :42) - it has to stay hourly for the 1h interval to be reachable.
- No new query path: freshness reuses the lookup the display path already runs.

## Tests

Full suite: 1055 tests, 0 failures.

6 existing tests rewritten (they encoded the fixed 6h rule). 7 new: the interval table at 0/12/23/24/48/72/96/120/144/168h, clamping at both ends, a 7-day-out event keeping a 23h-old row but dropping a 25h-old one, reuse-without-fetching, repeated runs fetching once, and a stale row still being refetched.

Docs updated: `weather-forecast-algorithm.md`, `celery-tasks.md`, debug page blurb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wzhLo9k6iANt3tR1hukYs