### PR TITLE
feat(forecasts): collapse unchanged rows in forecast history

### DIFF
--- a/web/templates/web/events/forecasts.html
+++ b/web/templates/web/events/forecasts.html
@@ -18,12 +18,20 @@
         <h2 class="fs-5 fw-medium mb-3">Forecast history</h2>
         <div class="card shadow-sm mb-4">
             <div class="card-body p-4">
+                {% if forecast_hidden_count %}
+                <button type="button" class="btn btn-link btn-sm p-0 mb-2"
+                        data-bs-toggle="collapse" data-bs-target=".fc-minor" aria-expanded="false">
+                    Show all {{ forecast_total }} forecasts
+                </button>
+                {% endif %}
                 <div class="list-group list-group-flush">
-                    {% for forecast in forecasts %}
+                    {% for forecast, material in forecast_rows %}
+                    {% if not material %}<div class="collapse fc-minor">{% endif %}
                     <div class="list-group-item d-flex flex-wrap align-items-center justify-content-between gap-2 px-0">
                         <span class="text-muted small">{{ forecast.prepared_at|date:"M j, g:i A" }}</span>
                         {% include 'web/events/_forecast_badge.html' with expandable=True %}
                     </div>
+                    {% if not material %}</div>{% endif %}
                     {% empty %}
                     <p class="text-muted mb-0">No forecasts have been prepared for this event yet.</p>
                     {% endfor %}

--- a/web/tests/views/test_event_forecasts_views.py
+++ b/web/tests/views/test_event_forecasts_views.py
@@ -83,6 +83,64 @@ class EventForecastsViewTestCase(TestCase):
         self.assertContains(response, 'sunny')
         self.assertLess(content.index('rainy'), content.index('sunny'))
 
+    def _create_forecast_prepared_minutes_ago(self, minutes, condition='sun', temperature=20):
+        return self._create_forecast(
+            hourly=[{
+                'time': self.starts_at.isoformat(),
+                'condition': condition,
+                'temperature': temperature,
+                'aqhi': 2,
+            }],
+            prepared_at=timezone.now() - timedelta(minutes=minutes),
+        )
+
+    def test_collapses_a_forecast_matching_the_older_one_below_it(self):
+        # Arrange
+        event = self._create_event()
+        oldest = self._create_forecast_prepared_minutes_ago(90, temperature=20)
+        middle = self._create_forecast_prepared_minutes_ago(60, temperature=20)
+        newest = self._create_forecast_prepared_minutes_ago(30, temperature=25)
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        content = response.content.decode()
+        self.assertEqual(content.count('collapse fc-minor'), 1)
+        self.assertLess(content.index(f'forecast-hourly-{newest.pk}'), content.index('collapse fc-minor'))
+        self.assertLess(content.index('collapse fc-minor'), content.index(f'forecast-hourly-{middle.pk}'))
+        self.assertLess(content.index(f'forecast-hourly-{middle.pk}'), content.index(f'forecast-hourly-{oldest.pk}'))
+        self.assertContains(response, 'Show all 3 forecasts')
+
+    def test_always_shows_the_newest_forecast_even_when_unchanged(self):
+        # Arrange
+        event = self._create_event()
+        oldest = self._create_forecast_prepared_minutes_ago(90)
+        self._create_forecast_prepared_minutes_ago(60)
+        newest = self._create_forecast_prepared_minutes_ago(30)
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        content = response.content.decode()
+        self.assertEqual(content.count('collapse fc-minor'), 1)
+        self.assertLess(content.index(f'forecast-hourly-{newest.pk}'), content.index('collapse fc-minor'))
+        self.assertIn(f'forecast-hourly-{oldest.pk}', content)
+
+    def test_shows_no_toggle_when_every_forecast_differs(self):
+        # Arrange
+        event = self._create_event()
+        self._create_forecast_prepared_minutes_ago(60, temperature=20)
+        self._create_forecast_prepared_minutes_ago(30, temperature=25)
+
+        # Act
+        response = self.client.get(reverse('event_forecasts', args=[event.id]))
+
+        # Assert
+        self.assertNotContains(response, 'collapse fc-minor')
+        self.assertNotContains(response, 'Show all')
+
     def test_excludes_forecasts_for_other_windows(self):
         # Arrange
         event = self._create_event()

--- a/web/views/events.py
+++ b/web/views/events.py
@@ -16,6 +16,7 @@ from django_tables2 import RequestConfig
 from audit.services import AuditService
 from backoffice.models import Event, Registration
 from backoffice.services.event_service import EventService
+from backoffice.services.forecast_summary import summarize
 from backoffice.services.registration_service import RegistrationService
 from web.filters import PublicRegistrationFilter
 from web.tables import PublicRegistrationTable
@@ -200,14 +201,40 @@ def event_detail(request: HttpRequest, event_id: int) -> HttpResponse:
     return render(request, 'web/events/detail.html', context)
 
 
+def _forecast_badge_key(forecast) -> tuple | None:
+    if not forecast.has_readings:
+        return None
+    summary = summarize(forecast)
+    return (
+        summary.condition_primary,
+        summary.condition_warning,
+        summary.temperature_display,
+        summary.aqhi_category if summary.aqhi_visible else None,
+        summary.aqhi_warning_category,
+    )
+
+
+def _forecast_rows(forecasts) -> list[tuple]:
+    forecasts = list(forecasts)
+    keys = [_forecast_badge_key(forecast) for forecast in forecasts]
+    last = len(keys) - 1
+
+    return [
+        (forecast, index in (0, last) or keys[index] != keys[index + 1])
+        for index, forecast in enumerate(forecasts)
+    ]
+
+
 def event_forecasts(request: HttpRequest, event_id: int) -> HttpResponse:
     event = get_object_or_404(Event, id=event_id)
 
-    forecasts = EventService().fetch_forecast_history(event)
+    forecast_rows = _forecast_rows(EventService().fetch_forecast_history(event))
 
     context = {
         'event': event,
-        'forecasts': forecasts,
+        'forecast_rows': forecast_rows,
+        'forecast_total': len(forecast_rows),
+        'forecast_hidden_count': sum(1 for _, material in forecast_rows if not material),
     }
 
     return render(request, 'web/events/forecasts.html', context)


### PR DESCRIPTION
## Problem

The forecast history page rendered every forecast ever prepared for an event — around 40 rows, most of them showing an identical badge. The repetition buried the handful of rows where the forecast actually changed.

## Change

A row is kept when its rendered badge differs from the next older row's. Comparison key is the full visible badge: primary condition, condition warning, temperature display, and AQHI category/warning (AQHI only when it is actually shown).

- The **oldest** row of each identical run is kept, so its timestamp reads as "the forecast has said this since then".
- The **newest** forecast is always shown, so the page demonstrates current data even when nothing changed.
- Collapsed rows are hidden behind a `Show all N forecasts` toggle (Bootstrap collapse, no new JS), so nothing is lost.

Example — before / after:

```
Aug 5: Sunny 25      Aug 5: Sunny 25
Aug 4: Sunny 20  ->
Aug 3: Sunny 20      Aug 3: Sunny 20
Aug 2: Sunny 19      Aug 2: Sunny 19
Aug 1: Sunny 18      Aug 1: Sunny 18
```

## Notes

- Collapse lives in the view (`_forecast_rows`); `EventService.fetch_forecast_history` still returns the raw queryset for other callers.
- Hidden rows are wrapped in a `.collapse` div rather than carrying the class themselves, since `d-flex` on the row would override `display: none`.
- The toggle label does not swap to "Show fewer" when expanded.

## Testing

Three new view tests cover the collapsed middle row, the always-visible newest forecast, and the absence of the toggle when every row differs. Full suite: 1100 tests, zero failures, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
