### PR TITLE
fix(forecast): let a window come due despite the run's own fetch latency

### DIFF
--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -19,13 +19,30 @@ YOW_LOCATION = (Decimal('45.32250'), Decimal('-75.66920'))
 
 FORECAST_WINDOW = timedelta(days=7)
 REQUEST_TIMEOUT_SECONDS = 3
+REQUESTS_PER_WINDOW = 2
 
 REFRESH_INTERVAL_MIN_HOURS = 1
 REFRESH_INTERVAL_MAX_HOURS = 12
 REFRESH_LEAD_MIN_HOURS = 24
 REFRESH_LEAD_MAX_HOURS = 168
 STALE_AFTER_INTERVALS = 2
-MAX_REFRESH_RUN_DURATION = timedelta(minutes=5)
+
+# A run fetches its windows one after another, and prepared_at is stamped once a
+# window's requests come back, so a stored forecast is always younger than the
+# run's clock by however long the run took to reach it. due_from allows for that
+# lag; without it a window is perpetually a fraction short of its interval and
+# waits for the run after next.
+#
+# Worst case is every window timing out on both requests:
+#   REQUEST_TIMEOUT_SECONDS * REQUESTS_PER_WINDOW * EXPECTED_REFRESH_RUN_WINDOWS
+# doubled, to leave room for more events than we see today. Raise the window
+# count if the season grows well past it. Any value here well under
+# REFRESH_INTERVAL_MIN_HOURS keeps a second run from refetching what the first
+# one just stored.
+EXPECTED_REFRESH_RUN_WINDOWS = 10
+MAX_REFRESH_RUN_DURATION = 2 * timedelta(
+    seconds=REQUEST_TIMEOUT_SECONDS * REQUESTS_PER_WINDOW * EXPECTED_REFRESH_RUN_WINDOWS
+)
 
 NO2_UG_M3_PER_PPB = 1.88
 O3_UG_M3_PER_PPB = 1.96

--- a/backoffice/services/forecast_service.py
+++ b/backoffice/services/forecast_service.py
@@ -25,6 +25,7 @@ REFRESH_INTERVAL_MAX_HOURS = 12
 REFRESH_LEAD_MIN_HOURS = 24
 REFRESH_LEAD_MAX_HOURS = 168
 STALE_AFTER_INTERVALS = 2
+MAX_REFRESH_RUN_DURATION = timedelta(minutes=5)
 
 NO2_UG_M3_PER_PPB = 1.88
 O3_UG_M3_PER_PPB = 1.96
@@ -96,7 +97,7 @@ def usable(forecast: Forecast | None, window: Window, now: datetime) -> Forecast
 
 
 def due_from(window_start: datetime, now: datetime) -> datetime:
-    return min(now, window_start) - refresh_interval(window_start, now)
+    return min(now, window_start) - refresh_interval(window_start, now) + MAX_REFRESH_RUN_DURATION
 
 
 def due(forecast: Forecast | None, window: Window, now: datetime) -> bool:

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -1071,7 +1071,7 @@ class ForecastServiceWindowsTestCase(TestCase):
         # Assert
         self.assertNotEqual(forecasts[window].pk, existing.pk)
 
-    def test_a_second_run_within_the_tolerance_does_not_refetch(self):
+    def test_a_second_run_soon_after_the_first_does_not_refetch(self):
         # Arrange
         window = (self.starts_at, self.starts_at + timedelta(hours=1))
         existing = self._create_forecast(window[0], window[1])

--- a/backoffice/tests/services/test_forecast_service.py
+++ b/backoffice/tests/services/test_forecast_service.py
@@ -1053,6 +1053,41 @@ class ForecastServiceWindowsTestCase(TestCase):
         self.assertEqual(forecasts[window].pk, existing.pk)
         self.assertEqual(Forecast.objects.count(), 1)
 
+    def test_hourly_run_refetches_despite_the_fetch_latency_of_the_previous_run(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        now = timezone.now()
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=now - timedelta(hours=1) + timedelta(seconds=1)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            mock_get.side_effect = _mock_get(self.starts_at, self.starts_at + timedelta(hours=1))
+
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window], now=now)
+
+        # Assert
+        self.assertNotEqual(forecasts[window].pk, existing.pk)
+
+    def test_a_second_run_within_the_tolerance_does_not_refetch(self):
+        # Arrange
+        window = (self.starts_at, self.starts_at + timedelta(hours=1))
+        existing = self._create_forecast(window[0], window[1])
+        now = timezone.now()
+        Forecast.objects.filter(pk=existing.pk).update(
+            prepared_at=now - timedelta(minutes=6)
+        )
+
+        with patch('backoffice.services.forecast_service.requests.get') as mock_get:
+            # Act
+            forecasts = self.service.refresh_forecasts_for_windows([window], now=now)
+
+        # Assert
+        self.assertEqual(forecasts[window].pk, existing.pk)
+        mock_get.assert_not_called()
+
     def test_distant_window_is_not_refetched_every_run(self):
         # Arrange
         starts_at = (timezone.now() + timedelta(days=7)).replace(

--- a/web/tests/views/test_forecast_badge_views.py
+++ b/web/tests/views/test_forecast_badge_views.py
@@ -137,7 +137,8 @@ class UpcomingPageForecastBadgeTests(ForecastBadgeTestCase):
         now = _local_hour_today(12)
         starts_at = now - timedelta(hours=1)
         self._create_event(starts_at=starts_at)
-        self._create_forecast(time=starts_at)
+        forecast = self._create_forecast(time=starts_at)
+        Forecast.objects.filter(pk=forecast.pk).update(prepared_at=now)
 
         # Act
         with patch('backoffice.services.forecast_service.timezone.now', return_value=now):


### PR DESCRIPTION
Follow-up to #348. That change made the refresh decide on one interval instead of two, but forecasts for events inside the 24 hour lead window still only appeared every two hours.

## What production showed

Tracing a single window through the logs after #348 deployed at 01:23:

```
01:23:03  Stored 2139   (manual run)
02:42:00  Stored 2141
03:42     skipped
05:42:00  Stored 2149
07:42:00  Stored 2154
09:42:00  Stored 2160
```

Every other beat, on an hourly schedule with a one hour interval.

## Why

`prepared_at` is stamped once a window's two provider requests come back, so a stored forecast is always younger than the `now` of the run that produced it. Windows are fetched one after another, so the lag grows through the run: about a second for the first window, eight for the tenth.

Beat fires at the same wall-clock second every hour, so:

- `09:42:00.935` stored, giving `prepared_at ≈ 09:42:00.9`
- next run's `now = 10:42:00.0`, so `due_from = 09:42:00.0`
- `09:42:00.9 < 09:42:00.0` is false, so not due

Every window landed a fraction short of its interval and waited another full hour. `due_from` asked for a full interval with no allowance, which a fixed-period scheduler can never satisfy.

## The change

`due_from` now allows for `MAX_REFRESH_RUN_DURATION`, so a window counts as due if it would come due at any point during the run rather than only at the instant the run started.

The allowance is derived from what it depends on rather than picked by eye:

```python
EXPECTED_REFRESH_RUN_WINDOWS = 10
MAX_REFRESH_RUN_DURATION = 2 * timedelta(
    seconds=REQUEST_TIMEOUT_SECONDS * REQUESTS_PER_WINDOW * EXPECTED_REFRESH_RUN_WINDOWS
)
```

That is every window timing out on both requests, doubled for headroom: two minutes. A comment records the derivation so a future change to the timeout or request count carries through. At 3.3% of the one hour minimum interval it stays far from the point where a second run would refetch what the first just stored, which is covered by a test.

Worth noting the window count is an expectation, not a bound. It is the number of distinct windows across events inside the seven day horizon, so a much busier season would need that number raised. The factor of two is the margin for that.

## Tests

- `test_hourly_run_refetches_despite_the_fetch_latency_of_the_previous_run` reproduces the production timing, a run whose `now` precedes the previous run's `prepared_at` offset. Verified it fails without the allowance.
- `test_a_second_run_soon_after_the_first_does_not_refetch` pins the other side, that the allowance does not let a run refetch what was just stored.

## Unrelated failure fixed on the way

`test_upcoming_renders_badge_for_ongoing_event` was already failing on `main` before this branch, confirmed by stashing. It creates the forecast on the real clock and then renders under a clock patched to local noon today, so the forecast reads as hours stale whenever the suite runs before local noon and the badge is absent. It passed last night only because local time was still on the previous day. The forecast is now prepared against the same clock the view sees.

Full suite: 1063 tests, zero failures, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V36osuVWzhD4KHBjHFpSCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01V36osuVWzhD4KHBjHFpSCr)_