### PR TITLE
Align profile page button colours

### DIFF
--- a/web/templates/web/profile/profile.html
+++ b/web/templates/web/profile/profile.html
@@ -154,14 +154,14 @@
                                         {% if registration.withdrawable %}
                                         <form method="post" action="{% url 'registration_withdraw' registration.id %}" onsubmit="return confirm('Are you sure you want to withdraw your registration for this event?');">
                                             {% csrf_token %}
-                                            <button type="submit" class="btn btn-primary btn-sm">
+                                            <button type="submit" class="btn btn-outline-secondary btn-sm">
                                                 Withdraw
                                             </button>
                                         </form>
                                         {% endif %}
                                         
                                         {% if registration.ride_leader_preference == 'y' and registration.state == 'confirmed' and registration.event.ride_leaders_wanted %}
-                                        <a href="{% url 'riders_list' registration.event.id %}" class="btn btn-warning btn-sm">
+                                        <a href="{% url 'riders_list' registration.event.id %}" class="btn btn-outline-warning btn-sm">
                                             Emergency
                                         </a>
                                         {% endif %}
@@ -220,7 +220,7 @@
                                     <td class="small">
                                         <div class="d-flex gap-1">
                                             {% if registration.editable %}
-                                            <a href="{% url 'registration_edit' registration.id %}" class="btn btn-outline-secondary btn-sm">
+                                            <a href="{% url 'registration_edit' registration.id %}" class="btn btn-outline-primary btn-sm">
                                                 Edit
                                             </a>
                                             {% endif %}
@@ -228,7 +228,7 @@
                                             {% if registration.withdrawable %}
                                             <form method="post" action="{% url 'registration_withdraw' registration.id %}" onsubmit="return confirm('Are you sure you want to withdraw your registration for this event?');" class="d-inline">
                                                 {% csrf_token %}
-                                                <button type="submit" class="btn btn-outline-primary btn-sm">
+                                                <button type="submit" class="btn btn-outline-secondary btn-sm">
                                                     Withdraw
                                                 </button>
                                             </form>


### PR DESCRIPTION
Follow-up to #354.

## Summary

The profile page renders the same three registration actions twice — once as mobile cards, once as a desktop table — and each layout used different button colours.

| Action | Was (mobile) | Was (desktop) | Now (both) |
|---|---|---|---|
| Edit | `btn-outline-primary` | `btn-outline-secondary` | `btn-outline-primary` |
| Withdraw | `btn-primary` | `btn-outline-primary` | `btn-outline-secondary` |
| Emergency | `btn-warning` | `btn-outline-warning` | `btn-outline-warning` |

All outline now, so the action row reads evenly in both layouts: primary for the main action, secondary for withdraw, warning for the emergency contacts link.

Based on `20260804-manage-copy-emails` so the diff stays clean; retarget to `main` once #354 merges.

## Test plan

- Full suite: 1102 tests, 0 failures, 0 errors
- Template-only change, no behaviour affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)