### PR TITLE
fix(forecast): refetch once per refresh interval, not once per two

### DIFF
--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -474,6 +474,11 @@ class Route(models.Model):
         return self.name
 
 
+class ForecastQuerySet(models.QuerySet):
+    def with_readings(self):
+        return self.filter(hourly__0__isnull=False)
+
+
 class Forecast(models.Model):
     class Condition(models.TextChoices):
         SUN = 'sun', 'Sun'
@@ -533,10 +538,16 @@ class Forecast(models.Model):
         )
     )
 
+    objects = ForecastQuerySet.as_manager()
+
     class Meta:
         indexes = [
             models.Index(fields=['latitude', 'longitude', 'start_time', 'end_time'], name='forecast_location_window_idx'),
         ]
+
+    @property
+    def has_readings(self) -> bool:
+        return isinstance(self.hourly, list) and bool(self.hourly)
 
     @staticmethod
     def format_aqhi(value: int) -> str:

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -95,6 +95,14 @@ def usable(forecast: Forecast | None, window: Window, now: datetime) -> Forecast
     return forecast
 
 
+def due_from(window_start: datetime, now: datetime) -> datetime:
+    return min(now, window_start) - refresh_interval(window_start, now)
+
+
+def due(forecast: Forecast | None, window: Window, now: datetime) -> bool:
+    return forecast is None or forecast.prepared_at < due_from(window.start, now)
+
+
 def hour_key(time: datetime) -> str:
     return time.astimezone(datetime_timezone.utc).strftime('%Y-%m-%dT%H:%M')
 
@@ -211,26 +219,29 @@ class ForecastService:
         latitude, longitude = YOW_LOCATION
 
         requested = [(window, window_for(window[0], window[1], now)) for window in windows]
-        fresh = self.get_forecasts_for_windows([window for window, _ in requested], now)
+        if not requested:
+            return {}
 
-        stale = dict.fromkeys(
+        latest = self._latest_by_window({snapped for _, snapped in requested}, now)
+
+        overdue = dict.fromkeys(
             snapped for window, snapped in requested
-            if not fresh.get(window) and within_forecast_range(window[0], now)
+            if due(latest.get(snapped), snapped, now) and within_forecast_range(window[0], now)
         )
         fetched = {
             snapped: self._fetch_and_store(latitude, longitude, snapped)
-            for snapped in stale
+            for snapped in overdue
         }
 
         logger.info(
-            'Refreshed %s of %s distinct forecast windows, %s already fresh',
+            'Refreshed %s of %s distinct forecast windows, %s not yet due',
             len([forecast for forecast in fetched.values() if forecast]),
             len({snapped for _, snapped in requested}),
-            len({snapped for window, snapped in requested if fresh.get(window)}),
+            len({snapped for _, snapped in requested} - set(overdue)),
         )
 
         return {
-            window: fresh.get(window) or fetched.get(snapped)
+            window: fetched.get(snapped) or usable(latest.get(snapped), snapped, now)
             for window, snapped in requested
         }
 
@@ -261,12 +272,12 @@ class ForecastService:
             or_, (Q(start_time=window.start, end_time=window.end) for window in windows)
         )
 
-        candidates = Forecast.objects.filter(
+        candidates = Forecast.objects.with_readings().filter(
             matches_a_window,
             latitude=latitude,
             longitude=longitude,
             prepared_at__gte=min(usable_from(window.start, now) for window in windows),
-        ).exclude(hourly=[]).order_by('prepared_at')
+        ).order_by('prepared_at')
 
         return {
             Window(forecast.start_time, forecast.end_time): forecast
@@ -277,10 +288,10 @@ class ForecastService:
                              ends_at=None) -> QuerySet:
         window = raw_window(starts_at, ends_at)
 
-        return Forecast.objects.filter(
+        return Forecast.objects.with_readings().filter(
             latitude=latitude, longitude=longitude,
             start_time=window.start, end_time=window.end,
-        ).exclude(hourly=[]).order_by('-prepared_at')
+        ).order_by('-prepared_at')
 
     def _fetch_and_store(self, latitude: Decimal, longitude: Decimal,
                          window: Window) -> Forecast | None:

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -999,6 +999,79 @@ class ForecastServiceWindowsTestCase(TestCase):
         self.assertNotEqual(forecasts[window].pk, existing.pk)
         self.assertEqual(Forecast.objects.count(), 2)
 
+    def test_forecast_past_one_interval_is_refetched_even_though_still_usable(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=timezone.now() - timedelta(minutes=90)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertNotEqual(forecasts[window].pk, existing.pk)
+        self.assertEqual(Forecast.objects.count(), 2)
+        self.assertEqual(self.service.get_forecast(window[0], window[1]).pk, forecasts[window].pk)
+
+    def test_forecast_within_one_interval_is_not_refetched(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=timezone.now() - timedelta(minutes=45)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertEqual(forecasts[window].pk, existing.pk)
+        mock_get.assert_not_called()
+        self.assertEqual(Forecast.objects.count(), 1)
+
+    def test_forecast_past_one_interval_but_unfetchable_still_returns_the_old_one(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=timezone.now() - timedelta(minutes=90)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = requests.RequestException('provider down')
+
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertEqual(forecasts[window].pk, existing.pk)
+        self.assertEqual(Forecast.objects.count(), 1)
+
+    def test_distant_window_is_not_refetched_every_run(self):
+        # Arrange
+        starts_at = (timezone.now() + timedelta(days=7)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        window = (starts_at, starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=timezone.now() - timedelta(hours=11)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window])
+
+        # Assert
+        self.assertEqual(forecasts[window].pk, existing.pk)
+        mock_get.assert_not_called()
+
 
 class ForecastRefreshIntervalTestCase(TestCase):
     def test_interval_scales_with_how_far_out_the_event_is(self):

--- a/web/templates/web/events/_forecast_badge.html
+++ b/web/templates/web/events/_forecast_badge.html
@@ -1,6 +1,6 @@
 {% load forecast_filters %}
-{% if forecast %}
 {% with summary=forecast|forecast_summary %}
+{% if summary %}
 {% if expandable %}
 <button type="button"
         class="meta-pill{% if compact %} meta-pill-sm{% endif %} text-muted"
@@ -20,5 +20,5 @@
     {% include 'web/events/_forecast_badge_content.html' with summary=summary %}
 </span>
 {% endif %}
-{% endwith %}
 {% endif %}
+{% endwith %}

--- a/web/templatetags/forecast_filters.py
+++ b/web/templatetags/forecast_filters.py
@@ -17,6 +17,6 @@ def forecast_badge(event, compact=False):
 
 @register.filter
 def forecast_summary(forecast):
-    if not forecast:
+    if not forecast or not forecast.has_readings:
         return None
     return summarize(forecast)

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -154,3 +154,28 @@ class EventForecastsViewTestCase(TestCase):
 
         # Assert
         self.assertContains(response, reverse('event_detail', args=[event.id]))
+
+
+class EventForecastsWithoutReadingsTestCase(EventForecastsViewTestCase):
+    def test_forecast_with_no_readings_does_not_break_the_page(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast(hourly=[])
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+    def test_forecast_with_a_non_list_hourly_does_not_break_the_page(self):
+        # Arrange
+        event = self._create_event()
+        forecast = self._create_forecast()
+        Forecast.objects.filter(pk=forecast.pk).update(hourly={})
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        self.assertEqual(response.status_code, 200)

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -31,10 +31,11 @@ class EventForecastsViewTestCase(TestCase):
     def _create_forecast(self, start_time=None, end_time=None, prepared_at=None, hourly=None):
         start_time = start_time or self.starts_at
         end_time = end_time or (start_time + timedelta(hours=1))
-        hourly = hourly or [
-            {'time': start_time.isoformat(), 'condition': 'rain', 'temperature': 12, 'aqhi': 5},
-            {'time': end_time.isoformat(), 'condition': 'cloud', 'temperature': 15, 'aqhi': 5},
-        ]
+        if hourly is None:
+            hourly = [
+                {'time': start_time.isoformat(), 'condition': 'rain', 'temperature': 12, 'aqhi': 5},
+                {'time': end_time.isoformat(), 'condition': 'cloud', 'temperature': 15, 'aqhi': 5},
+            ]
         forecast = Forecast.objects.create(
             latitude=self.latitude,
             longitude=self.longitude,
@@ -155,8 +156,6 @@ class EventForecastsViewTestCase(TestCase):
         # Assert
         self.assertContains(response, reverse('event_detail', args=[event.id]))
 
-
-class EventForecastsWithoutReadingsTestCase(EventForecastsViewTestCase):
     def test_forecast_with_no_readings_does_not_break_the_page(self):
         # Arrange
         event = self._create_event()
@@ -167,6 +166,7 @@ class EventForecastsWithoutReadingsTestCase(EventForecastsViewTestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'No forecasts have been prepared')
 
     def test_forecast_with_a_non_list_hourly_does_not_break_the_page(self):
         # Arrange


### PR DESCRIPTION
The refresh run decided what to refetch by asking get_forecasts_for_windows
what was still usable. That predicate exists for display: a stored forecast
stays shown until STALE_AFTER_INTERVALS (2) of its refresh intervals have
passed, so readers keep seeing something rather than a gap. Reusing it for
the refresh meant a window was only refetched once it was already too old to
display, doubling every interval - an event inside the 24 hour lead window
has a one hour interval but was left untouched for two.

Refreshing and displaying are now separate questions. due_from is one refresh
interval back and drives the fetch; usable_from stays at two and drives what
readers get. A 90 minute old forecast for an imminent event is now replaced
on the next run while remaining usable until the replacement lands, and a
provider failure still falls back to the forecast already on hand.

refresh_forecasts_for_windows reads the stored rows once and applies both
predicates to them, rather than querying through the display path and then
querying again.

Fixes OBC-RIDEHUB-4S

A forecast whose hourly payload was not a non-empty list reached summarize,
where _prevalent_condition called max() on an empty Counter and returned a
500 on /events/<id>/forecasts. The queries guarded against this with
.exclude(hourly=[]), which matches an empty list and nothing else - a row
storing {} passed straight through.

Forecast.objects.with_readings() replaces those exclusions and matches on the
presence of a first element, so any reading-less shape is filtered out.
Forecast.has_readings carries the same test to the render path, and the badge
template now guards on the summary rather than on the forecast, so a row that
survives the query still cannot render a blank badge.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V36osuVWzhD4KHBjHFpSCr