### PR TITLE
feat(events): restore staff cancel and add duplicate buttons

### DIFF
--- a/backoffice/models.py
+++ b/backoffice/models.py
@@ -262,6 +262,10 @@ class Event(models.Model):
         return self.state in (self.STATE_DRAFT, self.STATE_ANNOUNCED, self.STATE_LIVE)
 
     @property
+    def cancellable(self) -> bool:
+        return self.state == self.STATE_LIVE
+
+    @property
     def duration(self) -> timedelta:
         if self.ends_at:
             return self.ends_at - self.starts_at

--- a/web/templates/web/events/detail.html
+++ b/web/templates/web/events/detail.html
@@ -19,6 +19,24 @@
                 <i class="bi bi-people me-2"></i> Manage registrations
             </a>
             {% endif %}
+            <form method="post" action="{% url 'admin:backoffice_event_changelist' %}" class="d-inline">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="duplicate_event">
+                <input type="hidden" name="_selected_action" value="{{ event.id }}">
+                <button type="submit" class="btn btn-outline-primary btn-sm rounded-pill d-inline-flex align-items-center">
+                    <i class="bi bi-files me-2"></i> Duplicate event
+                </button>
+            </form>
+            {% if event.cancellable %}
+            <form method="post" action="{% url 'admin:backoffice_event_changelist' %}" class="d-inline">
+                {% csrf_token %}
+                <input type="hidden" name="action" value="cancel_event">
+                <input type="hidden" name="_selected_action" value="{{ event.id }}">
+                <button type="submit" class="btn btn-outline-danger btn-sm rounded-pill d-inline-flex align-items-center">
+                    <i class="bi bi-x-circle me-2"></i> Cancel event
+                </button>
+            </form>
+            {% endif %}
             {% endif %}
         </div>
 

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1,7 +1,8 @@
 ﻿from datetime import timedelta, datetime, date
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.utils import timezone
@@ -1211,6 +1212,14 @@ class EventDetailStaffActionsTests(BaseEventViewTestCase):
         self.url = reverse('event_detail', kwargs={'event_id': self.event.id})
         self.changelist_url = reverse('admin:backoffice_event_changelist')
 
+    def _grant_event_admin_permissions(self):
+        self.staff_user.user_permissions.set(
+            Permission.objects.filter(
+                content_type=ContentType.objects.get_for_model(Event),
+                codename__in=('view_event', 'add_event', 'change_event'),
+            )
+        )
+
     def test_staff_sees_cancel_and_duplicate_buttons(self):
         # Arrange
         self.client.login(username='staff_user', password='password123')
@@ -1254,8 +1263,7 @@ class EventDetailStaffActionsTests(BaseEventViewTestCase):
 
     def test_cancel_button_posts_to_admin_confirmation_page(self):
         # Arrange
-        self.staff_user.is_superuser = True
-        self.staff_user.save()
+        self._grant_event_admin_permissions()
         self.client.login(username='staff_user', password='password123')
 
         # Act
@@ -1271,8 +1279,7 @@ class EventDetailStaffActionsTests(BaseEventViewTestCase):
 
     def test_duplicate_button_posts_to_admin_confirmation_page(self):
         # Arrange
-        self.staff_user.is_superuser = True
-        self.staff_user.save()
+        self._grant_event_admin_permissions()
         self.client.login(username='staff_user', password='password123')
 
         # Act

--- a/web/tests/views/test_events_views.py
+++ b/web/tests/views/test_events_views.py
@@ -1203,6 +1203,90 @@ class EventDetailViewTests(BaseEventViewTestCase):
         self.assertTemplateUsed(response, 'web/events/detail.html')
 
 
+class EventDetailStaffActionsTests(BaseEventViewTestCase):
+    """Tests for the staff action buttons on the event_detail view."""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('event_detail', kwargs={'event_id': self.event.id})
+        self.changelist_url = reverse('admin:backoffice_event_changelist')
+
+    def test_staff_sees_cancel_and_duplicate_buttons(self):
+        # Arrange
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertContains(response, 'Cancel event')
+        self.assertContains(response, 'Duplicate event')
+        self.assertContains(response, f'action="{self.changelist_url}"')
+        self.assertContains(response, 'value="cancel_event"')
+        self.assertContains(response, 'value="duplicate_event"')
+        self.assertContains(response, f'name="_selected_action" value="{self.event.id}"', count=2)
+
+    def test_non_staff_sees_no_staff_action_buttons(self):
+        # Arrange
+        self.client.login(username='regular_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertNotContains(response, 'Cancel event')
+        self.assertNotContains(response, 'Duplicate event')
+        self.assertNotContains(response, 'value="cancel_event"')
+        self.assertNotContains(response, 'value="duplicate_event"')
+
+    def test_cancelled_event_hides_cancel_but_keeps_duplicate(self):
+        # Arrange
+        self.event.cancel()
+        self.event.save()
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.get(self.url)
+
+        # Assert
+        self.assertNotContains(response, 'value="cancel_event"')
+        self.assertContains(response, 'value="duplicate_event"')
+
+    def test_cancel_button_posts_to_admin_confirmation_page(self):
+        # Arrange
+        self.staff_user.is_superuser = True
+        self.staff_user.save()
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.post(self.changelist_url, {
+            'action': 'cancel_event',
+            '_selected_action': str(self.event.id),
+        })
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/backoffice/event/cancel_selected.html')
+        self.assertEqual(list(response.context['queryset']), [self.event])
+
+    def test_duplicate_button_posts_to_admin_confirmation_page(self):
+        # Arrange
+        self.staff_user.is_superuser = True
+        self.staff_user.save()
+        self.client.login(username='staff_user', password='password123')
+
+        # Act
+        response = self.client.post(self.changelist_url, {
+            'action': 'duplicate_event',
+            '_selected_action': str(self.event.id),
+        })
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/backoffice/event/duplicate_selected.html')
+        self.assertEqual(list(response.context['queryset']), [self.event])
+
+
 class ArchivedEventDetailViewTests(BaseEventViewTestCase):
     """Tests for the event_detail view when the event is archived."""
 


### PR DESCRIPTION
## Summary

Brings back the staff **Cancel event** button on the event detail page and adds a **Duplicate event** button next to it. Both post to the admin changelist, so staff land on the existing confirmation pages rather than firing the action directly.

The cancel button was dropped in 06049a6 (2026-03-17, "Improve button styling and navigation across event pages") when the staff button row was restyled. The duplicate action has only ever been reachable from the admin changelist.

## Button order

`Back to events` → `Edit event` → `Manage registrations` → `Duplicate event` → `Cancel event`

Navigation first, then the two everyday actions, then the occasional one, then the destructive one. Colour reinforces the grouping: `outline-secondary` for navigation, `primary` for edit and manage, `outline-primary` for duplicate so it reads as secondary, `outline-danger` for cancel. Keeping cancel last and away from Edit reduces the chance of a misclick.

## Gating

Cancel is now gated on a new `Event.cancellable` property that mirrors the FSM transition (`live` only), instead of the looser `not event.cancelled` check the old button used — that version rendered the button on draft and announced events, where the transition would have failed. Duplicate is ungated; the action works from any state, and archived events never render this template.

## Tests

Five new tests in `EventDetailStaffActionsTests`:

- staff sees both buttons, with the right action names and selected event id
- non-staff sees neither
- a cancelled event hides cancel but keeps duplicate
- each button's POST reaches the correct admin confirmation template with the expected queryset

Full suite: 1069 tests, zero failures, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
